### PR TITLE
fix log-explorer's nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,8 @@ let
     nri-prelude = super.callCabal2nix "nri-prelude" ./nri-prelude { };
     log-explorer = super.callCabal2nix "log-explorer" ./nri-log-explorer { };
     pretty-diff = super.callCabal2nix "pretty-diff" sources.pretty-diff { };
+    safe-coloured-text =
+      super.callCabal2nix "safe-coloured-text" "${sources.safe-coloured-text}/safe-coloured-text" { };
   });
 
 in {

--- a/nri-log-explorer/CHANGELOG.md
+++ b/nri-log-explorer/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements:
 
 - Add match count to search interface (#67)
+- Fix default.nix to make log-explorer buildable
 
 # 0.1.1.1
 


### PR DESCRIPTION
`default.nix` didn't include necessary dependencies

this includes them!