### PR TITLE
no need to set file mode of logFile to standard file mode

### DIFF
--- a/nri-prelude/src/Platform/DevLog.hs
+++ b/nri-prelude/src/Platform/DevLog.hs
@@ -13,7 +13,6 @@ import NriPrelude
 import qualified Platform.Internal
 import qualified System.IO
 import qualified System.IO.Unsafe
-import qualified System.Posix.Files
 import qualified Prelude
 
 -- | Write a tracing span to the development log, where it can be found by
@@ -27,7 +26,6 @@ writeSpanToDevLog span = do
       logFile
       System.IO.AppendMode
       ( \handle -> do
-          System.Posix.Files.setFileMode logFile System.Posix.Files.stdFileMode
           Data.ByteString.Lazy.hPut handle (Aeson.encode (now, span))
           Data.ByteString.Lazy.hPut handle "\n"
       )


### PR DESCRIPTION
I believe this will fix [this issue](https://noredink.slack.com/archives/C03UX60RX/p1643142078029600), where attempts to set the mode of `/tmp/nri-prelude-logs` fail because sometimes the user you're logged in as owns the file, and sometimes `nix_bld_<n>` owns it.

This change didn't seem to blow anything up :). I haven't been able to run tests on `trunk` without failures, so I'm not 100% sure how best to test.