### PR TITLE
format nri-redis changelog

### DIFF
--- a/nri-redis/CHANGELOG.md
+++ b/nri-redis/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased next version
 
-# 0.1.0.0 - Initial Release!
+# 0.1.0.0
 
-First release, but we've battle-tested it against significant load for months now!
-Hope you enjoy
+- First release, but we've battle-tested it against significant load for months now!
+  Hope you enjoy

--- a/release.sh
+++ b/release.sh
@@ -26,7 +26,7 @@ version=$(grep version: < package.yaml | awk '{print $2}')
 bundle="$name-$version.tar.gz"
 
 # check changelog contains an entry for this version
-grep "^# $version$" < CHANGELOG.md > /dev/null || fail "CHANGELOG.md is missing an entry for the current version."
+grep "^# $version$" < CHANGELOG.md > /dev/null || fail "CHANGELOG.md is missing an entry for the current version. The line must look exactly like: # $version"
 
 # check copyright year is current year
 grep "^copyright: $(date +'%Y')" < package.yaml > /dev/null \


### PR DESCRIPTION
can't release nri-redis because it has the wrong changelog