### PR TITLE
Zen/allow and check to return a value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ghcid-nri-observability-test: nri-observability/nri-observability.cabal
 nri-prelude/nri-prelude.cabal: nri-prelude/package.yaml
 	hpack nri-prelude
 
-ghcid-nri-prelude-test: nri-prelude-test/nri-prelude-test.cabal
+ghcid-nri-prelude-test: nri-prelude/nri-prelude.cabal
 	cd nri-prelude && ghcid --command "cabal repl nri-prelude:test:tests" --test Main.main
 
 ghcid-nri-prelude: nri-prelude/nri-prelude.cabal

--- a/nri-prelude/src/Expect.hs
+++ b/nri-prelude/src/Expect.hs
@@ -601,7 +601,7 @@ fromResult (Err msg) =
 -- > test "Greetings are friendly" <| \_ -> do
 -- >     getGreeting
 -- >         |> andCheck (Expect.equal "Hi!")
-andCheck :: (Stack.HasCallStack, Show err) => (a -> Expectation) -> Task err a -> Internal.Expectation
+andCheck :: (Stack.HasCallStack, Show err) => (a -> Internal.Expectation' b) -> Task err a -> Internal.Expectation' b
 andCheck expectation task = do
   x <- succeeds task
   Stack.withFrozenCallStack expectation x

--- a/nri-prelude/tests/TestSpec.hs
+++ b/nri-prelude/tests/TestSpec.hs
@@ -310,7 +310,8 @@ stdoutReporter =
                   test "test err" (\_ -> Expect.err (Ok ())),
                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-                  test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+                  test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ())),
+                  test "test andCheck no map ()" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2))
                 ]
         contents <-
           withTempFile

--- a/nri-prelude/tests/golden-results/test-report-logfile-all-passed
+++ b/nri-prelude/tests/golden-results/test-report-logfile-all-passed
@@ -53,8 +53,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 340,
-        "endLine": 340,
+        "startLine": 341,
+        "endLine": 341,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-no-tests-in-suite
+++ b/nri-prelude/tests/golden-results/test-report-logfile-no-tests-in-suite
@@ -6,8 +6,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 379,
-        "endLine": 379,
+        "startLine": 380,
+        "endLine": 380,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-onlys-passed
+++ b/nri-prelude/tests/golden-results/test-report-logfile-onlys-passed
@@ -53,8 +53,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 355,
-        "endLine": 355,
+        "startLine": 356,
+        "endLine": 356,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-passed-with-skipped
+++ b/nri-prelude/tests/golden-results/test-report-logfile-passed-with-skipped
@@ -53,8 +53,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 370,
-        "endLine": 370,
+        "startLine": 371,
+        "endLine": 371,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-tests-failed
+++ b/nri-prelude/tests/golden-results/test-report-logfile-tests-failed
@@ -97,8 +97,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 399,
-        "endLine": 399,
+        "startLine": 400,
+        "endLine": 400,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc
+++ b/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc
@@ -239,7 +239,7 @@ Expectation failed at tests/TestSpec.hs:311
   310:                   test "test err" (\_ -> Expect.err (Ok ())),
 ✗ 311:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
   312:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  313:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+  313:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ())),
 
 "oops"
 
@@ -251,8 +251,8 @@ Expectation failed at tests/TestSpec.hs:312
   310:                   test "test err" (\_ -> Expect.err (Ok ())),
   311:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
 ✗ 312:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  313:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  314:                 ]
+  313:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ())),
+  314:                   test "test andCheck no map ()" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2))
 
 "Expected failure but succeeded with \"oops\""
 
@@ -263,9 +263,28 @@ Expectation failed at tests/TestSpec.hs:312
 Expectation failed at tests/TestSpec.hs:313
   311:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
   312:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-✗ 313:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  314:                 ]
-  315:         contents <-
+✗ 313:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ())),
+  314:                   test "test andCheck no map ()" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2))
+  315:                 ]
+
+▼
+1
+╷
+│ Expect.equal
+╵
+2
+▲
+
+↓ tests/TestSpec.hs:314
+↓ suite loc
+✗ test andCheck no map ()
+
+Expectation failed at tests/TestSpec.hs:314
+  312:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+  313:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ())),
+✗ 314:                   test "test andCheck no map ()" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2))
+  315:                 ]
+  316:         contents <-
 
 ▼
 1
@@ -278,4 +297,4 @@ Expectation failed at tests/TestSpec.hs:313
 [4mTEST RUN FAILED[m
 
 Passed:    0
-Failed:    17
+Failed:    18


### PR DESCRIPTION
This allows an expectation chained with `andCheck` to return a value. This is useful in taskful tests.
See an example here https://github.com/NoRedInk/NoRedInk/pull/35216