### PR TITLE
Nri prelude plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ cabal build nri-prelude           # build the library
 cabal test nri-prelude            # run the tests
 hpack nri-prelude                 # generate nri-prelude.cabal from package.yaml
 ghcid -c "cabal repl nri-prelude" # start a code watcher
-ormolu -m inplace <file>          # Format a source file
+ormolu -i <file>                  # Format a source file
 cabal haddock nri-prelude         # Run documentation generation
+ormolu -i **/*.hs                 # Format everything
+cabal build all                   # build everything
+cabal test all                    # test everything
 ```
 
 We use [Ormolu][ormolu] for code formatting.

--- a/nri-env-parser/package.yaml
+++ b/nri-env-parser/package.yaml
@@ -44,3 +44,4 @@ ghc-options:
 - -Wpartial-fields
 - -Wredundant-constraints
 - -Wincomplete-uni-patterns
+- -fplugin=NriPrelude.Plugin

--- a/nri-env-parser/package.yaml
+++ b/nri-env-parser/package.yaml
@@ -45,3 +45,4 @@ ghc-options:
 - -Wredundant-constraints
 - -Wincomplete-uni-patterns
 - -fplugin=NriPrelude.Plugin
+- -fno-warn-unused-imports

--- a/nri-env-parser/package.yaml
+++ b/nri-env-parser/package.yaml
@@ -45,4 +45,3 @@ ghc-options:
 - -Wredundant-constraints
 - -Wincomplete-uni-patterns
 - -fplugin=NriPrelude.Plugin
-- -fno-warn-unused-imports

--- a/nri-log-explorer/package.yaml
+++ b/nri-log-explorer/package.yaml
@@ -56,3 +56,4 @@ ghc-options:
 - -threaded
 - -rtsopts "-with-rtsopts=-N -T -xq10m"
 - -O2
+- -fplugin=NriPrelude.Plugin

--- a/nri-prelude/README.md
+++ b/nri-prelude/README.md
@@ -3,19 +3,12 @@
 A Prelude inspired by the Elm programming language.
 
 enable ghc option
+
 ```
 -fplugin=NriPrelude.Plugin
 ```
+
 to get default imports (List, Maybe, Debug, etc)
-
-and
-```
--fno-warn-unused-imports
-```
-to stop warning that you're importing things you're not using (an unfortunate side effect of this)
-
-Longer term, perhaps we could dynamically import qualified imports only if they're used, to obviate the need to disable warnings
-
 
 This package re-implements API's and re-uses documentation from [elm-core][] ([license](./licenses/ELM_CORE_LICENSE)) and [elm-test][] ([license](./licenses/ELM_TEST_LICENSE)).
 

--- a/nri-prelude/README.md
+++ b/nri-prelude/README.md
@@ -2,6 +2,21 @@
 
 A Prelude inspired by the Elm programming language.
 
+enable ghc option
+```
+-fplugin=NriPrelude.Plugin
+```
+to get default imports (List, Maybe, Debug, etc)
+
+and
+```
+-fno-warn-unused-imports
+```
+to stop warning that you're importing things you're not using (an unfortunate side effect of this)
+
+Longer term, perhaps we could dynamically import qualified imports only if they're used, to obviate the need to disable warnings
+
+
 This package re-implements API's and re-uses documentation from [elm-core][] ([license](./licenses/ELM_CORE_LICENSE)) and [elm-test][] ([license](./licenses/ELM_TEST_LICENSE)).
 
 [elm-core]: https://github.com/elm/core

--- a/nri-prelude/package.yaml
+++ b/nri-prelude/package.yaml
@@ -27,6 +27,7 @@ library:
   - directory >= 1.3.3.0 && < 1.4
   - exceptions >= 0.10.4 && < 0.11
   - filepath >= 1.4.2.1 && < 1.5
+  - ghc >= 8.6.1 && < 8.10
   - hedgehog >= 1.0.2 && < 1.1
   - junit-xml >= 0.1.0.0 && < 0.2.0.0
   - pretty-diff >= 0.1.0.0 && < 0.3
@@ -50,6 +51,7 @@ library:
   - Log
   - Maybe
   - NriPrelude
+  - NriPrelude.Plugin
   - Platform
   - Process
   - Result

--- a/nri-prelude/src/NriPrelude/Plugin.hs
+++ b/nri-prelude/src/NriPrelude/Plugin.hs
@@ -21,7 +21,7 @@ where
 import Data.Function ((&))
 import qualified Data.List
 import qualified GhcPlugins
-import HsSyn (hsmodImports, hsmodName, ideclName, ideclQualified, simpleImportDecl)
+import HsSyn (hsmodImports, hsmodName, ideclImplicit, ideclName, ideclQualified, simpleImportDecl)
 import qualified Set
 import Prelude
 
@@ -86,6 +86,7 @@ addImplicitImports _ _ parsed =
 
     unqualified name =
       GhcPlugins.noLoc (simpleImportDecl (GhcPlugins.mkModuleName name))
+        & fmap (\qual -> qual {ideclImplicit = True})
     qualified name =
       fmap (\qual -> qual {ideclQualified = True}) (unqualified name)
 

--- a/nri-prelude/src/NriPrelude/Plugin.hs
+++ b/nri-prelude/src/NriPrelude/Plugin.hs
@@ -1,0 +1,52 @@
+{-# OPTIONS_GHC -fno-warn-incomplete-record-updates #-}
+
+-- | A compiler plugin that imports the equivalents of modules that Elm will
+-- also import.
+--
+-- Useful documentation
+-- - GHC user guide on compiler plugins: https://ghc.gitlab.haskell.org/ghc/doc/users_guide/extending_ghc.html#compiler-plugins
+-- - Module providing API for creating plugins: https://www.stackage.org/haddock/lts-17.4/ghc-lib-8.10.4.20210206/GhcPlugins.html
+module NriPrelude.Plugin
+  ( plugin,
+  )
+where
+
+import qualified GhcPlugins
+-- In GHC 8.10 and higher the imports below will come from the GHC.Hs module
+-- instead. We'll need to handle this, maybe using some CPP-powered conditional
+-- imports.
+import HsSyn (hsmodImports, ideclQualified, simpleImportDecl)
+import Prelude
+
+plugin :: GhcPlugins.Plugin
+plugin =
+  GhcPlugins.defaultPlugin
+    { GhcPlugins.parsedResultAction = addImplicitImports,
+      -- Let GHC know this plugin doesn't perform arbitrary IO. Given the same
+      -- input file it will make the same changes. Without this GHC will
+      -- recompile modules using this plugin every time which is expensive.
+      GhcPlugins.pluginRecompile = GhcPlugins.purePlugin
+    }
+
+addImplicitImports ::
+  [GhcPlugins.CommandLineOption] ->
+  GhcPlugins.ModSummary ->
+  GhcPlugins.HsParsedModule ->
+  GhcPlugins.Hsc GhcPlugins.HsParsedModule
+addImplicitImports _ _ parsed =
+  Prelude.pure
+    parsed
+      { GhcPlugins.hpm_module =
+          fmap addImports (GhcPlugins.hpm_module parsed)
+      }
+  where
+    addImports hsModule =
+      hsModule {hsmodImports = hsmodImports hsModule ++ extraImports}
+    extraImports =
+      [ unqualified "NriPrelude",
+        qualified "Debug"
+      ]
+    unqualified name =
+      GhcPlugins.noLoc (simpleImportDecl (GhcPlugins.mkModuleName name))
+    qualified name =
+      fmap (\qual -> qual {ideclQualified = True}) (unqualified name)

--- a/nri-prelude/src/NriPrelude/Plugin.hs
+++ b/nri-prelude/src/NriPrelude/Plugin.hs
@@ -3,7 +3,9 @@
 -- | A compiler plugin that imports the equivalents of modules that Elm will
 -- also import.
 --
+--
 -- Useful documentation
+-- - Elm's default imports: https://package.elm-lang.org/packages/elm/core/latest/
 -- - GHC user guide on compiler plugins: https://ghc.gitlab.haskell.org/ghc/doc/users_guide/extending_ghc.html#compiler-plugins
 -- - Module providing API for creating plugins: https://www.stackage.org/haddock/lts-17.4/ghc-lib-8.10.4.20210206/GhcPlugins.html
 module NriPrelude.Plugin
@@ -42,9 +44,21 @@ addImplicitImports _ _ parsed =
   where
     addImports hsModule =
       hsModule {hsmodImports = hsmodImports hsModule ++ extraImports}
+    -- taken from https://package.elm-lang.org/packages/elm/core/latest/
     extraImports =
-      [ unqualified "NriPrelude",
-        qualified "Debug"
+      [ unqualified "NriPrelude", -- Elm exports types from withi these modules. We re-export them from NriPrelude. Same effect.
+        qualified "Basics",
+        qualified "Char",
+        qualified "Debug",
+        qualified "List",
+        qualified "Maybe",
+        qualified "Platform",
+        qualified "Result",
+        qualified "Text", -- equivalent to Elm's String
+        qualified "Tuple",
+        -- Additionally Task and Log because we use them everywhere
+        qualified "Log",
+        qualified "Task"
       ]
     unqualified name =
       GhcPlugins.noLoc (simpleImportDecl (GhcPlugins.mkModuleName name))

--- a/nri-prelude/src/NriPrelude/Plugin.hs
+++ b/nri-prelude/src/NriPrelude/Plugin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 {-# OPTIONS_GHC -fno-warn-incomplete-record-updates #-}
 
 -- | A compiler plugin that imports the equivalents of modules that Elm will

--- a/nri-prelude/src/Task.hs
+++ b/nri-prelude/src/Task.hs
@@ -1,3 +1,9 @@
+-- GHC wants us to remove `Err never` branches from case statements, because it
+-- knows we'll never end up in those branches. We like them though, because
+-- missing such a branch in a case statement looks like a problem and so is
+-- distracting.
+{-# OPTIONS_GHC -fno-warn-overlapping-patterns #-}
+
 -- | Tasks make it easy to describe asynchronous operations that may fail, like
 -- HTTP requests or writing to a database.
 module Task
@@ -57,6 +63,8 @@ perform :: Internal.LogHandler -> Task Never a -> IO a
 perform output task =
   let onResult result =
         case result of
+          -- If you remove this branch, consider also removing the
+          -- -fno-warn-overlapping-patterns warning above.
           Err err -> never err
           Ok x -> x
    in attempt output task

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NumericUnderscores #-}
+-- GHC wants us to remove `Err never` branches from case statements, because it
+-- knows we'll never end up in those branches. We like them though, because
+-- missing such a branch in a case statement looks like a problem and so is
+-- distracting.
+{-# OPTIONS_GHC -fno-warn-overlapping-patterns #-}
 
 module Test.Internal where
 
@@ -421,6 +426,8 @@ runSingle test' =
         let testRest =
               case res of
                 Ok x -> x
+                -- If you remove this branch, consider also removing the
+                -- -fno-warn-overlapping-patterns warning above.
                 Err err -> never err
         span' <- MVar.takeMVar spanVar
         let span =


### PR DESCRIPTION
Automatically import common modules.

Possible improvements:
- [x] Disable `unused imports` warnings in plugin or, better yet, disable them only for our default imports (the import type has a `ideclImplicit` field that's set for `Prelude` normally, maybe setting it for our imports too will fix things?)
- [ ] Remove implicit Prelude import, so we don't also need to enable the `NoImplicitPrelude` language extension.
- [ ] Make it compile against GHC 8.10 too.
- [ ] Instead of not running the extension for `Paths_*` modules, check for the existence of an unqualified import of `Prelude`. If one exists do an `import NriPrelude hiding ((++))` instead of a regular `import NriPrelude`.

None of these are blocking to merging this PR though.