### PR TITLE
Allow for heterogenous expectation equality

### DIFF
--- a/nri-prelude/src/Expect.hs
+++ b/nri-prelude/src/Expect.hs
@@ -163,11 +163,14 @@ equal = Stack.withFrozenCallStack assert (==) "Expect.equal"
 -- > Expect.equalH 0 ""
 -- >
 -- > -- Fails because 0 is not the same type as ""
-equalH :: (Stack.HasCallStack, Show a, Eq a, Typeable a, Typeable b) => a -> b -> Expectation
-equalH x y =
+equalH :: (Stack.HasCallStack, Show a, Show b, Eq a, Typeable a, Typeable b) => a -> b -> Expectation
+equalH = Stack.withFrozenCallStack assert equalHPredicate "Expect.equalH"
+
+equalHPredicate :: (Eq a, Typeable a, Typeable b) => a -> b -> Bool
+equalHPredicate x y =
   case eqTypeRep (typeOf x) (typeOf y) of
-    Nothing -> Stack.withFrozenCallStack <| Expect.fail "Expect.equalH"
-    Just HRefl -> Stack.withFrozenCallStack <| assert (==) "Expect.equalH" x y
+    Nothing -> False
+    Just HRefl -> x == y
 
 -- | Passes if the arguments are not equal.
 --
@@ -563,7 +566,7 @@ newtype UnescapedShow = UnescapedShow Text deriving (Eq)
 instance Show UnescapedShow where
   show (UnescapedShow text) = Data.Text.unpack text
 
-assert :: (Stack.HasCallStack, Show a) => (a -> a -> Bool) -> Text -> a -> a -> Expectation
+assert :: (Stack.HasCallStack, Show a, Show b) => (a -> b -> Bool) -> Text -> a -> b -> Expectation
 assert pred funcName expected actual =
   if pred expected actual
     then Stack.withFrozenCallStack Internal.pass funcName ()

--- a/nri-prelude/src/Expect.hs
+++ b/nri-prelude/src/Expect.hs
@@ -162,12 +162,12 @@ equal = Stack.withFrozenCallStack assert (==) "Expect.equal"
 --
 -- > Expect.equalH 0 ""
 -- >
--- > -- Faild because 0 is not the same type as ""
+-- > -- Fails because 0 is not the same type as ""
 equalH :: (Stack.HasCallStack, Show a, Eq a, Typeable a, Typeable b) => a -> b -> Expectation
-equalH x y = Stack.withFrozenCallStack <|
+equalH x y =
   case eqTypeRep (typeOf x) (typeOf y) of
-      Nothing -> fail "Expect.equalH"
-      Just HRefl -> assert (==) "Expect.equalH" x y
+    Nothing -> Stack.withFrozenCallStack <| Expect.fail "Expect.equalH"
+    Just HRefl -> Stack.withFrozenCallStack <| assert (==) "Expect.equalH" x y
 
 -- | Passes if the arguments are not equal.
 --


### PR DESCRIPTION
Add the `equalH` function so that we can have expectation between values of different types.