### PR TITLE
Allow serialized test execution [QUE-350]

### DIFF
--- a/nri-postgresql/src/Postgres/Test.hs
+++ b/nri-postgresql/src/Postgres/Test.hs
@@ -29,13 +29,15 @@ test ::
   (Postgres.Connection -> Expect.Expectation) ->
   Test.Test
 test description body =
-  Stack.withFrozenCallStack Test.test description <| \_ ->
-    Expect.around
-      ( \task' -> do
-          conn <- getTestConnection
-          Postgres.inTestTransaction conn task'
-      )
-      body
+  Test.serialize "postgres"
+    <| Stack.withFrozenCallStack Test.test description
+    <| \_ ->
+      Expect.around
+        ( \task' -> do
+            conn <- getTestConnection
+            Postgres.inTestTransaction conn task'
+        )
+        body
 
 -- Obtain a Postgres connection for use in tests.
 getTestConnection :: Task e Postgres.Connection

--- a/nri-prelude/src/Test.hs
+++ b/nri-prelude/src/Test.hs
@@ -13,6 +13,9 @@ module Test
     Internal.fuzz2,
     Internal.fuzz3,
 
+    -- * Serialize test execution
+    Internal.serialize,
+
     -- * Running test
     run,
   )

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -43,12 +43,20 @@ data SingleTest a = SingleTest
   { describes :: [Text],
     name :: Text,
     label :: Label,
+    -- This is used for serializing execution of grouped tests (e.g. database tests)
+    group :: Group,
     loc :: Stack.SrcLoc,
     body :: a
   }
   deriving (Prelude.Functor)
 
 data Label = None | Skip | Only | Todo
+  deriving (Eq, Ord)
+
+data Group = Grouped (List GroupKey) | Ungrouped
+  deriving (Eq, Ord)
+
+newtype GroupKey = GroupKey {unGroupkey :: Text}
   deriving (Eq, Ord)
 
 data TestResult
@@ -143,6 +151,7 @@ todo name =
         { describes = [],
           name = name,
           loc = Stack.withFrozenCallStack getFrame name,
+          group = Ungrouped,
           label = Todo,
           body = Expectation (Task.succeed ())
         }
@@ -164,6 +173,7 @@ test name expectation =
         { describes = [],
           name = name,
           loc = Stack.withFrozenCallStack getFrame name,
+          group = Ungrouped,
           label = None,
           body = handleUnexpectedErrors (expectation ())
         }
@@ -185,6 +195,7 @@ fuzz fuzzer name expectation =
         { describes = [],
           name = name,
           loc = Stack.withFrozenCallStack getFrame name,
+          group = Ungrouped,
           label = None,
           body = fuzzBody fuzzer expectation
         }
