### PR TITLE
Allow network-uri 2.7.0.0

### DIFF
--- a/nri-http/CHANGELOG.md
+++ b/nri-http/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0.1
+
+- Relax version bounds to encompass `network-uri-2.7.0.0`.
+
 # 0.1.0.0
 
 - Initial release.

--- a/nri-http/nri-http.cabal
+++ b/nri-http/nri-http.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           nri-http
-version:        0.1.0.0
+version:        0.1.0.1
 synopsis:       Make Elm style HTTP requests
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-http#readme>.
 category:       Web
@@ -62,7 +62,7 @@ library
     , http-client-tls >=0.3.0 && <0.4
     , http-types ==0.12.*
     , mime-types >=0.1.0.0 && <0.2
-    , network-uri >=2.6.0.0 && <2.7
+    , network-uri >=2.6.0.0 && <2.8
     , nri-observability >=0.1.0.0 && <0.2
     , nri-prelude >=0.1.0.0 && <0.7
     , safe-exceptions >=0.1.7.0 && <1.3
@@ -106,7 +106,7 @@ test-suite spec
     , http-client-tls >=0.3.0 && <0.4
     , http-types ==0.12.*
     , mime-types >=0.1.0.0 && <0.2
-    , network-uri >=2.6.0.0 && <2.7
+    , network-uri >=2.6.0.0 && <2.8
     , nri-observability >=0.1.0.0 && <0.2
     , nri-prelude >=0.1.0.0 && <0.7
     , safe-exceptions >=0.1.7.0 && <1.3

--- a/nri-http/package.yaml
+++ b/nri-http/package.yaml
@@ -2,7 +2,7 @@ name: nri-http
 synopsis: Make Elm style HTTP requests
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-http#readme>.
 author: NoRedInk
-version: 0.1.0.0
+version: 0.1.0.1
 maintainer: haskell-open-source@noredink.com
 copyright: 2021 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-http
@@ -24,7 +24,7 @@ library:
   - http-client-tls >= 0.3.0 && < 0.4
   - http-types >= 0.12 && < 0.13
   - mime-types >= 0.1.0.0 && < 0.2
-  - network-uri >= 2.6.0.0 && < 2.7
+  - network-uri >= 2.6.0.0 && < 2.8
   - safe-exceptions >= 0.1.7.0 && < 1.3
   - text >= 1.2.3.1 && < 1.3
   exposed-modules:
@@ -44,7 +44,7 @@ tests:
     - http-client-tls >= 0.3.0 && < 0.4
     - http-types >= 0.12 && < 0.13
     - mime-types >= 0.1.0.0 && < 0.2
-    - network-uri >= 2.6.0.0 && < 2.7
+    - network-uri >= 2.6.0.0 && < 2.8
     - safe-exceptions >= 0.1.7.0 && < 1.3
     - text >= 1.2.3.1 && < 1.3
     - wai >= 3.2.0 && < 3.3


### PR DESCRIPTION
Version 2.7.0.0 of network-uri was retracted later and rereleased as
2.6.2.0, because all changes in it were backwards-compatible.

https://github.com/haskell/network-uri/issues/48

When setting the bounds to exclude it I assumed it was broken. I took
another look when https://packdeps.haskellers.com started reporting
nri-http wasn't supporting the latest version of network-uri.

It's probably best for folks not to use the version of network-uri
that's not recommended by the authors (it didn't bet minor and patch
level upgrades that were released on the 2.6 branch). 2.7.0.0 doesn't
seem _incompatible_ with nri-http though, so to make
packdeps.haskellers.com happy I suppose we can support it.