### PR TITLE
accept the slightly-broader Header' to allow for required headers

### DIFF
--- a/nri-test-encoding/src/Test/Encoding/Routes.hs
+++ b/nri-test-encoding/src/Test/Encoding/Routes.hs
@@ -25,7 +25,7 @@ import NriPrelude
 import qualified Servant
 import Servant.API
   ( Capture',
-    Header,
+    Header',
     QueryFlag,
     Raw,
     ReqBody',
@@ -228,7 +228,7 @@ instance
     Examples.HasExamples val,
     IsApi a
   ) =>
-  IsApi (Header key val :> a)
+  IsApi (Header' mods key val :> a)
   where
   crawl _ =
     crawl (Proxy :: Proxy a)


### PR DESCRIPTION
Right now we can't do

```haskell
Header' '[Required, Strict] "Key" Text
```

because we only implement `IsApi` for `Header`, which is an alias for `Header' '[Optional, Strict]`. We also can't add an orphan instance for it because `crawl` returns an opaque type. Loosening this up should still be valid for all instances of `Header`, however!