@@ -198,6 +209,7 @@ fuzz2 (Fuzzer genA) (Fuzzer genB) name expectation =
         { describes = [],
           name = name,
           loc = Stack.withFrozenCallStack getFrame name,
+          group = Ungrouped,
           label = None,
           body =
             fuzzBody
@@ -214,6 +226,7 @@ fuzz3 (Fuzzer genA) (Fuzzer genB) (Fuzzer genC) name expectation =
         { describes = [],
           name = name,
           loc = Stack.withFrozenCallStack getFrame name,
+          group = Ungrouped,
           label = None,
           body =
             fuzzBody

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -49,16 +49,16 @@ data SingleTest a = SingleTest
     loc :: Stack.SrcLoc,
     body :: a
   }
-  deriving (Prelude.Functor)
+  deriving (Show, Prelude.Functor)
 
 data Label = None | Skip | Only | Todo
-  deriving (Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 data Group = Grouped (Set.Set GroupKey) | Ungrouped
-  deriving (Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 newtype GroupKey = GroupKey {unGroupkey :: Text}
-  deriving (Eq, Ord)
+  deriving (Show, Eq, Ord)
 
 data TestResult
   = Succeeded
@@ -77,10 +77,17 @@ data SuiteResult
   = AllPassed [SingleTest TracingSpan]
   | OnlysPassed [SingleTest TracingSpan] [SingleTest NotRan]
   | PassedWithSkipped [SingleTest TracingSpan] [SingleTest NotRan]
-  | TestsFailed [SingleTest TracingSpan] [SingleTest NotRan] [SingleTest (TracingSpan, Failure)]
+  | TestsFailed [SingleTest TracingSpan] [SingleTest NotRan] [SingleTest FailedSpan]
   | NoTestsInSuite
+  deriving (Show)
 
 data NotRan = NotRan
+  deriving (Show)
+
+data FailedSpan = FailedSpan TracingSpan Failure
+
+instance Show FailedSpan where
+  show (FailedSpan span failure) = Prelude.show failure ++ ": " ++ Prelude.show span
 
 -- | A test which has yet to be evaluated. When evaluated, it produces one
 -- or more 'Expect.Expectation's.
@@ -410,7 +417,7 @@ run request (Test all) = do
             ( \test' ->
                 case body test' of
                   (tracingSpan, Failed failure) ->
-                    Prelude.Left test' {body = (tracingSpan, failure)}
+                    Prelude.Left test' {body = FailedSpan tracingSpan failure}
                   (tracingSpan, Succeeded) ->
                     Prelude.Right test' {body = tracingSpan}
             )

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -447,7 +447,7 @@ subset subsets singleTest =
           Nothing -> True
           Just requestedLoc' ->
             let requestedLoc = Prelude.fromIntegral requestedLoc'
-             in if requestedLoc >= srcLocStartLine && requestedLoc <= srcLocEndLine
+             in if srcLocStartLine <= requestedLoc && requestedLoc <= srcLocEndLine
                   then True
                   else subset rest singleTest
         else subset rest singleTest

--- a/nri-prelude/src/Test/Reporter/Logfile.hs
+++ b/nri-prelude/src/Test/Reporter/Logfile.hs
@@ -62,11 +62,13 @@ spansAndNamespaces results =
     Internal.PassedWithSkipped tests _ -> List.map bodyAndDescribes tests
     Internal.TestsFailed passed _ failed ->
       List.map bodyAndDescribes passed
-        ++ List.map (Tuple.mapSecond Tuple.first << bodyAndDescribes) failed
+        ++ List.map (bodyAndDescribes >> failedSpan) failed
     Internal.NoTestsInSuite -> []
   where
     bodyAndDescribes :: Internal.SingleTest body -> ([Text], body)
     bodyAndDescribes test = (Internal.describes test, Internal.body test)
+    failedSpan :: ([Text], Internal.FailedSpan) -> ([Text], Platform.TracingSpan)
+    failedSpan (text, (Internal.FailedSpan span _)) = (text, span)
 
 groupIntoNamespaces :: [([Text], Platform.TracingSpan)] -> [Platform.TracingSpan]
 groupIntoNamespaces namespacedSpans =

--- a/nri-prelude/src/Test/Reporter/Stdout.hs
+++ b/nri-prelude/src/Test/Reporter/Stdout.hs
@@ -19,7 +19,6 @@ import qualified Text
 import Text.Colour (chunk)
 import qualified Text.Colour
 import qualified Text.Colour.Capabilities.FromEnv
-import qualified Tuple
 import qualified Prelude
 
 report :: System.IO.Handle -> Internal.SuiteResult -> Prelude.IO ()
@@ -93,7 +92,7 @@ renderReport results =
       let amountPassed = List.length passed
       let amountFailed = List.length failed
       let amountSkipped = List.length skipped
-      let failures = List.map (map Tuple.second) failed
+      let failures = List.map (map (\(Internal.FailedSpan _ failure) -> failure)) failed
       srcLocs <- Prelude.traverse Test.Reporter.Internal.readSrcLoc failures
       let failuresSrcs = List.map renderFailureInFile srcLocs
       Prelude.pure

--- a/nri-prelude/tests/TestSpec.hs
+++ b/nri-prelude/tests/TestSpec.hs
@@ -295,10 +295,10 @@ stdoutReporter =
                   [ mockTest "test 3" Internal.NotRan,
                     mockTest "test 4" Internal.NotRan
                   ]
-                  [ mockTest "test 5" (mockTracingSpan, Internal.FailedAssertion "assertion error" mockSrcLoc),
-                    mockTest "test 6" (mockTracingSpan, Internal.ThrewException mockException),
-                    mockTest "test 7" (mockTracingSpan, Internal.TookTooLong),
-                    mockTest "test 7" (mockTracingSpan, Internal.TestRunnerMessedUp "sorry")
+                  [ mockTest "test 5" (Internal.FailedSpan mockTracingSpan (Internal.FailedAssertion "assertion error" mockSrcLoc)),
+                    mockTest "test 6" (Internal.FailedSpan mockTracingSpan (Internal.ThrewException mockException)),
+                    mockTest "test 7" (Internal.FailedSpan mockTracingSpan Internal.TookTooLong),
+                    mockTest "test 7" (Internal.FailedSpan mockTracingSpan (Internal.TestRunnerMessedUp "sorry"))
                   ]
                   |> Test.Reporter.Stdout.report handle
             )
@@ -464,10 +464,10 @@ logfileReporter =
                   [ mockTest "test 3" Internal.NotRan,
                     mockTest "test 4" Internal.NotRan
                   ]
-                  [ mockTest "test 5" (mockTracingSpan, Internal.FailedAssertion "assertion error" mockSrcLoc),
-                    mockTest "test 6" (mockTracingSpan, Internal.ThrewException mockException),
-                    mockTest "test 7" (mockTracingSpan, Internal.TookTooLong),
-                    mockTest "test 7" (mockTracingSpan, Internal.TestRunnerMessedUp "sorry")
+                  [ mockTest "test 5" (Internal.FailedSpan mockTracingSpan (Internal.FailedAssertion "assertion error" mockSrcLoc)),
+                    mockTest "test 6" (Internal.FailedSpan mockTracingSpan (Internal.ThrewException mockException)),
+                    mockTest "test 7" (Internal.FailedSpan mockTracingSpan Internal.TookTooLong),
+                    mockTest "test 7" (Internal.FailedSpan mockTracingSpan (Internal.TestRunnerMessedUp "sorry"))
                   ]
                   |> Test.Reporter.Logfile.report (writeSpan handle)
             )

--- a/nri-prelude/tests/TestSpec.hs
+++ b/nri-prelude/tests/TestSpec.hs
@@ -622,22 +622,24 @@ deadlockPrevention =
         mvar1 <- Expect.fromIO MVar.newEmptyMVar
         mvar2 <- Expect.fromIO MVar.newEmptyMVar
 
-        deadlockSuite mvar1 mvar2
-          |> describe "two deadlocking tests"
-          |> Internal.run Internal.All
-          |> Task.timeout 1000 Internal.TookTooLong
-          |> Expect.fails
-          |> map (always ()),
+        _ <-
+          deadlockSuite mvar1 mvar2
+            |> describe "two deadlocking tests"
+            |> Internal.run Internal.All
+            |> Task.timeout 1000 Internal.TookTooLong
+            |> Expect.fails
+        Expect.pass,
       test "serial tests don't deadlock" <| \_ -> do
         mvar1 <- Expect.fromIO MVar.newEmptyMVar
         mvar2 <- Expect.fromIO MVar.newEmptyMVar
 
-        deadlockSuite mvar1 mvar2
-          |> describe "two deadlocking tests"
-          |> serialize "groupKey"
-          |> Internal.run Internal.All
-          |> Expect.succeeds
-          |> map (always ())
+        _ <-
+          deadlockSuite mvar1 mvar2
+            |> describe "two deadlocking tests"
+            |> serialize "groupKey"
+            |> Internal.run Internal.All
+            |> Expect.succeeds
+        Expect.pass
     ]
 
 deadlockSuite :: MVar.MVar () -> MVar.MVar () -> List Test

--- a/nri-prelude/tests/TestSpec.hs
+++ b/nri-prelude/tests/TestSpec.hs
@@ -624,7 +624,6 @@ deadlockPrevention =
 
         _ <-
           deadlockSuite mvar1 mvar2
-            |> describe "two deadlocking tests"
             |> Internal.run Internal.All
             |> Task.timeout 1000 Internal.TookTooLong
             |> Expect.fails
@@ -635,27 +634,28 @@ deadlockPrevention =
 
         _ <-
           deadlockSuite mvar1 mvar2
-            |> describe "two deadlocking tests"
             |> serialize "groupKey"
             |> Internal.run Internal.All
             |> Expect.succeeds
         Expect.pass
     ]
 
-deadlockSuite :: MVar.MVar () -> MVar.MVar () -> List Test
+deadlockSuite :: MVar.MVar () -> MVar.MVar () -> Test
 deadlockSuite mvar1 mvar2 =
-  [ test "test 1" <| \_ -> do
-      Expect.fromIO (MVar.putMVar mvar1 ())
-      Expect.fromIO <| threadDelay 100
-      Expect.fromIO (MVar.putMVar mvar2 ())
-      _ <- Expect.fromIO (MVar.takeMVar mvar2)
-      _ <- Expect.fromIO (MVar.takeMVar mvar1)
-      Expect.pass,
-    test "test 2" <| \_ -> do
-      Expect.fromIO (MVar.putMVar mvar2 ())
-      Expect.fromIO <| threadDelay 100
-      Expect.fromIO (MVar.putMVar mvar1 ())
-      _ <- Expect.fromIO (MVar.takeMVar mvar1)
-      _ <- Expect.fromIO (MVar.takeMVar mvar2)
-      Expect.pass
-  ]
+  describe
+    "two deadlocking tests"
+    [ test "test 1" <| \_ -> do
+        Expect.fromIO (MVar.putMVar mvar1 ())
+        Expect.fromIO <| threadDelay 100
+        Expect.fromIO (MVar.putMVar mvar2 ())
+        _ <- Expect.fromIO (MVar.takeMVar mvar2)
+        _ <- Expect.fromIO (MVar.takeMVar mvar1)
+        Expect.pass,
+      test "test 2" <| \_ -> do
+        Expect.fromIO (MVar.putMVar mvar2 ())
+        Expect.fromIO <| threadDelay 100
+        Expect.fromIO (MVar.putMVar mvar1 ())
+        _ <- Expect.fromIO (MVar.takeMVar mvar1)
+        _ <- Expect.fromIO (MVar.takeMVar mvar2)
+        Expect.pass
+    ]

--- a/nri-prelude/tests/TestSpec.hs
+++ b/nri-prelude/tests/TestSpec.hs
@@ -73,14 +73,18 @@ api =
                 "suite"
                 [ test "test 1" (\_ -> Expect.pass),
                   test "test 2" (\_ -> Expect.pass),
-                  test "test 3" (\_ -> Expect.pass)
+                  test
+                    "test 3"
+                    ( \_ ->
+                        Expect.pass
+                    )
                 ]
         result <-
           suite
             |> Internal.run
               ( Internal.Some
                   [ Internal.SubsetOfTests "tests/TestSpec.hs" (Just (srcLoc + 6)),
-                    Internal.SubsetOfTests "tests/TestSpec.hs" (Just (srcLoc + 8))
+                    Internal.SubsetOfTests "tests/TestSpec.hs" (Just (srcLoc + 11))
                   ]
               )
             |> Expect.succeeds

--- a/nri-prelude/tests/TestSpec.hs
+++ b/nri-prelude/tests/TestSpec.hs
@@ -503,6 +503,7 @@ mockTest name body =
       Internal.name = name,
       Internal.label = Internal.None,
       Internal.loc = mockSrcLoc,
+      Internal.group = Internal.Ungrouped,
       Internal.body = body
     }
 

