### PR TITLE
Redis data needs examples

### DIFF
--- a/nri-redis/CHANGELOG.md
+++ b/nri-redis/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased next version
 
+- In order to prevent accidental API changes, we force data in redis API to
+  implement the HasExamples TypeClass from the nri-test-encoding package. (thanks @stoeffel / #82)
+
 # 0.1.0.0
 
 - First release, but we've battle-tested it against significant load for months now!

--- a/nri-redis/nri-redis.cabal
+++ b/nri-redis/nri-redis.cabal
@@ -36,6 +36,7 @@ library
       Redis.List
       Redis.Mock
       Redis.Set
+      Redis.Test
   other-modules:
       Redis.Codec
       Redis.Internal
@@ -56,6 +57,7 @@ library
     , nri-env-parser >=0.1.0.0 && <0.2
     , nri-observability >=0.1.0 && <0.2
     , nri-prelude >=0.1.0.0 && <0.7
+    , nri-test-encoding >=0.1.0 && <0.2
     , resourcet >=1.2.0 && <1.3
     , safe-exceptions >=0.1.7.0 && <1.3
     , text >=1.2.3.1 && <1.3
@@ -78,6 +80,7 @@ test-suite tests
       Redis.Real
       Redis.Set
       Redis.Settings
+      Redis.Test
       Paths_nri_redis
   hs-source-dirs:
       test
@@ -94,6 +97,7 @@ test-suite tests
     , nri-env-parser >=0.1.0.0 && <0.2
     , nri-observability >=0.1.0 && <0.2
     , nri-prelude >=0.1.0.0 && <0.7
+    , nri-test-encoding >=0.1.0 && <0.2
     , resourcet >=1.2.0 && <1.3
     , safe-exceptions >=0.1.7.0 && <1.3
     , text >=1.2.3.1 && <1.3

--- a/nri-redis/package.yaml
+++ b/nri-redis/package.yaml
@@ -25,6 +25,7 @@ library:
     - nri-env-parser >= 0.1.0.0 && < 0.2
     - nri-observability >= 0.1.0 && < 0.2
     - nri-prelude >= 0.1.0.0 && < 0.7
+    - nri-test-encoding >= 0.1.0 && < 0.2
     - resourcet >= 1.2.0 && < 1.3
     - safe-exceptions >= 0.1.7.0 && < 1.3
     - text >= 1.2.3.1 && < 1.3
@@ -38,6 +39,7 @@ library:
     - Redis.List
     - Redis.Mock
     - Redis.Set
+    - Redis.Test
   source-dirs:
     - src
 default-extensions:

--- a/nri-redis/src/Redis.hs
+++ b/nri-redis/src/Redis.hs
@@ -32,6 +32,11 @@ module Redis
     set,
     setex,
     setnx,
+
+    -- * Every `Redis.Api key value` needs to implement an instance for `HasExamples value`.
+
+    -- | This instance is used to generate golden-tests for the api's value.
+    -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
     Examples.HasExamples (..),
 
     -- * Running Redis queries
@@ -135,13 +140,17 @@ data Api key a = Api
   }
 
 -- | Creates a json API mapping a 'key' to a json-encodable-decodable type
--- @
--- data Key = Key { fieldA: Text, fieldB: Text }
--- data Val = Val { ... }
 --
--- myJsonApi :: Redis.Api Key Val
--- myJsonApi = Redis.jsonApi (\Key {fieldA, fieldB}-> Text.join "-" [fieldA, fieldB, "v1"])
--- @
+-- > data Key = Key { fieldA: Text, fieldB: Text }
+-- > data Val = Val { ... }
+-- >
+-- > -- | This instance can be used to generate a golden test for this type.
+-- > -- | See Redis.Test
+-- > instance Redis.HasExamples Val where
+-- >   example = Examples.example "Val" Val { ... }
+-- >
+-- > myJsonApi :: Redis.Api Key Val
+-- > myJsonApi = Redis.jsonApi (\Key {fieldA, fieldB}-> Text.join "-" [fieldA, fieldB, "v1"])
 jsonApi ::
   forall a key.
   (Examples.HasExamples a, Aeson.ToJSON a, Aeson.FromJSON a) =>

