### PR TITLE
Ensure a frozen callstack for generated tests [QUE-402]

### DIFF
--- a/nri-test-encoding/src/Test/Encoding.hs
+++ b/nri-test-encoding/src/Test/Encoding.hs
@@ -3,6 +3,7 @@ module Test.Encoding (examplesToTest) where
 
 import qualified Examples
 import qualified Expect
+import qualified GHC.Stack as Stack
 import NriPrelude
 import System.FilePath ((</>))
 import qualified System.FilePath as FilePath
@@ -10,7 +11,7 @@ import Test (Test, test)
 import qualified Text
 
 -- | Creates tests for some examples
-examplesToTest :: Text -> Text -> Examples.Examples -> Test
+examplesToTest :: Stack.HasCallStack => Text -> Text -> Examples.Examples -> Test
 examplesToTest name fileName examples =
   test name <| \() ->
     Expect.equalToContentsOf

--- a/nri-test-encoding/src/Test/Encoding/Redis.hs
+++ b/nri-test-encoding/src/Test/Encoding/Redis.hs
@@ -4,6 +4,7 @@ module Test.Encoding.Redis (test) where
 import Data.Proxy (Proxy (Proxy))
 import qualified Data.Typeable as Typeable
 import qualified Examples
+import qualified GHC.Stack as Stack
 import NriPrelude
 import Test (Test)
 import qualified Test.Encoding
@@ -16,8 +17,17 @@ import qualified Text
 -- 2. encoded the examples into JSON
 -- 3. check the encoded JSON against the generated file
 --   NOTE: it will generate the file if it doesn't exist yet
-test :: forall m key a. (Typeable.Typeable a, Examples.HasExamples a) => m key a -> Test
-test _ =
+test :: forall m key a. (Typeable.Typeable a, Examples.HasExamples a, Stack.HasCallStack) => m key a -> Test
+test proxy =
+  -- We need to freeze the call stack before proceeding.
+  -- If we don't, the callstack for these generated tests would point to haskell-libraries code
+  -- and not client code.
+  -- This didn't matter that much until we had the ability to specify `--files tests/BlaSpec.hs`
+  -- If we don't fix this, we can't ever `--files tests/SomeApiSpec.hs`
+  Stack.withFrozenCallStack frozenTest proxy
+
+frozenTest :: forall m key a. (Typeable.Typeable a, Examples.HasExamples a, Stack.HasCallStack) => m key a -> Test
+frozenTest _ =
   let proxy = Proxy :: Proxy a
       tyCon =
         Typeable.typeRep proxy

--- a/nri-test-encoding/src/Test/Encoding/Routes.hs
+++ b/nri-test-encoding/src/Test/Encoding/Routes.hs
@@ -19,6 +19,7 @@ import qualified Data.Typeable as Typeable
 import qualified Debug
 import qualified Examples
 import qualified Expect
+import qualified GHC.Stack as Stack
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import qualified List
 import NriPrelude
@@ -47,8 +48,17 @@ import qualified Text
 --   describe
 --     "Spec.ApiEncoding"
 --     (TestEncoding.tests (Proxy :: Proxy Routes.Routes))
-tests :: forall routes. IsApi (ToServantApi routes) => Proxy routes -> List Test
-tests _ =
+tests :: forall routes. (IsApi (ToServantApi routes), Stack.HasCallStack) => Proxy routes -> List Test
+tests proxy =
+  -- We need to freeze the call stack before proceeding.
+  -- If we don't, the callstack for these generated tests would point to haskell-libraries code
+  -- and not client code.
+  -- This didn't matter that much until we had the ability to specify `--files tests/BlaSpec.hs`
+  -- If we don't fix this, we can't ever `--files tests/SomeApiSpec.hs`
+  Stack.withFrozenCallStack frozenTests proxy
+
+frozenTests :: forall routes. (IsApi (ToServantApi routes), Stack.HasCallStack) => Proxy routes -> List Test
+frozenTests _ =
   let routes = crawl (Proxy :: Proxy (ToServantApi routes))
    in [ test "route types haven't changed" <| \() ->
           routes
@@ -236,17 +246,18 @@ instance
   ) =>
   IsApi (QueryParam' x key value :> a)
   where
-  crawl _ = crawl (Proxy :: Proxy a)
-    |> List.map
-      ( \route ->
-          route
+  crawl _ =
+    crawl (Proxy :: Proxy a)
+      |> List.map
+        ( \route ->
+            route
               { queryParams =
                   ( Text.fromList (symbolVal (Proxy :: Proxy key)),
                     SomeType (Proxy :: Proxy value)
                   ) :
                   queryParams route
               }
-      )
+        )
 
 instance (Typeable.Typeable body, Examples.HasExamples body, IsApi a) => IsApi (ReqBody' x encodings body :> a) where
   crawl _ =


### PR DESCRIPTION
Before this commit, we effectively had this:

```
a :: Stack.HasCallStack => IO ()
a = do
  Stack.withFrozenCallStack b

b :: IO ()
b = do
  c

c :: Stack.HasCallStack => IO ()
c = do
  Stack.callStack & Stack.getCallStack & print
```

And the effect of this, is in `c`, we get a callstack with a single
frame: `b`'s call to `c`.

We need to have `HasCallStack` all the way through for
`Stack.withFrozenCallStack` to work.