--- a/nri-prelude/tests/golden-results/debug-todo-stacktrace
+++ b/nri-prelude/tests/golden-results/debug-todo-stacktrace
@@ -1,3 +1,3 @@
 foo
 CallStack (from HasCallStack):
-  todo, called at tests/TestSpec.hs:164:20 in main:TestSpec
+  todo, called at tests/TestSpec.hs:171:20 in main:TestSpec

--- a/nri-prelude/tests/golden-results/debug-todo-stacktrace
+++ b/nri-prelude/tests/golden-results/debug-todo-stacktrace
@@ -1,3 +1,3 @@
 foo
 CallStack (from HasCallStack):
-  todo, called at tests/TestSpec.hs:171:20 in main:TestSpec
+  todo, called at tests/TestSpec.hs:175:20 in main:TestSpec

--- a/nri-prelude/tests/golden-results/test-report-logfile-all-passed
+++ b/nri-prelude/tests/golden-results/test-report-logfile-all-passed
@@ -53,8 +53,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 420,
-        "endLine": 420,
+        "startLine": 424,
+        "endLine": 424,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-all-passed
+++ b/nri-prelude/tests/golden-results/test-report-logfile-all-passed
@@ -53,8 +53,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 413,
-        "endLine": 413,
+        "startLine": 420,
+        "endLine": 420,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-no-tests-in-suite
+++ b/nri-prelude/tests/golden-results/test-report-logfile-no-tests-in-suite
@@ -6,8 +6,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 459,
-        "endLine": 459,
+        "startLine": 463,
+        "endLine": 463,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-no-tests-in-suite
+++ b/nri-prelude/tests/golden-results/test-report-logfile-no-tests-in-suite
@@ -6,8 +6,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 452,
-        "endLine": 452,
+        "startLine": 459,
+        "endLine": 459,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-onlys-passed
+++ b/nri-prelude/tests/golden-results/test-report-logfile-onlys-passed
@@ -53,8 +53,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 428,
-        "endLine": 428,
+        "startLine": 435,
+        "endLine": 435,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-onlys-passed
+++ b/nri-prelude/tests/golden-results/test-report-logfile-onlys-passed
@@ -53,8 +53,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 435,
-        "endLine": 435,
+        "startLine": 439,
+        "endLine": 439,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-passed-with-skipped
+++ b/nri-prelude/tests/golden-results/test-report-logfile-passed-with-skipped
@@ -53,8 +53,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 443,
-        "endLine": 443,
+        "startLine": 450,
+        "endLine": 450,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-passed-with-skipped
+++ b/nri-prelude/tests/golden-results/test-report-logfile-passed-with-skipped
@@ -53,8 +53,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 450,
-        "endLine": 450,
+        "startLine": 454,
+        "endLine": 454,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-tests-failed
+++ b/nri-prelude/tests/golden-results/test-report-logfile-tests-failed
@@ -97,8 +97,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 479,
-        "endLine": 479,
+        "startLine": 483,
+        "endLine": 483,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-logfile-tests-failed
+++ b/nri-prelude/tests/golden-results/test-report-logfile-tests-failed
@@ -97,8 +97,8 @@
     "details": null,
     "finished": 0,
     "frame": {
-        "startLine": 472,
-        "endLine": 472,
+        "startLine": 479,
+        "endLine": 479,
         "name": "report",
         "endCol": 69,
         "module": "TestSpec",

--- a/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc
+++ b/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc
@@ -1,26 +1,26 @@
-↓ tests/TestSpec.hs:311
+↓ tests/TestSpec.hs:318
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:311
-  309:               describe
-  310:                 "suite loc"
-✗ 311:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  312:                   test "test equal" (\_ -> Expect.equal True False),
-  313:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+Expectation failed at tests/TestSpec.hs:318
+  316:               describe
+  317:                 "suite loc"
+✗ 318:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  319:                   test "test equal" (\_ -> Expect.equal True False),
+  320:                   test "test notEqual" (\_ -> Expect.notEqual True True),
 
 fail
 
-↓ tests/TestSpec.hs:312
+↓ tests/TestSpec.hs:319
 ↓ suite loc
 ✗ test equal
 
-Expectation failed at tests/TestSpec.hs:312
-  310:                 "suite loc"
-  311:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-✗ 312:                   test "test equal" (\_ -> Expect.equal True False),
-  313:                   test "test notEqual" (\_ -> Expect.notEqual True True),
-  314:                   test
+Expectation failed at tests/TestSpec.hs:319
+  317:                 "suite loc"
+  318:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+✗ 319:                   test "test equal" (\_ -> Expect.equal True False),
+  320:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+  321:                   test
 
 ▼▼▼▼
 False
@@ -30,16 +30,16 @@ False
 True
 ▲▲▲
 
-↓ tests/TestSpec.hs:313
+↓ tests/TestSpec.hs:320
 ↓ suite loc
 ✗ test notEqual
 
-Expectation failed at tests/TestSpec.hs:313
-  311:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  312:                   test "test equal" (\_ -> Expect.equal True False),
-✗ 313:                   test "test notEqual" (\_ -> Expect.notEqual True True),
-  314:                   test
-  315:                     "test all"
+Expectation failed at tests/TestSpec.hs:320
+  318:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  319:                   test "test equal" (\_ -> Expect.equal True False),
+✗ 320:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+  321:                   test
+  322:                     "test all"
 
 True
 ╷
@@ -47,16 +47,16 @@ True
 ╵
 True
 
-↓ tests/TestSpec.hs:314
+↓ tests/TestSpec.hs:321
 ↓ suite loc
 ✗ test all
 
-Expectation failed at tests/TestSpec.hs:319
-  317:                         True
-  318:                           |> Expect.all
-✗ 319:                             [ Expect.equal False
-  320:                             ]
-  321:                     ),
+Expectation failed at tests/TestSpec.hs:326
+  324:                         True
+  325:                           |> Expect.all
+✗ 326:                             [ Expect.equal False
+  327:                             ]
+  328:                     ),
 
 ▼▼▼
 True
