### PR TITLE
Set logfile mode only when necessary

### DIFF
--- a/nri-prelude/src/Platform/DevLog.hs
+++ b/nri-prelude/src/Platform/DevLog.hs
@@ -29,7 +29,9 @@ writeSpanToDevLog span = do
       System.IO.AppendMode
       ( \handle -> do
           fileStatus <- Files.getFileStatus logFile
-          Control.Monad.unless (Files.fileMode fileStatus == Files.stdFileMode) <|
+          let fileMode = Files.fileMode fileStatus
+          let fileAccessModes = Files.intersectFileModes fileMode Files.accessModes
+          Control.Monad.unless (fileAccessModes == Files.stdFileMode) <|
             Files.setFileMode logFile Files.stdFileMode
           Data.ByteString.Lazy.hPut handle (Aeson.encode (now, span))
           Data.ByteString.Lazy.hPut handle "\n"


### PR DESCRIPTION
Which should be the first time, when the user just created and owns the
file. Subsequently, the user running the code may not own the log file,
especially with multi-user nix installations, and thus won't be able to
change the file mode.