### PR TITLE
Fix typo: outoing -> outgoing

### DIFF
--- a/nri-http/src/Http.hs
+++ b/nri-http/src/Http.hs
@@ -343,7 +343,7 @@ prepareManagerForRequest manager = do
               |> (\showS -> Text.fromList (showS ""))
        in Platform.tracingSpanIO
             log
-            "Outoing HTTP Request"
+            "Outgoing HTTP Request"
             ( \log' ->
                 Exception.finally
                   io

--- a/nri-http/test/golden-results/expected-http-span
+++ b/nri-http/test/golden-results/expected-http-span
@@ -21,7 +21,7 @@ TracingSpan
   , allocated = 0
   , children =
       [ TracingSpan
-          { name = "Outoing HTTP Request"
+          { name = "Outgoing HTTP Request"
           , started = MonotonicTime { inMicroseconds = 0 }
           , finished = MonotonicTime { inMicroseconds = 0 }
           , frame =

--- a/nri-observability/tests/Spec/Reporter/File.hs
+++ b/nri-observability/tests/Spec/Reporter/File.hs
@@ -102,7 +102,7 @@ tests =
                 |> Just
           },
       logTest
-        "logs information about an outoing http request"
+        "logs information about an outgoing http request"
         emptyTracingSpan
           { Platform.details =
               HttpRequest.emptyDetails


### PR DESCRIPTION
This is a small typo but we should be aware that this will change the traces recorded in Honeycomb.