@@ -66,16 +66,16 @@ True
 False
 ▲▲▲▲
 
-↓ tests/TestSpec.hs:322
+↓ tests/TestSpec.hs:329
 ↓ suite loc
 ✗ test lessThan
 
-Expectation failed at tests/TestSpec.hs:322
-  320:                             ]
-  321:                     ),
-✗ 322:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-  323:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  324:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+Expectation failed at tests/TestSpec.hs:329
+  327:                             ]
+  328:                     ),
+✗ 329:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+  330:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  331:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
 
 ▼
 2
@@ -85,16 +85,16 @@ Expectation failed at tests/TestSpec.hs:322
 1
 ▲
 
-↓ tests/TestSpec.hs:323
+↓ tests/TestSpec.hs:330
 ↓ suite loc
 ✗ test astMost
 
-Expectation failed at tests/TestSpec.hs:323
-  321:                     ),
-  322:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-✗ 323:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  324:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  325:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+Expectation failed at tests/TestSpec.hs:330
+  328:                     ),
+  329:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+✗ 330:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  331:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  332:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
 
 ▼
 2
@@ -104,16 +104,16 @@ Expectation failed at tests/TestSpec.hs:323
 1
 ▲
 
-↓ tests/TestSpec.hs:324
+↓ tests/TestSpec.hs:331
 ↓ suite loc
 ✗ test greatherThan
 