--- a/nri-redis/src/Redis.hs
+++ b/nri-redis/src/Redis.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 -- | A simple Redis library providing high level access to Redis features we
 -- use here at NoRedInk
@@ -31,6 +32,7 @@ module Redis
     set,
     setex,
     setnx,
+    Examples.HasExamples (..),
 
     -- * Running Redis queries
     Internal.query,
@@ -49,6 +51,7 @@ import qualified Data.ByteString as ByteString
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Dict
+import qualified Examples
 import qualified NonEmptyDict
 import qualified Redis.Codec as Codec
 import qualified Redis.Internal as Internal
@@ -139,8 +142,12 @@ data Api key a = Api
 -- myJsonApi :: Redis.Api Key Val
 -- myJsonApi = Redis.jsonApi (\Key {fieldA, fieldB}-> Text.join "-" [fieldA, fieldB, "v1"])
 -- @
-jsonApi :: (Aeson.ToJSON a, Aeson.FromJSON a) => (key -> Text) -> Api key a
-jsonApi = makeApi Codec.jsonCodec
+jsonApi ::
+  forall a key.
+  (Examples.HasExamples a, Aeson.ToJSON a, Aeson.FromJSON a) =>
+  (key -> Text) ->
+  Api key a
+jsonApi toKey = makeApi Codec.jsonCodec toKey
 
 -- | Creates a Redis API mapping a 'key' to Text
 textApi :: (key -> Text) -> Api key Text

--- a/nri-redis/src/Redis.hs
+++ b/nri-redis/src/Redis.hs
@@ -33,13 +33,6 @@ module Redis
     setex,
     setnx,
 
-    -- * Every `Redis.Api key value` needs to implement an instance for `HasExamples value`.
-
-    -- | This instance is used to generate golden-tests for the api's value.
-    -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
-    Examples.HasExamples (..),
-    Examples.example,
-
     -- * Running Redis queries
     Internal.query,
     Internal.transaction,
@@ -49,6 +42,13 @@ module Redis
     Internal.map2,
     Internal.map3,
     Internal.sequence,
+
+    -- * Every `Redis.Api key value` needs to implement an instance for `HasExamples value`.
+
+    -- | This instance is used to generate golden-tests for the api's value.
+    -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
+    Examples.HasExamples (..),
+    Examples.example,
   )
 where
 

--- a/nri-redis/src/Redis.hs
+++ b/nri-redis/src/Redis.hs
@@ -38,6 +38,7 @@ module Redis
     -- | This instance is used to generate golden-tests for the api's value.
     -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
     Examples.HasExamples (..),
+    Examples.example,
 
     -- * Running Redis queries
     Internal.query,

--- a/nri-redis/src/Redis/Hash.hs
+++ b/nri-redis/src/Redis/Hash.hs
@@ -38,6 +38,7 @@ module Redis.Hash
     -- | This instance is used to generate golden-tests for the api's value.
     -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
     Examples.HasExamples (..),
+    Examples.example,
 
     -- * Running Redis queries
     Internal.query,

--- a/nri-redis/src/Redis/Hash.hs
+++ b/nri-redis/src/Redis/Hash.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 -- | A simple Redis library providing high level access to Redis features we
 -- use here at NoRedInk
@@ -32,6 +33,12 @@ module Redis.Hash
     hset,
     hsetnx,
 
+    -- * Every `Redis.Api key value` needs to implement an instance for `HasExamples value`.
+
+    -- | This instance is used to generate golden-tests for the api's value.
+    -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
+    Examples.HasExamples (..),
+
     -- * Running Redis queries
     Internal.query,
     Internal.transaction,
@@ -50,6 +57,7 @@ import qualified Data.ByteString as ByteString
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Dict
+import qualified Examples
 import qualified NonEmptyDict
 import qualified Redis.Codec as Codec
 import qualified Redis.Internal as Internal
