### PR TITLE
Fix bug where andCheck would eval twice

### DIFF
--- a/nri-prelude/src/Expect/Task.hs
+++ b/nri-prelude/src/Expect/Task.hs
@@ -31,7 +31,7 @@ andCheck expectation task = do
       |> Internal.unExpectation
       |> Task.mapError never
   case res of
-    Internal.Succeeded -> task
+    Internal.Succeeded -> Task.succeed x
     Internal.Failed failure -> Task.fail failure
 
 -- | Check an expectation in the middle of a @do@ block.


### PR DESCRIPTION
Running `andCheck` currently results in the task passed in being evaluated twice. This can result in subtle bugs, for example a task doing a database query inserting two rows intead of one, possibly failing the second insert because of a uniqueness constraint.

Paired with @Arkham 