-Expectation failed at tests/TestSpec.hs:324
-  322:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-  323:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-✗ 324:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  325:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  326:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+Expectation failed at tests/TestSpec.hs:331
+  329:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+  330:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+✗ 331:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  332:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  333:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
 
 ▼
 1
@@ -123,16 +123,16 @@ Expectation failed at tests/TestSpec.hs:324
 2
 ▲
 
-↓ tests/TestSpec.hs:325
+↓ tests/TestSpec.hs:332
 ↓ suite loc
 ✗ test atLeast
 
-Expectation failed at tests/TestSpec.hs:325
-  323:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  324:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-✗ 325:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  326:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  327:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+Expectation failed at tests/TestSpec.hs:332
+  330:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  331:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+✗ 332:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  333:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  334:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
 
 ▼
 1
@@ -142,16 +142,16 @@ Expectation failed at tests/TestSpec.hs:325
 2
 ▲
 
-↓ tests/TestSpec.hs:326
+↓ tests/TestSpec.hs:333
 ↓ suite loc
 ✗ test within
 
-Expectation failed at tests/TestSpec.hs:326
-  324:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  325:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-✗ 326:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  327:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  328:                   test "test true" (\_ -> Expect.true False),
+Expectation failed at tests/TestSpec.hs:333
+  331:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  332:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+✗ 333:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  334:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  335:                   test "test true" (\_ -> Expect.true False),
 
 ▼
 2.0
@@ -161,16 +161,16 @@ Expectation failed at tests/TestSpec.hs:326
 1.0
 ▲
 
-↓ tests/TestSpec.hs:327
+↓ tests/TestSpec.hs:334
 ↓ suite loc
 ✗ test notWithin
 
-Expectation failed at tests/TestSpec.hs:327
-  325:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  326:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-✗ 327:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  328:                   test "test true" (\_ -> Expect.true False),
-  329:                   test "test false" (\_ -> Expect.false True),
+Expectation failed at tests/TestSpec.hs:334
+  332:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  333:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+✗ 334:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  335:                   test "test true" (\_ -> Expect.true False),
+  336:                   test "test false" (\_ -> Expect.false True),
 
 1.0
 ╷
@@ -178,94 +178,94 @@ Expectation failed at tests/TestSpec.hs:327
 ╵
 1.0
 
-↓ tests/TestSpec.hs:328
+↓ tests/TestSpec.hs:335
 ↓ suite loc
 ✗ test true
 
-Expectation failed at tests/TestSpec.hs:328
-  326:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  327:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-✗ 328:                   test "test true" (\_ -> Expect.true False),
-  329:                   test "test false" (\_ -> Expect.false True),
-  330:                   test "test ok" (\_ -> Expect.ok (Err ())),
+Expectation failed at tests/TestSpec.hs:335
+  333:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  334:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+✗ 335:                   test "test true" (\_ -> Expect.true False),
+  336:                   test "test false" (\_ -> Expect.false True),
+  337:                   test "test ok" (\_ -> Expect.ok (Err ())),
 
 I expected a True but got False
 
-↓ tests/TestSpec.hs:329
+↓ tests/TestSpec.hs:336
 ↓ suite loc
 ✗ test false
 
-Expectation failed at tests/TestSpec.hs:329
-  327:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  328:                   test "test true" (\_ -> Expect.true False),
-✗ 329:                   test "test false" (\_ -> Expect.false True),
-  330:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  331:                   test "test err" (\_ -> Expect.err (Ok ())),
+Expectation failed at tests/TestSpec.hs:336
+  334:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  335:                   test "test true" (\_ -> Expect.true False),
+✗ 336:                   test "test false" (\_ -> Expect.false True),
+  337:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  338:                   test "test err" (\_ -> Expect.err (Ok ())),
 
 I expected a False but got True
 
-↓ tests/TestSpec.hs:330
+↓ tests/TestSpec.hs:337
 ↓ suite loc
 ✗ test ok
 
-Expectation failed at tests/TestSpec.hs:330
-  328:                   test "test true" (\_ -> Expect.true False),
-  329:                   test "test false" (\_ -> Expect.false True),
-✗ 330:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  331:                   test "test err" (\_ -> Expect.err (Ok ())),
-  332:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+Expectation failed at tests/TestSpec.hs:337
+  335:                   test "test true" (\_ -> Expect.true False),
+  336:                   test "test false" (\_ -> Expect.false True),
+✗ 337:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  338:                   test "test err" (\_ -> Expect.err (Ok ())),
+  339:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
 
 I expected a Ok but got Err (())
 
-↓ tests/TestSpec.hs:331
+↓ tests/TestSpec.hs:338
 ↓ suite loc
 ✗ test err
 