@@ -125,7 +133,8 @@ data Api key field a = Api
   }
 
 jsonApi ::
-  (Aeson.ToJSON a, Aeson.FromJSON a, Ord field) =>
+  forall a field key.
+  (Examples.HasExamples a, Aeson.ToJSON a, Aeson.FromJSON a, Ord field) =>
   (key -> Text) ->
   (field -> Text) ->
   (Text -> Maybe field) ->

--- a/nri-redis/src/Redis/Hash.hs
+++ b/nri-redis/src/Redis/Hash.hs
@@ -33,13 +33,6 @@ module Redis.Hash
     hset,
     hsetnx,
 
-    -- * Every `Redis.Api key value` needs to implement an instance for `HasExamples value`.
-
-    -- | This instance is used to generate golden-tests for the api's value.
-    -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
-    Examples.HasExamples (..),
-    Examples.example,
-
     -- * Running Redis queries
     Internal.query,
     Internal.transaction,
@@ -49,6 +42,13 @@ module Redis.Hash
     Internal.map2,
     Internal.map3,
     Internal.sequence,
+
+    -- * Every `Redis.Api key value` needs to implement an instance for `HasExamples value`.
+
+    -- | This instance is used to generate golden-tests for the api's value.
+    -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
+    Examples.HasExamples (..),
+    Examples.example,
   )
 where
 

--- a/nri-redis/src/Redis/List.hs
+++ b/nri-redis/src/Redis/List.hs
@@ -32,6 +32,7 @@ module Redis.List
     -- | This instance is used to generate golden-tests for the api's value.
     -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
     Examples.HasExamples (..),
+    Examples.example,
 
     -- * Running Redis queries
     Internal.query,

--- a/nri-redis/src/Redis/List.hs
+++ b/nri-redis/src/Redis/List.hs
@@ -27,13 +27,6 @@ module Redis.List
     lrange,
     rpush,
 
-    -- * Every `Redis.Api key value` needs to implement an instance for `HasExamples value`.
-
-    -- | This instance is used to generate golden-tests for the api's value.
-    -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
-    Examples.HasExamples (..),
-    Examples.example,
-
     -- * Running Redis queries
     Internal.query,
     Internal.transaction,
@@ -43,6 +36,13 @@ module Redis.List
     Internal.map2,
     Internal.map3,
     Internal.sequence,
+
+    -- * Every `Redis.Api key value` needs to implement an instance for `HasExamples value`.
+
+    -- | This instance is used to generate golden-tests for the api's value.
+    -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
+    Examples.HasExamples (..),
+    Examples.example,
   )
 where
 

--- a/nri-redis/src/Redis/List.hs
+++ b/nri-redis/src/Redis/List.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 -- | A simple Redis library providing high level access to Redis features we
 -- use here at NoRedInk
@@ -26,6 +27,12 @@ module Redis.List
     lrange,
     rpush,
 
+    -- * Every `Redis.Api key value` needs to implement an instance for `HasExamples value`.
+
+    -- | This instance is used to generate golden-tests for the api's value.
+    -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
+    Examples.HasExamples (..),
+
     -- * Running Redis queries
     Internal.query,
     Internal.transaction,
@@ -42,6 +49,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as ByteString
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
+import qualified Examples
 import qualified Redis.Codec as Codec
 import qualified Redis.Internal as Internal
 import qualified Redis.Real as Real
@@ -84,7 +92,11 @@ data Api key a = Api
     rpush :: key -> NonEmpty a -> Internal.Query Int
   }
 
-jsonApi :: (Aeson.ToJSON a, Aeson.FromJSON a) => (key -> Text) -> Api key a
+jsonApi ::
+  forall a key.
+  (Examples.HasExamples a, Aeson.ToJSON a, Aeson.FromJSON a) =>
+  (key -> Text) ->
+  Api key a
 jsonApi = makeApi Codec.jsonCodec
 
 textApi :: (key -> Text) -> Api key Text

