### PR TITLE
Release nri-prelude-0.2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ To publish the new version run the `release.sh` script for the package you want 
 ./release.sh nri-prelude
 ```
 
+Note: this requires an account on [hackage.org][hackage] with rights to publish the library. These are the steps to creating such an account:
+
+1. [Fill the registration form][hackage-registration].
+2. Send an email to hackage-trustees@haskell.org to requesting upload access for your account.
+3. Login to hackage using the shared NoRedInk account (NRI engineers can find the password in the usual place).
+4. Using the NoRedInk account add your new own hackage account to the [maintainer groups][hackage-maintainers] of the NRI libraries.
+
 ### To [stackage.org][stackage]
 
 [Stackage][stackage] is a repository built on top of hackage. Stackage runs nightly builds checking the latest version of packages are compiling against each other.
@@ -76,3 +83,5 @@ To remain in stackage these libraries need to up-to-date with the latest version
 [ormolu]: https://github.com/tweag/ormolu
 [haddock]: https://haskell-haddock.readthedocs.io
 [nri-on-stackage]: https://github.com/commercialhaskell/stackage/blob/b9c0bfa723bd4cba5f964c6fb99b7528c4027692/build-constraints.yaml#L4414-L4416
+[hackage-registration]: https://hackage.haskell.org/users/register-request
+[hackage-maintainers]: https://hackage.haskell.org/user/NoRedInk

--- a/nri-env-parser/CHANGELOG.md
+++ b/nri-env-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0.2
+
+- Relax version bounds to encompass `nri-prelude-0.2.0.0`.
+
 # 0.1.0.1
 
 - Relax version bounds to encompass `base-4.14.0.0`.

--- a/nri-env-parser/package.yaml
+++ b/nri-env-parser/package.yaml
@@ -2,7 +2,7 @@ name: nri-env-parser
 synopsis: Read environment variables as settings to build 12-factor apps.
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/env-parser>.
 author: NoRedInk
-version: 0.1.0.1
+version: 0.1.0.2
 maintainer: haskell-open-source@noredink.com
 copyright: 2020 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/env-parser
@@ -15,7 +15,7 @@ extra-doc-files:
 library:
   dependencies:
     - base >= 4.12.0.0 && < 4.15
-    - nri-prelude >= 0.1.0.0 && < 0.2
+    - nri-prelude >= 0.1.0.0 && < 0.3
     - modern-uri >= 0.3.1.0 && < 0.4
     - network-uri >= 2.6.2.0 && < 2.8
     - text >= 1.2.3.1 && < 1.3

--- a/nri-prelude/CHANGELOG.md
+++ b/nri-prelude/CHANGELOG.md
@@ -1,7 +1,8 @@
-# Next version (unreleased)
+# 0.2.0.0
 
 - Breaking change: drop `Platform.TracingSpan` constructor.
 - Add `Platform.emptyTracingSpan` export.
+- Relax version bounds to encompas `tasty-1.4`.
 
 # 0.1.0.4
 

--- a/nri-prelude/package.yaml
+++ b/nri-prelude/package.yaml
@@ -2,7 +2,7 @@ name: nri-prelude
 synopsis: A Prelude inspired by the Elm programming language
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-prelude>.
 author: NoRedInk
-version: 0.1.0.4
+version: 0.2.0.0
 maintainer: haskell-open-source@noredink.com
 copyright: 2020 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-prelude
@@ -33,7 +33,7 @@ library:
   - pretty-show >= 1.9.5 && < 1.11
   - resourcet >= 1.2.2 && < 1.3
   - safe-exceptions >= 0.1.7.0 && < 1.3
-  - tasty >= 1.2.3 && < 1.4
+  - tasty >= 1.2.3 && < 1.5
   - tasty-test-reporter >= 0.1.1.1 && < 0.2
   - terminal-size >= 0.3.2.1 && < 0.4
   - text >= 1.2.3.1 && < 1.3


### PR DESCRIPTION
Updating `nri-prelude` to support the latest version of `tasty`.

This update means we also release previously breaking changes for `nri-prelude`. That in turn requires an update of `nri-env-parser`.