-Expectation failed at tests/TestSpec.hs:331
-  329:                   test "test false" (\_ -> Expect.false True),
-  330:                   test "test ok" (\_ -> Expect.ok (Err ())),
-✗ 331:                   test "test err" (\_ -> Expect.err (Ok ())),
-  332:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  333:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+Expectation failed at tests/TestSpec.hs:338
+  336:                   test "test false" (\_ -> Expect.false True),
+  337:                   test "test ok" (\_ -> Expect.ok (Err ())),
+✗ 338:                   test "test err" (\_ -> Expect.err (Ok ())),
+  339:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  340:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
 
 I expected a Err but got Ok (())
 
-↓ tests/TestSpec.hs:332
+↓ tests/TestSpec.hs:339
 ↓ suite loc
 ✗ test succeeds
 
-Expectation failed at tests/TestSpec.hs:332
-  330:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  331:                   test "test err" (\_ -> Expect.err (Ok ())),
-✗ 332:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  333:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  334:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+Expectation failed at tests/TestSpec.hs:339
+  337:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  338:                   test "test err" (\_ -> Expect.err (Ok ())),
+✗ 339:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  340:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+  341:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
 
 "oops"
 
-↓ tests/TestSpec.hs:333
+↓ tests/TestSpec.hs:340
 ↓ suite loc
 ✗ test fails
 
-Expectation failed at tests/TestSpec.hs:333
-  331:                   test "test err" (\_ -> Expect.err (Ok ())),
-  332:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-✗ 333:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  334:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  335:                 ]
+Expectation failed at tests/TestSpec.hs:340
+  338:                   test "test err" (\_ -> Expect.err (Ok ())),
+  339:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+✗ 340:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+  341:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+  342:                 ]
 
 "Expected failure but succeeded with \"oops\""
 
-↓ tests/TestSpec.hs:334
+↓ tests/TestSpec.hs:341
 ↓ suite loc
 ✗ test andCheck
 
-Expectation failed at tests/TestSpec.hs:334
-  332:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  333:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-✗ 334:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  335:                 ]
-  336:         contents <-
+Expectation failed at tests/TestSpec.hs:341
+  339:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  340:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+✗ 341:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+  342:                 ]
+  343:         contents <-
 
 ▼
 1

--- a/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc
+++ b/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc
@@ -1,26 +1,26 @@
-↓ tests/TestSpec.hs:318
+↓ tests/TestSpec.hs:322
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:318
-  316:               describe
-  317:                 "suite loc"
-✗ 318:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  319:                   test "test equal" (\_ -> Expect.equal True False),
-  320:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+Expectation failed at tests/TestSpec.hs:322
+  320:               describe
+  321:                 "suite loc"
+✗ 322:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  323:                   test "test equal" (\_ -> Expect.equal True False),
+  324:                   test "test notEqual" (\_ -> Expect.notEqual True True),
 
 fail
 
-↓ tests/TestSpec.hs:319
+↓ tests/TestSpec.hs:323
 ↓ suite loc
 ✗ test equal
 
-Expectation failed at tests/TestSpec.hs:319
-  317:                 "suite loc"
-  318:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-✗ 319:                   test "test equal" (\_ -> Expect.equal True False),
-  320:                   test "test notEqual" (\_ -> Expect.notEqual True True),
-  321:                   test
+Expectation failed at tests/TestSpec.hs:323
+  321:                 "suite loc"
+  322:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+✗ 323:                   test "test equal" (\_ -> Expect.equal True False),
+  324:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+  325:                   test
 
 ▼▼▼▼
 False
@@ -30,16 +30,16 @@ False
 True
 ▲▲▲
 
-↓ tests/TestSpec.hs:320
+↓ tests/TestSpec.hs:324
 ↓ suite loc
 ✗ test notEqual
 
-Expectation failed at tests/TestSpec.hs:320
-  318:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  319:                   test "test equal" (\_ -> Expect.equal True False),
-✗ 320:                   test "test notEqual" (\_ -> Expect.notEqual True True),
-  321:                   test
-  322:                     "test all"
+Expectation failed at tests/TestSpec.hs:324
+  322:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  323:                   test "test equal" (\_ -> Expect.equal True False),
+✗ 324:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+  325:                   test
+  326:                     "test all"
 
 True
 ╷
@@ -47,16 +47,16 @@ True
 ╵
 True
 
-↓ tests/TestSpec.hs:321
+↓ tests/TestSpec.hs:325
 ↓ suite loc
 ✗ test all
 
-Expectation failed at tests/TestSpec.hs:326
-  324:                         True
-  325:                           |> Expect.all
-✗ 326:                             [ Expect.equal False
-  327:                             ]
-  328:                     ),
+Expectation failed at tests/TestSpec.hs:330
+  328:                         True
+  329:                           |> Expect.all
+✗ 330:                             [ Expect.equal False
+  331:                             ]
+  332:                     ),
 
 ▼▼▼
 True
@@ -66,16 +66,16 @@ True
 False
 ▲▲▲▲
 
-↓ tests/TestSpec.hs:329
+↓ tests/TestSpec.hs:333
 ↓ suite loc
 ✗ test lessThan
 
-Expectation failed at tests/TestSpec.hs:329
-  327:                             ]
-  328:                     ),
-✗ 329:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-  330:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  331:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+Expectation failed at tests/TestSpec.hs:333
+  331:                             ]
+  332:                     ),
+✗ 333:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+  334:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  335:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
 
 ▼
 2
@@ -85,16 +85,16 @@ Expectation failed at tests/TestSpec.hs:329
 1
 ▲
 
