### PR TITLE
Set partition.assignment.strategy to range and cooperative

### DIFF
--- a/nri-kafka/src/Kafka/Worker/Internal.hs
+++ b/nri-kafka/src/Kafka/Worker/Internal.hs
@@ -267,7 +267,8 @@ createConsumer
             ++ Consumer.compression Consumer.Snappy
             ++ Consumer.extraProps
               ( Dict.fromList
-                  [("max.poll.interval.ms", Text.fromInt (Settings.unMaxPollIntervalMs maxPollIntervalMs))]
+                  [("max.poll.interval.ms", Text.fromInt (Settings.unMaxPollIntervalMs maxPollIntervalMs))
+                  , ("partition.assignment.strategy", "range,cooperative-sticky")]
               )
     let subscription' =
           Consumer.topics [Consumer.TopicName (Kafka.unTopic topic)]

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -16,18 +16,23 @@ pg_ctl start -o '-k .'
 mkdir -p ./_build/redis/data
 redis-server --daemonize yes --dir ./_build/redis/data
 
-## start zookeeper (for kafka) 
+## start zookeeper (for kafka)
+zk_server_properties_path=$(dirname "$(which zkServer.sh)")/../conf/zoo_sample.cfg
 mkdir -p /tmp/zookeeper /tmp/zookeeper-logs
-ZOOPIDFILE=/tmp/zookeeper-logs/pid ZOO_LOG_DIR=/tmp/zookeeper-logs  zkServer.sh stop zoo_sample.cfg
+ZOOPIDFILE=/tmp/zookeeper-logs/pid \
+          ZOO_LOG_DIR=/tmp/zookeeper-logs \
+          zkServer.sh stop "$zk_server_properties_path"
 rm -rf /tmp/zookeeper/* /tmp/zookeeper-logs/*
-ZOOPIDFILE=/tmp/zookeeper-logs/pid ZOO_LOG_DIR=/tmp/zookeeper-logs zkServer.sh start zoo_sample.cfg
+ZOOPIDFILE=/tmp/zookeeper-logs/pid \
+          ZOO_LOG_DIR=/tmp/zookeeper-logs \
+          zkServer.sh start "$zk_server_properties_path"
 
 ## wait for zookeeper
 echo "waiting for zookeeper to start"
 until nc -vz localhost 2181
 do
   sleep 1
-done 
+done
 echo "zookeeper available"
 
 ## start kafka
@@ -50,4 +55,6 @@ cabal test all
 
 # cleanup
 kafka-server-stop.sh
-ZOOPIDFILE=/tmp/zookeeper-logs/pid ZOO_LOG_DIR=/tmp/zookeeper-logs  zkServer.sh stop zoo_sample.cfg
+ZOOPIDFILE=/tmp/zookeeper-logs/pid \
+          ZOO_LOG_DIR=/tmp/zookeeper-logs  \
+          zkServer.sh stop "$zk_server_properties_path"


### PR DESCRIPTION
# Description
Enable both range and cooperative strategies. This will eventually lead us to set cooperative as a hard-default when hw-kafka is on librdkafka 1.7+.

# Docs
- [Kafka KIP on Cooperative Rebalance](https://cwiki.apache.org/confluence/display/KAFKA/KIP-429%3A+Kafka+Consumer+Incremental+Rebalance+Protocol)
- See `partition.assignment.strategy` on [librdkafka docs](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
- [librdkafka 1.7 bug on Cooperative Rebalance](https://github.com/edenhill/librdkafka/issues/3306)
