### PR TITLE
Honeycomb handler function only takes settings

### DIFF
--- a/nri-observability/src/Reporter/Honeycomb/Internal.hs
+++ b/nri-observability/src/Reporter/Honeycomb/Internal.hs
@@ -472,8 +472,9 @@ data SendOrSample
 
 -- | Create a 'Handler' for a specified set of 'Settings'. Do this once when
 -- your application starts and reuse the 'Handler' you get.
-handler :: Timer.Timer -> Settings -> Prelude.IO Handler
-handler timer settings = do
+handler :: Settings -> Prelude.IO Handler
+handler settings = do
+  timer <- Timer.mkTimer
   http <- HTTP.TLS.getGlobalManager
   revision <- getRevision
   hostname' <- Network.HostName.getHostName


### PR DESCRIPTION
This makes it match the signature of the other handlers. The handler can
create a timer by itself.