### PR TITLE
Allow labeling honeycomb spans with the k8s node

### DIFF
--- a/nri-observability/tests/Spec/Reporter/Honeycomb.hs
+++ b/nri-observability/tests/Spec/Reporter/Honeycomb.hs
@@ -401,7 +401,8 @@ emptySettings =
       Honeycomb.fractionOfSuccessRequestsLogged = 0.0,
       Honeycomb.apdexTimeMs = 10,
       Honeycomb.modifyFractionOfSuccessRequestsLogged = always,
-      Honeycomb.modifyApdexTimeMs = always
+      Honeycomb.modifyApdexTimeMs = always,
+      Honeycomb.k8sNode = Nothing
     }
 
 toBatchEvents :: Platform.TracingSpan -> [Honeycomb.BatchEvent]


### PR DESCRIPTION
When a non-empty `HONEYCOMB_K8S_NODE` environment variable is specified,
honeycomb spans will include a `k8s_node` field set to the value of that
env variable.

I don't particularly like tying haskell-libraries to our techstack, but I'm not seeing great alternatives. At least this ways it's "optional" and nothing will happen when this isn't set.

Some alternatives:

- having some sort of `pattern "HONEYCOMB_EXTRA_FIELD_*"` env parser thing resulting in a `Dict Text Text`. 

  Really flexible. Perhaps way too flexible, and doesn't fit very well within the design for `nri-env-parser` we currently have
- adding a generic `extraFields :: Dict Text Text` field to the settings and defaulting it to `Dict.empty`. 

  Since settings are exposed, they can be modified later on. But that requires changes in every place we use it, while historically our `Settings` system has been "batteries included", not "don't forget to change this". It may also be "too" flexible in the "add whatever field you want" way; I feel like we somewhat want to constrain what information can end up in fields.

In the end, having this environment variable recognized while having no further functional impact impact when not set seemed like a good way to go.
