### PR TITLE
Fix ReqBody instance

### DIFF
--- a/nri-test-encoding/src/Examples.hs
+++ b/nri-test-encoding/src/Examples.hs
@@ -96,3 +96,6 @@ instance HasExamples Int where
 
 instance HasExamples () where
   examples _ = example "unit" ()
+
+instance HasExamples Text where
+  examples _ = example "text" ("" :: Text)

--- a/nri-test-encoding/src/Test/Encoding/Routes.hs
+++ b/nri-test-encoding/src/Test/Encoding/Routes.hs
@@ -28,7 +28,6 @@ import Servant.API
     Header,
     QueryFlag,
     Raw,
-    ReqBody,
     ReqBody',
     Summary,
     Verb,
@@ -185,16 +184,6 @@ instance (KnownSymbol s, IsApi a) => IsApi (Capture' mods s paramType :> a) wher
         ( \route ->
             route
               { path = (":" ++ Text.fromList (symbolVal (Proxy :: Proxy s))) : path route
-              }
-        )
-
-instance (Typeable.Typeable body, Examples.HasExamples body, IsApi a) => IsApi (ReqBody encodings body :> a) where
-  crawl _ =
-    crawl (Proxy :: Proxy a)
-      |> List.map
-        ( \route ->
-            route
-              { requestBody = Just (SomeType (Proxy :: Proxy body))
               }
         )
 


### PR DESCRIPTION
The `IsApi` instance for `ReqBody` and `ReqBody'` where overlapping and `ReqBody` was not necessary.