-↓ tests/TestSpec.hs:330
+↓ tests/TestSpec.hs:334
 ↓ suite loc
 ✗ test astMost
 
-Expectation failed at tests/TestSpec.hs:330
-  328:                     ),
-  329:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-✗ 330:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  331:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  332:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+Expectation failed at tests/TestSpec.hs:334
+  332:                     ),
+  333:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+✗ 334:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  335:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  336:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
 
 ▼
 2
@@ -104,16 +104,16 @@ Expectation failed at tests/TestSpec.hs:330
 1
 ▲
 
-↓ tests/TestSpec.hs:331
+↓ tests/TestSpec.hs:335
 ↓ suite loc
 ✗ test greatherThan
 
-Expectation failed at tests/TestSpec.hs:331
-  329:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-  330:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-✗ 331:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  332:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  333:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+Expectation failed at tests/TestSpec.hs:335
+  333:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+  334:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+✗ 335:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  336:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  337:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
 
 ▼
 1
@@ -123,16 +123,16 @@ Expectation failed at tests/TestSpec.hs:331
 2
 ▲
 
-↓ tests/TestSpec.hs:332
+↓ tests/TestSpec.hs:336
 ↓ suite loc
 ✗ test atLeast
 
-Expectation failed at tests/TestSpec.hs:332
-  330:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  331:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-✗ 332:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  333:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  334:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+Expectation failed at tests/TestSpec.hs:336
+  334:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  335:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+✗ 336:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  337:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  338:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
 
 ▼
 1
@@ -142,16 +142,16 @@ Expectation failed at tests/TestSpec.hs:332
 2
 ▲
 
-↓ tests/TestSpec.hs:333
+↓ tests/TestSpec.hs:337
 ↓ suite loc
 ✗ test within
 
-Expectation failed at tests/TestSpec.hs:333
-  331:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  332:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-✗ 333:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  334:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  335:                   test "test true" (\_ -> Expect.true False),
+Expectation failed at tests/TestSpec.hs:337
+  335:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  336:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+✗ 337:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  338:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  339:                   test "test true" (\_ -> Expect.true False),
 
 ▼
 2.0
@@ -161,16 +161,16 @@ Expectation failed at tests/TestSpec.hs:333
 1.0
 ▲
 
-↓ tests/TestSpec.hs:334
+↓ tests/TestSpec.hs:338
 ↓ suite loc
 ✗ test notWithin
 
-Expectation failed at tests/TestSpec.hs:334
-  332:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  333:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-✗ 334:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  335:                   test "test true" (\_ -> Expect.true False),
-  336:                   test "test false" (\_ -> Expect.false True),
+Expectation failed at tests/TestSpec.hs:338
+  336:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  337:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+✗ 338:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  339:                   test "test true" (\_ -> Expect.true False),
+  340:                   test "test false" (\_ -> Expect.false True),
 
 1.0
 ╷
@@ -178,94 +178,94 @@ Expectation failed at tests/TestSpec.hs:334
 ╵
 1.0
 
-↓ tests/TestSpec.hs:335
+↓ tests/TestSpec.hs:339
 ↓ suite loc
 ✗ test true
 
-Expectation failed at tests/TestSpec.hs:335
-  333:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  334:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-✗ 335:                   test "test true" (\_ -> Expect.true False),
-  336:                   test "test false" (\_ -> Expect.false True),
-  337:                   test "test ok" (\_ -> Expect.ok (Err ())),
+Expectation failed at tests/TestSpec.hs:339
+  337:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  338:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+✗ 339:                   test "test true" (\_ -> Expect.true False),
+  340:                   test "test false" (\_ -> Expect.false True),
+  341:                   test "test ok" (\_ -> Expect.ok (Err ())),
 
 I expected a True but got False
 
-↓ tests/TestSpec.hs:336
+↓ tests/TestSpec.hs:340
 ↓ suite loc
 ✗ test false
 
-Expectation failed at tests/TestSpec.hs:336
-  334:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  335:                   test "test true" (\_ -> Expect.true False),
-✗ 336:                   test "test false" (\_ -> Expect.false True),
-  337:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  338:                   test "test err" (\_ -> Expect.err (Ok ())),
+Expectation failed at tests/TestSpec.hs:340
+  338:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  339:                   test "test true" (\_ -> Expect.true False),
+✗ 340:                   test "test false" (\_ -> Expect.false True),
+  341:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  342:                   test "test err" (\_ -> Expect.err (Ok ())),
 
 I expected a False but got True
 
-↓ tests/TestSpec.hs:337
+↓ tests/TestSpec.hs:341
 ↓ suite loc
 ✗ test ok
 
-Expectation failed at tests/TestSpec.hs:337
-  335:                   test "test true" (\_ -> Expect.true False),
-  336:                   test "test false" (\_ -> Expect.false True),
-✗ 337:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  338:                   test "test err" (\_ -> Expect.err (Ok ())),
-  339:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+Expectation failed at tests/TestSpec.hs:341
+  339:                   test "test true" (\_ -> Expect.true False),
+  340:                   test "test false" (\_ -> Expect.false True),
+✗ 341:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  342:                   test "test err" (\_ -> Expect.err (Ok ())),
+  343:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
 
 I expected a Ok but got Err (())
 
-↓ tests/TestSpec.hs:338
+↓ tests/TestSpec.hs:342
 ↓ suite loc
 ✗ test err
 
