### PR TITLE
Fxn background type signature

### DIFF
--- a/nri-prelude/src/Expect.hs
+++ b/nri-prelude/src/Expect.hs
@@ -62,7 +62,6 @@ module Expect
 where
 
 import qualified Data.Text
-import Type.Reflection (Typeable, eqTypeRep, typeOf, (:~~:) (HRefl))
 import qualified Data.Text.IO
 import qualified Debug
 import qualified GHC.Stack as Stack
@@ -77,6 +76,7 @@ import qualified Task
 import Test.Internal (Expectation)
 import qualified Test.Internal as Internal
 import qualified Text.Show.Pretty
+import Type.Reflection (Typeable, eqTypeRep, typeOf, (:~~:) (HRefl))
 import qualified Prelude
 
 -- | Always passes.

--- a/nri-prelude/src/Task.hs
+++ b/nri-prelude/src/Task.hs
@@ -213,16 +213,12 @@ concurrently taskA taskB =
         Prelude.pure <| Shortcut.map2 (,) resultA resultB
     )
 
--- | Given a task and a callback, execute the task in a greenthread
--- and sends its result to callback.
-background :: Task x a -> (Result x a -> Task y b) -> Task z ()
-background task callback =
+-- | Given a task, execute the task in a greenthread.
+background :: Task Never a -> Task x ()
+background task =
   Internal.Task
     ( \handler -> do
-        let runBackgroundTask greenTask = do
-              result <- Internal._run greenTask handler
-              Internal._run (callback result) handler
-        _ <- Async.async (runBackgroundTask task)
+        _ <- Async.async (Internal._run task handler)
         Prelude.pure <| Ok ()
     )
 

--- a/nri-prelude/src/Task.hs
+++ b/nri-prelude/src/Task.hs
@@ -215,13 +215,11 @@ concurrently taskA taskB =
 
 -- | Given a task and a callback, execute the task in a greenthread
 -- and sends its result to callback.
--- Always returns @OK ()@
-background :: forall x a . Task x a -> (Result x a -> Task x a) -> Task x ()
+background :: Task x a -> (Result x a -> Task y b) -> Task z ()
 background task callback =
   Internal.Task
     ( \handler -> do
-        let runBackgroundTask :: Task x a -> IO (Result x a)
-            runBackgroundTask greenTask = do
+        let runBackgroundTask greenTask = do
               result <- Internal._run greenTask handler
               Internal._run (callback result) handler
         _ <- Async.async (runBackgroundTask task)

--- a/nri-prelude/tests/TaskSpec.hs
+++ b/nri-prelude/tests/TaskSpec.hs
@@ -3,35 +3,38 @@ module TaskSpec (tests) where
 import qualified Expect
 import qualified List
 import NriPrelude
-import Prelude ((*>))
 import qualified Process
+import qualified Task
 import Test (Test, describe, test)
 import Test.Internal (Failure)
-import qualified Task
 import qualified Tuple
+import Prelude ((*>))
 
 tests :: Test
 tests =
-  describe "Task"
-    [ describe "parallel"
-      [ test "returns the right values" <| \() -> do
-        let results = [1, 2, 3]
-        let tasks = List.map afterDelay results
+  describe
+    "Task"
+    [ describe
+        "parallel"
+        [ test "returns the right values" <| \() -> do
+            let results = [1, 2, 3]
+            let tasks = List.map afterDelay results
 
-        parallelResults <- Expect.succeeds <| Task.parallel tasks
+            parallelResults <- Expect.succeeds <| Task.parallel tasks
 
-        Expect.equal results parallelResults
-      ]
-    , describe "concurrently"
-      [ test "returns the right values" <| \() -> do
-        let results = (1, ("two", 3.0 :: Float))
-        let (taskA, (taskB, taskC)) = Tuple.mapBoth afterDelay (Tuple.mapBoth afterDelay afterDelay) results
+            Expect.equal results parallelResults
+        ],
+      describe
+        "concurrently"
+        [ test "returns the right values" <| \() -> do
+            let results = (1, ("two", 3.0 :: Float))
+            let (taskA, (taskB, taskC)) = Tuple.mapBoth afterDelay (Tuple.mapBoth afterDelay afterDelay) results
 
-        concurrentResults <-
-          Expect.succeeds <| Task.concurrently taskA <| Task.concurrently taskB taskC
+            concurrentResults <-
+              Expect.succeeds <| Task.concurrently taskA <| Task.concurrently taskB taskC
 
-        Expect.equal results concurrentResults
-      ]
+            Expect.equal results concurrentResults
+        ]
     ]
 
 afterDelay :: a -> Task Failure a


### PR DESCRIPTION
The type signature of `background` is unnecessarily restricted, which in practice makes it harder to use than required.

```hs
background :: forall x a . Task x a -> (Result x a -> Task x a) -> Task x ()
```

As it stands, both of the tasks that execute in the background (I'm not sure why there are two of them?) must result in the same failure and success types, and the resulting task also has a failure type corresponding to that failure type. In reality, the resulting task that `background` returns cannot actually fail with some value of type `x`. It runs asynchronously, in the background.

The type of the "callback" is also restricted somewhat needlessly: there's no reason for it to preserve `x` or `a`.

This PR clarifies that all of those tyvars are independent:

```hs
background :: Task x a -> (Result x a -> Task y b) -> Task z ()
```

---------

On a more general note, I sort of feel like changing the signature of this whole thing to:
- only have a single parameter: the task to background
- require the background task to never fail

```hs
background :: Task Never a -> Task x ()
```

This makes it clearer that the positive result is discarded, and a negative result is simply not allowed; meaning the end-user must handle failure. With a simple combinator like `withResult` (see below), people who prefer to split the "action" from the "handling of the result", as the current API provides, can transition from `background myTask callback` to `background (withResult myTask callback)`, so no expressivity is lost.

I feel that having a "callback" in the API implies that it's supposed to be used to get results from the asynchronous call back into the "foreground" context. No such thing happens, or is possible. Both the task and the callback are executed asynchronously, together, exactly the way they are when `withResult` is used.

```hs
asResult :: Task x a -> Task z (Result x a)
asResult = Task.map Ok >> Task.onError (Err >> Task.fail)

withResult :: Task x a -> (Result x a -> Task x a) -> Task x a
withResult task callback = asResult task |> Task.andThen callback
```