### PR TITLE
Allow commiting to kafka in addition to an external storage

### DIFF
--- a/nri-kafka/CHANGELOG.md
+++ b/nri-kafka/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0.4
+
+- Added new `ElsewhereButToKafkaAsWell` mode to `CommitOffsets`, which commits offsets to Kafka once the external Offset storage has been updated. Kafka commits are performed only to keep Kafka informed about consumer lag.
+
 # 0.1.0.3
 
 - Relax version bounds to encompass `text-2.0.x`, `base-4.16.x` and `template-haskell-2.18.x`

--- a/nri-kafka/src/Kafka/Worker.hs
+++ b/nri-kafka/src/Kafka/Worker.hs
@@ -26,6 +26,7 @@ module Kafka.Worker
     Internal.subscriptionManageOwnOffsets,
     Internal.PartitionOffset (..),
     Partition.SeekCmd (..),
+    Internal.CommitToKafkaAsWell (..),
   )
 where
 


### PR DESCRIPTION
This adds the ability to commit Offsets to Kafka in addition to committing them in an external data store.

The need arose for us because we wanted to be able to rely on Kafka consumer lag metrics, in addition to still wanting to have exactly-once-delivery from Kafka into the database we shove Kafka messages into.