### PR TITLE
fix redis release

### DIFF
--- a/nri-redis/nri-redis.cabal
+++ b/nri-redis/nri-redis.cabal
@@ -45,7 +45,7 @@ library
   hs-source-dirs:
       src
   default-extensions: DataKinds DeriveGeneric ExtendedDefaultRules FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving MultiParamTypeClasses NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures ScopedTypeVariables Strict TypeOperators
-  ghc-options: -Werror -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fno-warn-type-defaults -fplugin=NriPrelude.Plugin
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fno-warn-type-defaults -fplugin=NriPrelude.Plugin
   build-depends:
       aeson >=1.4.6.0 && <1.6
     , async >=2.2.2 && <2.3
@@ -83,7 +83,7 @@ test-suite tests
       test
       src
   default-extensions: DataKinds DeriveGeneric ExtendedDefaultRules FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving MultiParamTypeClasses NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedStrings PartialTypeSignatures ScopedTypeVariables Strict TypeOperators
-  ghc-options: -Werror -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fno-warn-type-defaults -fplugin=NriPrelude.Plugin
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fno-warn-type-defaults -fplugin=NriPrelude.Plugin
   build-depends:
       aeson >=1.4.6.0 && <1.6
     , async >=2.2.2 && <2.3

--- a/nri-redis/package.yaml
+++ b/nri-redis/package.yaml
@@ -56,7 +56,6 @@ default-extensions:
   - Strict
   - TypeOperators
 ghc-options:
-  - -Werror
   - -Wall
   - -Wcompat
   - -Widentities


### PR DESCRIPTION
```sh
$ ./release.sh nri-redis
~/Documents/work/haskell-libraries/nri-redis ~/Documents/work/haskell-libraries
nri-redis.cabal is up-to-date
Uploading nri-redis-0.1.0.0.tar.gz...
Error uploading nri-redis-0.1.0.0.tar.gz: http code 400
Error: Invalid package

'ghc-options: -Wall -Werror' makes the package very easy to break with future
GHC versions because new GHC versions often add new warnings. Use just
'ghc-options: -Wall' instead. Alternatively, if you want to use this, make it
conditional based on a Cabal configuration flag (with 'manual: True' and
'default: False') and enable that flag during development.
```

`-Werror` is invalid for packages