-Expectation failed at tests/TestSpec.hs:338
-  336:                   test "test false" (\_ -> Expect.false True),
-  337:                   test "test ok" (\_ -> Expect.ok (Err ())),
-✗ 338:                   test "test err" (\_ -> Expect.err (Ok ())),
-  339:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  340:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+Expectation failed at tests/TestSpec.hs:342
+  340:                   test "test false" (\_ -> Expect.false True),
+  341:                   test "test ok" (\_ -> Expect.ok (Err ())),
+✗ 342:                   test "test err" (\_ -> Expect.err (Ok ())),
+  343:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  344:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
 
 I expected a Err but got Ok (())
 
-↓ tests/TestSpec.hs:339
+↓ tests/TestSpec.hs:343
 ↓ suite loc
 ✗ test succeeds
 
-Expectation failed at tests/TestSpec.hs:339
-  337:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  338:                   test "test err" (\_ -> Expect.err (Ok ())),
-✗ 339:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  340:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  341:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+Expectation failed at tests/TestSpec.hs:343
+  341:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  342:                   test "test err" (\_ -> Expect.err (Ok ())),
+✗ 343:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  344:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+  345:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
 
 "oops"
 
-↓ tests/TestSpec.hs:340
+↓ tests/TestSpec.hs:344
 ↓ suite loc
 ✗ test fails
 
-Expectation failed at tests/TestSpec.hs:340
-  338:                   test "test err" (\_ -> Expect.err (Ok ())),
-  339:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-✗ 340:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  341:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  342:                 ]
+Expectation failed at tests/TestSpec.hs:344
+  342:                   test "test err" (\_ -> Expect.err (Ok ())),
+  343:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+✗ 344:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+  345:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+  346:                 ]
 
 "Expected failure but succeeded with \"oops\""
 
-↓ tests/TestSpec.hs:341
+↓ tests/TestSpec.hs:345
 ↓ suite loc
 ✗ test andCheck
 
-Expectation failed at tests/TestSpec.hs:341
-  339:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  340:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-✗ 341:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  342:                 ]
-  343:         contents <-
+Expectation failed at tests/TestSpec.hs:345
+  343:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  344:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+✗ 345:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+  346:                 ]
+  347:         contents <-
 
 ▼
 1

--- a/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc-one-file
+++ b/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc-one-file
@@ -1,13 +1,13 @@
-↓ tests/TestSpec.hs:389
+↓ tests/TestSpec.hs:393
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:389
-  387:               describe
-  388:                 "suite loc"
-✗ 389:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  390:                   test "test equal" (\_ -> Expect.equal True True),
-  391:                   test "test notEqual" (\_ -> Expect.notEqual True False)
+Expectation failed at tests/TestSpec.hs:393
+  391:               describe
+  392:                 "suite loc"
+✗ 393:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  394:                   test "test equal" (\_ -> Expect.equal True True),
+  395:                   test "test notEqual" (\_ -> Expect.notEqual True False)
 
 fail
 

--- a/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc-one-file
+++ b/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc-one-file
@@ -1,13 +1,13 @@
-↓ tests/TestSpec.hs:382
+↓ tests/TestSpec.hs:389
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:382
-  380:               describe
-  381:                 "suite loc"
-✗ 382:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  383:                   test "test equal" (\_ -> Expect.equal True True),
-  384:                   test "test notEqual" (\_ -> Expect.notEqual True False)
+Expectation failed at tests/TestSpec.hs:389
+  387:               describe
+  388:                 "suite loc"
+✗ 389:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  390:                   test "test equal" (\_ -> Expect.equal True True),
+  391:                   test "test notEqual" (\_ -> Expect.notEqual True False)
 
 fail
 

--- a/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc-subset
+++ b/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc-subset
@@ -1,13 +1,13 @@
-↓ tests/TestSpec.hs:362
+↓ tests/TestSpec.hs:366
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:362
-  360:               describe
-  361:                 "suite loc"
-✗ 362:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  363:                   test "test equal" (\_ -> Expect.equal True True),
-  364:                   test "test notEqual" (\_ -> Expect.notEqual True False)
+Expectation failed at tests/TestSpec.hs:366
+  364:               describe
+  365:                 "suite loc"
+✗ 366:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  367:                   test "test equal" (\_ -> Expect.equal True True),
+  368:                   test "test notEqual" (\_ -> Expect.notEqual True False)
 
 fail
 

--- a/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc-subset
+++ b/nri-prelude/tests/golden-results/test-report-stdout-tests-failed-loc-subset
@@ -1,13 +1,13 @@
-↓ tests/TestSpec.hs:355
+↓ tests/TestSpec.hs:362
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:355
-  353:               describe
-  354:                 "suite loc"
-✗ 355:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  356:                   test "test equal" (\_ -> Expect.equal True True),
-  357:                   test "test notEqual" (\_ -> Expect.notEqual True False)
+Expectation failed at tests/TestSpec.hs:362
+  360:               describe
+  361:                 "suite loc"
+✗ 362:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  363:                   test "test equal" (\_ -> Expect.equal True True),
+  364:                   test "test notEqual" (\_ -> Expect.notEqual True False)
 
 fail
 


### PR DESCRIPTION
This PR allows us to specify groupings for test, which are then used by the test runner to serialize their execution.

The ideal future is to have these groupings:

```
[] -- no group
[mysql] -- mysql group
[postgres] --postgres group
[mysql, postgres] --group that uses both mysql and postgres
```

And have them execute like this:

```
parallel
  parallel
    []
  series
    [mysql]
  series
    [postgres]

series
  [mysql, postgres]
```

So we get maximum safety and maximum parallelism.

But right now, we're going for maximum safety:

```
parallel
  parallel
    []
  series
    [[mysql],[postgres],[mysql,postgres]]
```