### PR TITLE
Expose functions for setting span summaries

### DIFF
--- a/nri-prelude/src/Log.hs
+++ b/nri-prelude/src/Log.hs
@@ -129,7 +129,10 @@ withContext name contexts task =
     name
     ( Platform.finally
         task
-        (Platform.setTracingSpanDetails (LogContexts contexts))
+        ( do
+            Platform.setTracingSpanDetails (LogContexts contexts)
+            Platform.setTracingSpanSummary name
+        )
     )
 
 --

--- a/nri-prelude/src/Platform.hs
+++ b/nri-prelude/src/Platform.hs
@@ -20,6 +20,8 @@ module Platform
     Internal.rootTracingSpanIO,
     Internal.setTracingSpanDetails,
     Internal.setTracingSpanDetailsIO,
+    Internal.setTracingSpanSummary,
+    Internal.setTracingSpanSummaryIO,
     Internal.markTracingSpanFailed,
     Internal.markTracingSpanFailedIO,
 

--- a/nri-prelude/tests/golden-results/log-async-exceptions
+++ b/nri-prelude/tests/golden-results/log-async-exceptions
@@ -16,7 +16,7 @@
               }
           )
     , details = Just "{\"number\":825}"
-    , summary = Nothing
+    , summary = Just "outer span"
     , succeeded = FailedWith TestException
     , allocated = 0
     , children =
@@ -38,7 +38,7 @@
                       }
                   )
             , details = Just "{\"word\":\"sabbatical\"}"
-            , summary = Nothing
+            , summary = Just "inner span"
             , succeeded = FailedWith TestException
             , allocated = 0
             , children = []

--- a/nri-prelude/tests/golden-results/log-nested-spans
+++ b/nri-prelude/tests/golden-results/log-nested-spans
@@ -16,7 +16,7 @@
               }
           )
     , details = Just "{\"number\":825}"
-    , summary = Nothing
+    , summary = Just "outer span"
     , succeeded = Succeeded
     , allocated = 0
     , children =
@@ -38,7 +38,7 @@
                       }
                   )
             , details = Just "{\"word\":\"sabbatical\"}"
-            , summary = Nothing
+            , summary = Just "inner span"
             , succeeded = Succeeded
             , allocated = 0
             , children =

--- a/nri-prelude/tests/golden-results/log-unexpected-exceptions
+++ b/nri-prelude/tests/golden-results/log-unexpected-exceptions
@@ -16,7 +16,7 @@
               }
           )
     , details = Just "{\"number\":825}"
-    , summary = Nothing
+    , summary = Just "outer span"
     , succeeded = FailedWith TestException
     , allocated = 0
     , children =
@@ -38,7 +38,7 @@
                       }
                   )
             , details = Just "{\"word\":\"sabbatical\"}"
-            , summary = Nothing
+            , summary = Just "inner span"
             , succeeded = FailedWith TestException
             , allocated = 0
             , children = []


### PR DESCRIPTION
A small piece that was missing from https://github.com/NoRedInk/haskell-libraries/pull/13: the ability to set summaries on tracing spans outside this library.