### PR TITLE
Failure loc in junit

### DIFF
--- a/nri-prelude/nri-prelude.cabal
+++ b/nri-prelude/nri-prelude.cabal
@@ -61,6 +61,7 @@ library
       Platform.Internal
       Test.Internal
       Test.Reporter.ExitCode
+      Test.Reporter.Internal
       Test.Reporter.Junit
       Test.Reporter.Logfile
       Test.Reporter.Stdout
@@ -133,6 +134,7 @@ test-suite tests
       Test
       Test.Internal
       Test.Reporter.ExitCode
+      Test.Reporter.Internal
       Test.Reporter.Junit
       Test.Reporter.Logfile
       Test.Reporter.Stdout

--- a/nri-prelude/src/Test/Reporter/Internal.hs
+++ b/nri-prelude/src/Test/Reporter/Internal.hs
@@ -1,0 +1,83 @@
+module Test.Reporter.Internal where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Builder as Builder
+import qualified GHC.Stack as Stack
+import qualified List
+import NriPrelude
+import qualified System.Console.ANSI as ANSI
+import qualified System.Directory
+import System.FilePath ((</>))
+import qualified Prelude
+
+extraLinesOnFailure :: Int
+extraLinesOnFailure = 2
+
+renderSrcLoc ::
+  ([ANSI.SGR] -> Builder.Builder -> Builder.Builder) ->
+  Stack.SrcLoc ->
+  Prelude.IO Builder.Builder
+renderSrcLoc styled loc = do
+  cwd <- System.Directory.getCurrentDirectory
+  let path = cwd </> Stack.srcLocFile loc
+  exists <- System.Directory.doesFileExist path
+  if exists
+    then do
+      contents <- BS.readFile path
+      let startLine = Prelude.fromIntegral (Stack.srcLocStartLine loc)
+      let lines =
+            contents
+              |> BS.split 10 -- splitting newlines
+              |> List.drop (startLine - extraLinesOnFailure - 1)
+              |> List.take (extraLinesOnFailure * 2 + 1)
+              |> List.indexedMap
+                ( \i l ->
+                    Builder.intDec
+                      ( Prelude.fromIntegral
+                          <| startLine + i - extraLinesOnFailure
+                      )
+                      ++ ": "
+                      ++ Builder.byteString l
+                )
+      Prelude.pure <| case lines of
+        [] -> ""
+        lines' ->
+          "\n"
+            ++ "Expectation failed at "
+            ++ Builder.stringUtf8 (Stack.srcLocFile loc)
+            ++ ":"
+            ++ Builder.intDec (Stack.srcLocStartLine loc)
+            ++ "\n"
+            ++ Prelude.foldMap
+              ( \(nr, line) ->
+                  if nr == extraLinesOnFailure
+                    then styled [red] ("✗ " ++ line) ++ "\n"
+                    else "  " ++ styled [dullGrey] line ++ "\n"
+              )
+              (List.indexedMap (,) lines')
+            ++ "\n"
+    else Prelude.pure ""
+
+sgr :: [ANSI.SGR] -> Builder.Builder
+sgr = Builder.stringUtf8 << ANSI.setSGRCode
+
+red :: ANSI.SGR
+red = ANSI.SetColor ANSI.Foreground ANSI.Dull ANSI.Red
+
+yellow :: ANSI.SGR
+yellow = ANSI.SetColor ANSI.Foreground ANSI.Dull ANSI.Yellow
+
+green :: ANSI.SGR
+green = ANSI.SetColor ANSI.Foreground ANSI.Dull ANSI.Green
+
+grey :: ANSI.SGR
+grey = ANSI.SetColor ANSI.Foreground ANSI.Vivid ANSI.Black
+
+dullGrey :: ANSI.SGR
+dullGrey = ANSI.SetColor ANSI.Foreground ANSI.Dull ANSI.Black
+
+black :: ANSI.SGR
+black = ANSI.SetColor ANSI.Foreground ANSI.Dull ANSI.White
+
+underlined :: ANSI.SGR
+underlined = ANSI.SetUnderlining ANSI.SingleUnderline

--- a/nri-prelude/src/Test/Reporter/Junit.hs
+++ b/nri-prelude/src/Test/Reporter/Junit.hs
@@ -24,24 +24,32 @@ import qualified Prelude
 report :: FilePath.FilePath -> Internal.SuiteResult -> Prelude.IO ()
 report path result = do
   createPathDirIfMissing path
-  JUnit.writeXmlReport path (testResults result)
+  results <- testResults result
+  JUnit.writeXmlReport path results
 
-testResults :: Internal.SuiteResult -> List JUnit.TestSuite
+testResults :: Internal.SuiteResult -> Prelude.IO (List JUnit.TestSuite)
 testResults result =
   case result of
     Internal.AllPassed passed ->
       List.map renderPassed passed
+        |> Prelude.pure
     Internal.OnlysPassed passed skipped ->
-      List.map renderSkipped skipped
-        ++ List.map renderPassed passed
+      Prelude.pure
+        ( List.map renderSkipped skipped
+            ++ List.map renderPassed passed
+        )
     Internal.PassedWithSkipped passed skipped ->
-      List.map renderSkipped skipped
-        ++ List.map renderPassed passed
+      Prelude.pure
+        ( List.map renderSkipped skipped
+            ++ List.map renderPassed passed
+        )
     Internal.TestsFailed passed skipped failed ->
-      List.map renderFailed failed
-        ++ List.map renderSkipped skipped
-        ++ List.map renderPassed passed
-    Internal.NoTestsInSuite -> []
+      Prelude.pure
+        ( List.map renderFailed failed
+            ++ List.map renderSkipped skipped
+            ++ List.map renderPassed passed
+        )
+    Internal.NoTestsInSuite -> Prelude.pure []
 
 renderPassed :: Internal.SingleTest Platform.TracingSpan -> JUnit.TestSuite
 renderPassed test =


### PR DESCRIPTION
You can run `cabal test nri-prelude --test-options="--xml ./junit.xml"` locally to see the unit output.

I've checked the XML output using a random online XML viewer https://jsonformatter.org/xml-viewer
![Screenshot 2021-03-16 at 13 59 06](https://user-images.githubusercontent.com/1217681/111312647-ccbebf00-865f-11eb-98aa-7b1173df6fd2.png)

