### PR TITLE
Add task green thread ability

### DIFF
--- a/nix/mk-shell.nix
+++ b/nix/mk-shell.nix
@@ -5,6 +5,12 @@ let
   workaround140774 = hpkg:
     with pkgs.haskell.lib;
     overrideCabal hpkg (drv: { enableSeparateBinOutput = false; });
+  # It is still necessary to run `hpack --force` into packages home dirs
+  haskell-language-server = pkgs.haskellPackages.haskell-language-server.override {
+    hls-ormolu-plugin = pkgs.haskellPackages.hls-ormolu-plugin.override {
+      ormolu = (workaround140774 pkgs.haskellPackages.ormolu);
+    };
+  };
 
 in pkgs.mkShell {
   buildInputs = [
@@ -59,17 +65,18 @@ in pkgs.mkShell {
         vector
         vty
       ]))
+    (workaround140774 pkgs.haskellPackages.ghcid)
+    (workaround140774 pkgs.haskellPackages.niv)
+    (workaround140774 pkgs.haskellPackages.ormolu)
     pkgs.apacheKafka # for nri-kafka
     pkgs.cabal-install
     pkgs.cachix
     pkgs.gnumake
-    (workaround140774 pkgs.haskellPackages.ghcid)
+    haskell-language-server
     pkgs.haskellPackages.hpack
-    (workaround140774 pkgs.haskellPackages.niv)
-    (workaround140774 pkgs.haskellPackages.ormolu)
     pkgs.pcre
-    pkgs.redis # for nri-redis
     pkgs.postgresql # for nri-postgres
+    pkgs.redis # for nri-redis
     pkgs.zlib
     pkgs.zookeeper # for nri-kafka
   ];

--- a/nri-prelude/src/Task.hs
+++ b/nri-prelude/src/Task.hs
@@ -3,7 +3,6 @@
 -- missing such a branch in a case statement looks like a problem and so is
 -- distracting.
 {-# OPTIONS_GHC -fno-warn-overlapping-patterns #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Tasks make it easy to describe asynchronous operations that may fail, like
 -- HTTP requests or writing to a database.


### PR DESCRIPTION
This PR has two small changes:
- Make haskell-language-server work by using well-known ormolu workaround
- Allow Tasks to be run in a green thread. The Task result is then send to the provided callback

Worth noting: the same LogHandler will be used while executing the task.