--- a/nri-redis/src/Redis/Set.hs
+++ b/nri-redis/src/Redis/Set.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 -- | A simple Redis library providing high level access to Redis features we
 -- use here at NoRedInk
@@ -37,6 +38,13 @@ module Redis.Set
     Internal.map2,
     Internal.map3,
     Internal.sequence,
+
+    -- * Every `Redis.Api key value` needs to implement an instance for `HasExamples value`.
+
+    -- | This instance is used to generate golden-tests for the api's value.
+    -- | You can use `Redis.Test.fromExamples yourRedisApi` in your test suite.
+    Examples.HasExamples (..),
+    Examples.example,
   )
 where
 
@@ -44,6 +52,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as ByteString
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
+import qualified Examples
 import qualified Redis.Codec as Codec
 import qualified Redis.Internal as Internal
 import qualified Redis.Real as Real
@@ -95,7 +104,11 @@ data Api key a = Api
     smembers :: key -> Internal.Query (Set.Set a)
   }
 
-jsonApi :: (Aeson.ToJSON a, Aeson.FromJSON a, Ord a) => (key -> Text) -> Api key a
+jsonApi ::
+  forall a key.
+  (Examples.HasExamples a, Aeson.ToJSON a, Aeson.FromJSON a, Ord a) =>
+  (key -> Text) ->
+  Api key a
 jsonApi = makeApi Codec.jsonCodec
 
 textApi :: (key -> Text) -> Api key Text

--- a/nri-redis/src/Redis/Test.hs
+++ b/nri-redis/src/Redis/Test.hs
@@ -8,6 +8,13 @@ import Test (Test)
 import qualified Test.Encoding
 import qualified Text
 
+-- | Turns a Redis.Api into a test.
+-- The test does the following:
+--
+-- 1. get examples from the `HasExamples` constraint
+-- 2. encoded the examples into JSON
+-- 3. check the encoded JSON against the generated file
+--   NOTE: it will generate the file if it doesn't exist yet
 encoding :: forall m key a. (Typeable.Typeable a, Examples.HasExamples a) => m key a -> Test
 encoding _ =
   let proxy = Proxy :: Proxy a

--- a/nri-redis/src/Redis/Test.hs
+++ b/nri-redis/src/Redis/Test.hs
@@ -1,0 +1,12 @@
+-- | Useful to test encoding of data stored in redis.
+module Redis.Test (encoding) where
+
+import Data.Proxy (Proxy (Proxy))
+import qualified Examples
+import Test (Test)
+import qualified Test.Encoding
+
+encoding :: forall m key a. Examples.HasExamples a => Text -> Text -> m key a -> Test
+encoding name fileName _ =
+  Examples.examples (Proxy :: Proxy a)
+    |> Test.Encoding.examplesToTest name fileName

--- a/nri-redis/src/Redis/Test.hs
+++ b/nri-redis/src/Redis/Test.hs
@@ -2,11 +2,20 @@
 module Redis.Test (encoding) where
 
 import Data.Proxy (Proxy (Proxy))
+import qualified Data.Typeable as Typeable
 import qualified Examples
 import Test (Test)
 import qualified Test.Encoding
+import qualified Text
 
-encoding :: forall m key a. Examples.HasExamples a => Text -> Text -> m key a -> Test
-encoding name fileName _ =
-  Examples.examples (Proxy :: Proxy a)
-    |> Test.Encoding.examplesToTest name fileName
+encoding :: forall m key a. (Typeable.Typeable a, Examples.HasExamples a) => m key a -> Test
+encoding _ =
+  let proxy = Proxy :: Proxy a
+      tyCon =
+        Typeable.typeRep proxy
+          |> Typeable.typeRepTyCon
+      typeName =
+        Typeable.tyConModule tyCon ++ "." ++ Typeable.tyConName tyCon
+          |> Text.fromList
+   in Examples.examples proxy
+        |> Test.Encoding.examplesToTest typeName ("redis-encoding-" ++ typeName)


### PR DESCRIPTION
forces redis APIs to have examples to make it harder to make regressions