### PR TITLE
Small test fixes

### DIFF
--- a/nix/mk-shell.nix
+++ b/nix/mk-shell.nix
@@ -36,6 +36,7 @@ in pkgs.mkShell {
       ]))
     pkgs.cabal-install
     pkgs.haskellPackages.hpack
+    pkgs.niv
     pkgs.zlib
     pkgs.haskellPackages.ghcid
     pkgs.ormolu

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "stoeffel",
         "repo": "pretty-diff",
-        "rev": "46280511bbdc721147594e636f80ba0ce31a7102",
-        "sha256": "1zjcw6dgw0b8zpxp9pp6m34649dd3xszsl50hg33m7ixyvg46527",
+        "rev": "c59ed76cf6d6808b363eea991236c097f6f42996",
+        "sha256": "16gnsbn2pg42f5478k9la20gammd520v9gw2ams69cq7rq0cx224",
         "type": "tarball",
-        "url": "https://github.com/stoeffel/pretty-diff/archive/46280511bbdc721147594e636f80ba0ce31a7102.tar.gz",
+        "url": "https://github.com/stoeffel/pretty-diff/archive/c59ed76cf6d6808b363eea991236c097f6f42996.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": null,
         "owner": "stoeffel",
         "repo": "pretty-diff",
-        "rev": "c59ed76cf6d6808b363eea991236c097f6f42996",
-        "sha256": "16gnsbn2pg42f5478k9la20gammd520v9gw2ams69cq7rq0cx224",
+        "rev": "4d7ecac49f8d9dde8a006126900843cc1ba63ca6",
+        "sha256": "0d6zc52m6g6651a9pr33vyhhdljwhf83a2z0p0mqwz80gx2w1xnb",
         "type": "tarball",
-        "url": "https://github.com/stoeffel/pretty-diff/archive/c59ed76cf6d6808b363eea991236c097f6f42996.tar.gz",
+        "url": "https://github.com/stoeffel/pretty-diff/archive/4d7ecac49f8d9dde8a006126900843cc1ba63ca6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nri-prelude/package.yaml
+++ b/nri-prelude/package.yaml
@@ -30,7 +30,7 @@ library:
   - ghc >= 8.6.1 && < 8.11
   - hedgehog >= 1.0.2 && < 1.1
   - junit-xml >= 0.1.0.0 && < 0.2.0.0
-  - pretty-diff >= 0.4.0.0 && < 0.5
+  - pretty-diff >= 0.4.0.1 && < 0.5
   - pretty-show >= 1.9.5 && < 1.11
   - safe-exceptions >= 0.1.7.0 && < 1.3
   - terminal-size >= 0.3.2.1 && < 0.4

--- a/nri-prelude/package.yaml
+++ b/nri-prelude/package.yaml
@@ -30,7 +30,7 @@ library:
   - ghc >= 8.6.1 && < 8.11
   - hedgehog >= 1.0.2 && < 1.1
   - junit-xml >= 0.1.0.0 && < 0.2.0.0
-  - pretty-diff >= 0.4.0.1 && < 0.5
+  - pretty-diff >= 0.4.0.2 && < 0.5
   - pretty-show >= 1.9.5 && < 1.11
   - safe-exceptions >= 0.1.7.0 && < 1.3
   - terminal-size >= 0.3.2.1 && < 0.4

--- a/nri-prelude/src/Expect.hs
+++ b/nri-prelude/src/Expect.hs
@@ -429,7 +429,7 @@ err res =
 -- encodings. When a test fails we can throw away the file, rerun the test, and
 -- use @git diff golden-results/complicated-object.txt@ to check whether the
 -- changes are acceptable.
-equalToContentsOf :: Text -> Text -> Expectation
+equalToContentsOf :: Stack.HasCallStack => Text -> Text -> Expectation
 equalToContentsOf filepath' actual = do
   let filepath = Data.Text.unpack filepath'
   exists <-


### PR DESCRIPTION
<img width="710" alt="Screenshot 2021-02-22 at 19 53 31" src="https://user-images.githubusercontent.com/1217681/108755559-b7b2ac80-7547-11eb-92b0-c0db2c7df21c.png">
Seems to add the missing `SrcLoc` for `equalToContentsOf`


Update of `pretty-diff` seems to have fixed the broken diff as well

<img width="689" alt="Screenshot 2021-02-22 at 20 19 56" src="https://user-images.githubusercontent.com/1217681/108758498-745a3d00-754b-11eb-8398-dc52c7bbfde1.png">
