### PR TITLE
Route overrideable sampling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ nri-observability/nri-observability.cabal: nri-observability/package.yaml
 ghcid-nri-observability: nri-observability/nri-observability.cabal
 	cd nri-observability && ghcid
 
+ghcid-nri-observability-test: nri-observability/nri-observability.cabal
+	cd nri-observability && ghcid --command "cabal repl nri-observability:test:tests" --test Main.main
+
 nri-prelude/nri-prelude.cabal: nri-prelude/package.yaml
 	hpack nri-prelude
 

--- a/nri-observability/src/Reporter/Honeycomb.hs
+++ b/nri-observability/src/Reporter/Honeycomb.hs
@@ -3,7 +3,7 @@ module Reporter.Honeycomb
   ( Internal.report,
     Internal.handler,
     Internal.Handler,
-    Internal.Settings(..),
+    Internal.Settings (..),
     Internal.decoder,
   )
 where

--- a/nri-observability/src/Reporter/Honeycomb/Internal.hs
+++ b/nri-observability/src/Reporter/Honeycomb/Internal.hs
@@ -571,7 +571,19 @@ data Settings = Settings
     --
     -- [@environment variable@] HONEYCOMB_APDEX_TIME_IN_MILLISECONDS
     -- [@default value@] 100
-    apdexTimeMs :: Int
+    apdexTimeMs :: Int,
+    -- | Allows overriding the default sample rates for given spans.
+    -- This allows us to change the sample rate for certain endpoints within an
+    -- application, for example if a path is critical but low volume we may choose
+    -- to increase the rate.
+    -- [@default value@] the input float
+    modifyFractionOfSuccessRequestsLogged :: Float -> Platform.TracingSpan -> Float,
+    -- | Allows overriding the default apdex rates for given spans.
+    -- This allows us to change the apdex for certain endpoints within an
+    -- application, for example if a path is significantly lower volume than
+    -- another the apdex may require tuning.
+    -- [@default value@] the input int
+    modifyApdexTimeMs :: Int -> Platform.TracingSpan -> Int
   }
 
 -- | Read 'Settings' from environment variables. Default variables will be used
@@ -584,6 +596,8 @@ decoder =
     |> andMap honeycombAppNameDecoder
     |> andMap fractionOfSuccessRequestsLoggedDecoder
     |> andMap apdexTimeMsDecoder
+    |> andMap (Prelude.pure always)
+    |> andMap (Prelude.pure always)
 
 honeycombApiKeyDecoder :: Environment.Decoder (Log.Secret ByteString.ByteString)
 honeycombApiKeyDecoder =

--- a/nri-observability/src/Reporter/Honeycomb/Internal.hs
+++ b/nri-observability/src/Reporter/Honeycomb/Internal.hs
@@ -99,13 +99,15 @@ deriveSampleRate rootSpan settings =
           -- healthcheck endpoints don't populate `HttpRequest.endpoint`.
           -- Fix that first before trying this.
           Just requestPath -> List.any (requestPath ==) ["/health/readiness", "/metrics", "/health/liveness"]
-      baseRate = fractionOfSuccessRequestsLogged settings
+      baseRate = modifyFractionOfSuccessRequestsLogged settings (fractionOfSuccessRequestsLogged settings) rootSpan
       requestDurationMs =
         Timer.difference (Platform.started rootSpan) (Platform.finished rootSpan)
           |> Platform.inMicroseconds
           |> Prelude.fromIntegral
           |> (*) 1e-3
-      apdexTMs = Prelude.fromIntegral (apdexTimeMs settings)
+      apdexTMs =
+        modifyApdexTimeMs settings (apdexTimeMs settings) rootSpan
+          |> Prelude.fromIntegral
    in if isNonAppRequestPath
         then --
         -- We have 2678400 seconds in a month


### PR DESCRIPTION
This modifies the honeycomb settings to allow modifying the Adpex and sample rates based upon the TracingSpan. 

This will allow configuring custom values based on properties such as the route or even elements of the tracing span (database vs non-database).

🍐'd w/ @jwoudenberg 