### PR TITLE
[HACKY-102] Support Postgres Enums

### DIFF
--- a/nri-postgresql/nri-postgresql.cabal
+++ b/nri-postgresql/nri-postgresql.cabal
@@ -30,6 +30,7 @@ source-repository head
 library
   exposed-modules:
       Postgres
+      Postgres.Enum
       Postgres.Test
   other-modules:
       Postgres.Connection
@@ -80,6 +81,7 @@ test-suite tests
   other-modules:
       Postgres
       Postgres.Connection
+      Postgres.Enum
       Postgres.Error
       Postgres.Query
       Postgres.QueryParser

--- a/nri-postgresql/nri-postgresql.cabal
+++ b/nri-postgresql/nri-postgresql.cabal
@@ -130,5 +130,6 @@ test-suite tests
     , safe-exceptions >=0.1.7.0 && <1.3
     , template-haskell >=2.15.0.0 && <2.19
     , text >=1.2.3.1 && <2.1
+    , th-test-utils
     , time >=1.8.0.2 && <2
   default-language: Haskell2010

--- a/nri-postgresql/nri-postgresql.cabal
+++ b/nri-postgresql/nri-postgresql.cabal
@@ -38,6 +38,7 @@ library
       Postgres.Query
       Postgres.QueryParser
       Postgres.Settings
+      Postgres.TH
       Postgres.Time
       Paths_nri_postgresql
   hs-source-dirs:
@@ -87,7 +88,9 @@ test-suite tests
       Postgres.QueryParser
       Postgres.Settings
       Postgres.Test
+      Postgres.TH
       Postgres.Time
+      Enum
       ObservabilitySpec
       PostgresSettingsSpec
       QueryParserSpec

--- a/nri-postgresql/package.yaml
+++ b/nri-postgresql/package.yaml
@@ -57,6 +57,7 @@ ghc-options:
 library:
   exposed-modules:
   - Postgres
+  - Postgres.Enum
   - Postgres.Test
   source-dirs: src
 tests:

--- a/nri-postgresql/package.yaml
+++ b/nri-postgresql/package.yaml
@@ -72,3 +72,5 @@ tests:
       - -fno-warn-type-defaults
     default-extensions:
       - ExtendedDefaultRules
+    dependencies:
+      - th-test-utils

--- a/nri-postgresql/run-tests.sh
+++ b/nri-postgresql/run-tests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+## start postgres
+mkdir -p "../_build/postgres/data"
+PGDATA="$(realpath ../_build/postgres/data)"
+export PGDATA
+export PGUSER=$USER
+pg_ctl stop || true
+rm -rf "$PGDATA"
+initdb --no-locale --encoding=UTF8
+pg_ctl start -o '-k .'
+
+
+cabal build
+cabal test

--- a/nri-postgresql/src/Postgres.hs
+++ b/nri-postgresql/src/Postgres.hs
@@ -37,8 +37,6 @@ import Database.PostgreSQL.Typed.Protocol
     pgRollback,
     pgRollbackAll,
   )
-import qualified Database.PostgreSQL.Typed.Dynamic as PGDynamic
-import qualified Database.PostgreSQL.Typed.Enum as PGEnum
 import qualified Database.PostgreSQL.Typed.Types as PGTypes
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 import qualified List

--- a/nri-postgresql/src/Postgres.hs
+++ b/nri-postgresql/src/Postgres.hs
@@ -23,7 +23,7 @@ module Postgres
     PGTypes.PGColumn (pgDecode),
     PGTypes.PGParameter (pgEncode),
     PGTypes.PGType (..),
-    PGTypes.PGRep (..),
+    PGDynamic.PGRep (..),
     PGEnum.PGEnum (pgEnumValues),
   )
 where
@@ -40,6 +40,7 @@ import Database.PostgreSQL.Typed.Protocol
     pgRollback,
     pgRollbackAll,
   )
+import qualified Database.PostgreSQL.Typed.Dynamic as PGDynamic
 import qualified Database.PostgreSQL.Typed.Enum as PGEnum
 import qualified Database.PostgreSQL.Typed.Types as PGTypes
 import GHC.Stack (HasCallStack, withFrozenCallStack)

--- a/nri-postgresql/src/Postgres.hs
+++ b/nri-postgresql/src/Postgres.hs
@@ -22,6 +22,7 @@ module Postgres
     -- Reexposing useful postgresql-typed types
     PGTypes.PGColumn (pgDecode),
     PGTypes.PGParameter (pgEncode),
+    PGTypes.PGStringType (..),
     PGTypes.PGType (..),
     PGDynamic.PGRep (..),
     PGEnum.PGEnum (..),

--- a/nri-postgresql/src/Postgres.hs
+++ b/nri-postgresql/src/Postgres.hs
@@ -21,11 +21,7 @@ module Postgres
     inTestTransaction,
     -- Reexposing useful postgresql-typed types
     PGTypes.PGColumn (pgDecode),
-    PGTypes.PGParameter (pgEncode),
-    PGTypes.PGStringType (..),
-    PGTypes.PGType (..),
-    PGDynamic.PGRep (..),
-    PGEnum.PGEnum (..),
+    PGTypes.PGParameter (pgEncode)
   )
 where
 

--- a/nri-postgresql/src/Postgres.hs
+++ b/nri-postgresql/src/Postgres.hs
@@ -24,7 +24,7 @@ module Postgres
     PGTypes.PGParameter (pgEncode),
     PGTypes.PGType (..),
     PGDynamic.PGRep (..),
-    PGEnum.PGEnum (pgEnumValues),
+    PGEnum.PGEnum (..),
   )
 where
 

--- a/nri-postgresql/src/Postgres.hs
+++ b/nri-postgresql/src/Postgres.hs
@@ -22,6 +22,9 @@ module Postgres
     -- Reexposing useful postgresql-typed types
     PGTypes.PGColumn (pgDecode),
     PGTypes.PGParameter (pgEncode),
+    PGTypes.PGType (..),
+    PGTypes.PGRep (..),
+    PGEnum.PGEnum (pgEnumValues),
   )
 where
 
@@ -37,6 +40,7 @@ import Database.PostgreSQL.Typed.Protocol
     pgRollback,
     pgRollbackAll,
   )
+import qualified Database.PostgreSQL.Typed.Enum as PGEnum
 import qualified Database.PostgreSQL.Typed.Types as PGTypes
 import GHC.Stack (HasCallStack, withFrozenCallStack)
 import qualified List

--- a/nri-postgresql/src/Postgres/Enum.hs
+++ b/nri-postgresql/src/Postgres/Enum.hs
@@ -47,6 +47,13 @@ generatePGEnum :: TH.Name -> Text -> [(TH.Name, Text)] -> TH.Q [TH.Dec]
 generatePGEnum hsTypeName databaseTypeName mapping = do 
   let hsTypeString = Prelude.show hsTypeName
 
+  typeFamiliesEnabled <- TH.isExtEnabled TH.TypeFamilies
+
+  if not typeFamiliesEnabled then 
+    Prelude.fail "You need to enable the `TypeFamilies` extension in this module to automatically derive enum instances. Add {-# LANGUAGE TypeFamilies #-} above the module definition."
+  else
+    Prelude.pure ()
+
   info <- TH.reify hsTypeName
 
   conNames <-
@@ -175,7 +182,7 @@ generatePGEnum hsTypeName databaseTypeName mapping = do
     dbConnectDecls
     ++
     [ -- instance PGType "display_element_type" where
-      --   PGVal "display_element_type" = DisplayElementType
+      --   PGVal "display_element_type" = DisplayElementType 
       TH.InstanceD Nothing [] (TH.ConT ''PGType `TH.AppT` pgTypeString) 
         [ TH.TySynInstD <| TH.TySynEqn Nothing (TH.AppT (TH.ConT ''PGVal) pgTypeString) (TH.ConT hsTypeName) ] 
 

--- a/nri-postgresql/src/Postgres/Enum.hs
+++ b/nri-postgresql/src/Postgres/Enum.hs
@@ -183,7 +183,7 @@ generatePGEnum hsTypeName databaseTypeName mapping = do
         Prelude.fail <| "The following values of type " ++ quote hsTypeString ++ " are not mapped to values of pg enum type " ++ quote (Text.toList databaseTypeName) ++ ": " ++ Prelude.show hsOnlyValues
 
       (pgOnlyValues, _) -> 
-        Prelude.fail <| "The following values from the pg enum type " ++ quote (Text.toList databaseTypeName) ++ " are not mapped to values of " ++ quote hsTypeString ++ ": " ++ Prelude.show pgOnlyValues1
+        Prelude.fail <| "The following values from the pg enum type " ++ quote (Text.toList databaseTypeName) ++ " are not mapped to values of " ++ quote hsTypeString ++ ": " ++ Prelude.show pgOnlyValues
 
   -- Validation passed! Let's generate some instances
   let pgTypeString = TH.LitT (TH.StrTyLit (Text.toList databaseTypeName))

--- a/nri-postgresql/src/Postgres/Enum.hs
+++ b/nri-postgresql/src/Postgres/Enum.hs
@@ -25,16 +25,8 @@ findDuplicates list =
   list
     |> List.sort 
     |> group
-    |> List.filterMap 
-        (\items -> 
-          case items of 
-            (item : _ : _) -> 
-              Just item
-
-            _ ->
-              Nothing
-        )
-
+    |> List.filterMap (List.drop 1 >> List.head)
+    
 unexpectedValue :: Prelude.String -> a
 unexpectedValue value = 
   Prelude.error <| "Unexpected enum value " ++ quote value ++ " encountered. Perhaps your database is out of sync with your compiled executabe?"

--- a/nri-postgresql/src/Postgres/Enum.hs
+++ b/nri-postgresql/src/Postgres/Enum.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Postgres.Enum where
+
+import qualified Data.ByteString.Lazy as BSL
+import Data.List (group)
+import qualified Data.Text.Encoding as Encoding
+import qualified Language.Haskell.TH as TH
+import Database.PostgreSQL.Typed.Enum
+import Database.PostgreSQL.Typed.Protocol (pgSimpleQuery)
+import Database.PostgreSQL.Typed.TH (withTPGConnection)
+import Database.PostgreSQL.Typed.Dynamic (pgDecodeRep)
+import Set (Set)
+import qualified Set
+import qualified Prelude 
+
+
+quote :: Text -> Text
+quote t = "'" ++ t ++ "'"
+
+makeValueList :: List Text -> Text
+makeValueList list = 
+  "[" ++ Text.join ", " (List.map quote list) ++ "]"
+
+generatePGEnum :: TH.Name -> Text -> [(a, Text)] -> TH.Q [TH.Dec]
+generatePGEnum name databaseTypeName mapping =
+  TH.runIO <| withTPGConnection (\connection -> do
+    let hsTypeName = "_"
+
+    let duplicateValues =
+          List.map Tuple.second mapping
+            |> List.sort 
+            |> group
+            |> List.filterMap 
+                (\items -> case items of 
+                            (item : _ : _) -> 
+                              Just item
+
+                            _ ->
+                              Nothing
+                )
+
+    _ <- case duplicateValues of 
+      [] -> Prelude.pure () 
+      _ -> Prelude.fail <| "The following values in the mapping are duplicated: " ++ Text.toList (makeValueList duplicateValues)
+
+    -- Check if the databaseTypeName exists on the PG database and is an enum
+    -- See https://www.postgresql.org/docs/current/catalog-pg-type.html
+    (_, typeRows) <-
+      pgSimpleQuery connection (BSL.fromChunks
+        [ "SELECT typtype"
+        , " FROM pg_catalog.pg_type"
+        , " WHERE typname = '", Encoding.encodeUtf8 databaseTypeName, "'"
+        ])
+
+    _ <- case List.map (\[v] -> pgDecodeRep v) typeRows of 
+      [] -> 
+        Prelude.fail ("Type '" ++ Text.toList databaseTypeName ++ "' does not exist on the database.")
+      
+      -- 'e' means enum type
+      ['e'] -> 
+        Prelude.pure ()
+      
+      _ -> 
+        Prelude.fail ("Type '" ++ Text.toList databaseTypeName ++ "' is not an enum type.")
+
+    (_, enumRows) <- 
+      pgSimpleQuery connection (BSL.fromChunks
+        [ "SELECT enumlabel"
+        , " FROM pg_catalog.pg_enum"
+        , " WHERE enumtypid = '", Encoding.encodeUtf8 databaseTypeName, "'::regtype"
+        , " ORDER BY enumsortorder"
+        ])
+        
+    (values :: List Text) <- 
+      case List.map (\[value] -> pgDecodeRep value) enumRows of 
+        [] -> 
+          Prelude.fail ("Enum type '" ++ Text.toList databaseTypeName ++ "' does not contain any values.")
+        vs -> 
+          Prelude.pure vs
+
+    let dbValuesSet = Set.fromList values
+    let mappingValuesSet = Set.fromList (List.map Tuple.second mapping)    
+
+    _ <- 
+      case (Set.toList (Set.diff dbValuesSet mappingValuesSet), Set.toList (Set.diff mappingValuesSet dbValuesSet)) of 
+        ([], []) -> 
+          Prelude.pure ()
+
+        ([], hsOnlyValues) ->
+          Prelude.fail <| "The following values of type '" ++ hsTypeName ++ "' are not mapped to values of pg enum type '" ++ Text.toList databaseTypeName ++ "': " ++ Text.toList (makeValueList hsOnlyValues)
+
+        (pgOnlyValues, _) -> 
+          Prelude.fail <| "The following values from the pg enum type '" ++ Text.toList databaseTypeName ++ "' are not mapped to values of " ++ hsTypeName ++ ": " ++ Text.toList (makeValueList pgOnlyValues)
+
+    Prelude.fail "TODO"
+  )

--- a/nri-postgresql/src/Postgres/Enum.hs
+++ b/nri-postgresql/src/Postgres/Enum.hs
@@ -58,13 +58,6 @@ generatePGEnum :: TH.Name -> Text -> [(TH.Name, Text)] -> TH.Q [TH.Dec]
 generatePGEnum hsTypeName databaseTypeName mapping = do 
   let hsTypeString = Prelude.show hsTypeName
 
-  typeFamiliesEnabled <- TH.isExtEnabled TH.TypeFamilies
-
-  if not typeFamiliesEnabled then 
-    Prelude.fail "You need to enable the `TypeFamilies` extension in this module to automatically derive enum instances. Add {-# LANGUAGE TypeFamilies #-} above the module definition."
-  else
-    Prelude.pure ()
-
   info <- TH.reify hsTypeName
 
   conNames <-

--- a/nri-postgresql/src/Postgres/Enum.hs
+++ b/nri-postgresql/src/Postgres/Enum.hs
@@ -24,10 +24,6 @@ makeValueList :: List Text -> Text
 makeValueList list = 
   "[" ++ Text.join ", " (List.map (Text.toList >> quote >> Text.fromList) list) ++ "]"
 
-makeConList :: List TH.Name -> Text
-makeConList list =
-  makeValueList (List.map (Prelude.show >> Text.fromList) list)
-
 findDuplicates :: (Ord a) => List a -> List a
 findDuplicates list = 
   list
@@ -118,7 +114,7 @@ generatePGEnum hsTypeName databaseTypeName mapping = do
         Prelude.pure ()
 
       duplicates ->
-        Prelude.fail <| "The following constructors in the mapping are duplicated: " ++ Text.toList (makeConList duplicates)
+        Prelude.fail <| "The following constructors in the mapping are duplicated: " ++ Prelude.show duplicates
 
   let hsConSet = Set.fromList conNames
   let mappingConSet = Set.fromList (List.map Tuple.first mapping)
@@ -129,10 +125,10 @@ generatePGEnum hsTypeName databaseTypeName mapping = do
         Prelude.pure ()
 
       ([], mappingOnlyCons) ->
-        Prelude.fail <| "The following names in the mapping are not constructors from the data type " ++ quote hsTypeString ++ ": " ++ Text.toList (makeConList mappingOnlyCons)
+        Prelude.fail <| "The following names in the mapping are not constructors from the data type " ++ quote hsTypeString ++ ": " ++ Prelude.show mappingOnlyCons
 
       (hsOnlyCons, _) -> 
-        Prelude.fail <| "The following constructors are not present in the mapping: " ++ Text.toList (makeConList hsOnlyCons)
+        Prelude.fail <| "The following constructors are not present in the mapping: " ++ Prelude.show hsOnlyCons
 
   pgDatabase <-
     TH.runIO <| do 

--- a/nri-postgresql/src/Postgres/Enum.hs
+++ b/nri-postgresql/src/Postgres/Enum.hs
@@ -20,10 +20,6 @@ import qualified Prelude
 quote :: Prelude.String -> Prelude.String
 quote t = "\"" ++ t ++ "\""
 
-makeValueList :: List Text -> Text
-makeValueList list = 
-  "[" ++ Text.join ", " (List.map (Text.toList >> quote >> Text.fromList) list) ++ "]"
-
 findDuplicates :: (Ord a) => List a -> List a
 findDuplicates list = 
   list
@@ -105,7 +101,7 @@ generatePGEnum hsTypeName databaseTypeName mapping = do
         Prelude.pure () 
 
       duplicates ->
-        Prelude.fail <| "The following values in the mapping are duplicated: " ++ Text.toList (makeValueList duplicates)  
+        Prelude.fail <| "The following values in the mapping are duplicated: " ++ Prelude.show duplicates
 
   -- Check for duplicate constructor names specified in the mapping
   _ <-
@@ -184,10 +180,10 @@ generatePGEnum hsTypeName databaseTypeName mapping = do
         Prelude.pure ()
 
       ([], hsOnlyValues) ->
-        Prelude.fail <| "The following values of type " ++ quote hsTypeString ++ " are not mapped to values of pg enum type " ++ quote (Text.toList databaseTypeName) ++ ": " ++ Text.toList (makeValueList hsOnlyValues)
+        Prelude.fail <| "The following values of type " ++ quote hsTypeString ++ " are not mapped to values of pg enum type " ++ quote (Text.toList databaseTypeName) ++ ": " ++ Prelude.show hsOnlyValues
 
       (pgOnlyValues, _) -> 
-        Prelude.fail <| "The following values from the pg enum type " ++ quote (Text.toList databaseTypeName) ++ " are not mapped to values of " ++ quote hsTypeString ++ ": " ++ Text.toList (makeValueList pgOnlyValues)
+        Prelude.fail <| "The following values from the pg enum type " ++ quote (Text.toList databaseTypeName) ++ " are not mapped to values of " ++ quote hsTypeString ++ ": " ++ Prelude.show pgOnlyValues1
 
   -- Validation passed! Let's generate some instances
   let pgTypeString = TH.LitT (TH.StrTyLit (Text.toList databaseTypeName))

--- a/nri-postgresql/src/Postgres/Enum.hs
+++ b/nri-postgresql/src/Postgres/Enum.hs
@@ -22,76 +22,103 @@ makeValueList :: List Text -> Text
 makeValueList list = 
   "[" ++ Text.join ", " (List.map quote list) ++ "]"
 
-generatePGEnum :: TH.Name -> Text -> [(a, Text)] -> TH.Q [TH.Dec]
-generatePGEnum name databaseTypeName mapping =
-  TH.runIO <| withTPGConnection (\connection -> do
-    let hsTypeName = "_"
+generatePGEnum :: (Ord a, Eq a) => TH.Name -> Text -> [(a, Text)] -> TH.Q [TH.Dec]
+generatePGEnum hsTypeName databaseTypeName mapping = do 
+  let hsTypeString = Prelude.show hsTypeName
 
-    let duplicateValues =
-          List.map Tuple.second mapping
-            |> List.sort 
-            |> group
-            |> List.filterMap 
-                (\items -> case items of 
-                            (item : _ : _) -> 
-                              Just item
+  info <- TH.reify hsTypeName
 
-                            _ ->
-                              Nothing
-                )
+  conNames <-
+    case info of 
+      TH.TyConI (TH.DataD _ _ _ _ constructors _) ->
+        constructors
+          |> Prelude.traverse (\con -> case con of 
+                TH.NormalC name [] ->
+                  Prelude.pure name
 
-    _ <- case duplicateValues of 
-      [] -> Prelude.pure () 
-      _ -> Prelude.fail <| "The following values in the mapping are duplicated: " ++ Text.toList (makeValueList duplicateValues)
+                TH.NormalC name _ ->
+                  Prelude.fail <| "Constructor '" ++ Prelude.show name ++ "' cannot have any arguments in order to be mapped to an enum."
 
-    -- Check if the databaseTypeName exists on the PG database and is an enum
-    -- See https://www.postgresql.org/docs/current/catalog-pg-type.html
-    (_, typeRows) <-
-      pgSimpleQuery connection (BSL.fromChunks
-        [ "SELECT typtype"
-        , " FROM pg_catalog.pg_type"
-        , " WHERE typname = '", Encoding.encodeUtf8 databaseTypeName, "'"
-        ])
+                _ -> 
+                  Prelude.fail <| "Data type '" ++ hsTypeString ++ "' must contain only simple constructors with no arguments."
+              )
 
-    _ <- case List.map (\[v] -> pgDecodeRep v) typeRows of 
-      [] -> 
-        Prelude.fail ("Type '" ++ Text.toList databaseTypeName ++ "' does not exist on the database.")
-      
-      -- 'e' means enum type
-      ['e'] -> 
-        Prelude.pure ()
-      
-      _ -> 
-        Prelude.fail ("Type '" ++ Text.toList databaseTypeName ++ "' is not an enum type.")
+      _ ->
+        Prelude.fail <| "The datatype name '" ++ hsTypeString ++ "' must be a data declaration."
 
-    (_, enumRows) <- 
-      pgSimpleQuery connection (BSL.fromChunks
-        [ "SELECT enumlabel"
-        , " FROM pg_catalog.pg_enum"
-        , " WHERE enumtypid = '", Encoding.encodeUtf8 databaseTypeName, "'::regtype"
-        , " ORDER BY enumsortorder"
-        ])
+  -- Check for duplicate values specified in the mapping
+  _ <- 
+    List.map Tuple.second mapping
+      |> List.sort 
+      |> group
+      |> List.filterMap 
+          (\items -> 
+            case items of 
+              (item : _ : _) -> 
+                Just item
+
+              _ ->
+                Nothing
+          )
+      |> (\duplicateValues -> 
+            case duplicateValues of 
+              [] -> 
+                Prelude.pure () 
+
+              _ -> 
+                Prelude.fail <| "The following values in the mapping are duplicated: " ++ Text.toList (makeValueList duplicateValues)  
+          )
+
+  (pgEnumValues :: List Text) <-
+    TH.runIO <| withTPGConnection (\connection -> do 
+      -- Check if the databaseTypeName exists on the PG database and is an enum
+      -- See https://www.postgresql.org/docs/current/catalog-pg-type.html
+      (_, typeRows) <-
+        pgSimpleQuery connection (BSL.fromChunks
+          [ "SELECT typtype"
+          , " FROM pg_catalog.pg_type"
+          , " WHERE typname = '", Encoding.encodeUtf8 databaseTypeName, "'"
+          ])
+
+      _ <- case List.map (\[v] -> pgDecodeRep v) typeRows of 
+        [] -> 
+          Prelude.fail ("Type '" ++ Text.toList databaseTypeName ++ "' does not exist on the database.")
         
-    (values :: List Text) <- 
+        -- 'e' means enum type
+        ['e'] -> 
+          Prelude.pure ()
+        
+        _ -> 
+          Prelude.fail ("Type '" ++ Text.toList databaseTypeName ++ "' is not an enum type.")
+
+      (_, enumRows) <- 
+        pgSimpleQuery connection (BSL.fromChunks
+          [ "SELECT enumlabel"
+          , " FROM pg_catalog.pg_enum"
+          , " WHERE enumtypid = '", Encoding.encodeUtf8 databaseTypeName, "'::regtype"
+          , " ORDER BY enumsortorder"
+          ])
+        
       case List.map (\[value] -> pgDecodeRep value) enumRows of 
         [] -> 
           Prelude.fail ("Enum type '" ++ Text.toList databaseTypeName ++ "' does not contain any values.")
+
         vs -> 
           Prelude.pure vs
+    )
 
-    let dbValuesSet = Set.fromList values
-    let mappingValuesSet = Set.fromList (List.map Tuple.second mapping)    
+  let pgValuesSet = Set.fromList pgEnumValues
+  let mappingValuesSet = Set.fromList (List.map Tuple.second mapping) 
 
-    _ <- 
-      case (Set.toList (Set.diff dbValuesSet mappingValuesSet), Set.toList (Set.diff mappingValuesSet dbValuesSet)) of 
-        ([], []) -> 
-          Prelude.pure ()
+  _ <- 
+    case (Set.toList (Set.diff pgValuesSet mappingValuesSet), Set.toList (Set.diff mappingValuesSet pgValuesSet)) of 
+      ([], []) -> 
+        Prelude.pure ()
 
-        ([], hsOnlyValues) ->
-          Prelude.fail <| "The following values of type '" ++ hsTypeName ++ "' are not mapped to values of pg enum type '" ++ Text.toList databaseTypeName ++ "': " ++ Text.toList (makeValueList hsOnlyValues)
+      ([], hsOnlyValues) ->
+        Prelude.fail <| "The following values of type '" ++ hsTypeString ++ "' are not mapped to values of pg enum type '" ++ Text.toList databaseTypeName ++ "': " ++ Text.toList (makeValueList hsOnlyValues)
 
-        (pgOnlyValues, _) -> 
-          Prelude.fail <| "The following values from the pg enum type '" ++ Text.toList databaseTypeName ++ "' are not mapped to values of " ++ hsTypeName ++ ": " ++ Text.toList (makeValueList pgOnlyValues)
+      (pgOnlyValues, _) -> 
+        Prelude.fail <| "The following values from the pg enum type '" ++ Text.toList databaseTypeName ++ "' are not mapped to values of " ++ hsTypeString ++ ": " ++ Text.toList (makeValueList pgOnlyValues)
 
-    Prelude.fail "TODO"
-  )
+  Prelude.fail "TODO"

--- a/nri-postgresql/src/Postgres/Enum.hs
+++ b/nri-postgresql/src/Postgres/Enum.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS -Wno-incomplete-uni-patterns #-}
+{-# OPTIONS -Wno-orphans #-}
 
 module Postgres.Enum where
 
@@ -6,12 +8,10 @@ import qualified Data.ByteString.Lazy as BSL
 import Data.List (group)
 import qualified Data.Text.Encoding as Encoding
 import qualified Language.Haskell.TH as TH
-import Database.PostgreSQL.Typed.Enum
 import Database.PostgreSQL.Typed.Protocol (pgSimpleQuery)
 import Database.PostgreSQL.Typed.TH (withTPGConnection)
 import Database.PostgreSQL.Typed.Dynamic (pgDecodeRep, PGRepType, PGRep)
 import Database.PostgreSQL.Typed.Types (PGType, PGVal, PGParameter, pgEncode, PGColumn, pgDecode)
-import Set (Set)
 import qualified Set
 import qualified Prelude 
 
@@ -27,7 +27,7 @@ makeConList :: List TH.Name -> Text
 makeConList list =
   makeValueList (List.map (Prelude.show >> Text.fromList) list)
 
-findDuplicates :: (Ord a, Eq a) => List a -> List a
+findDuplicates :: (Ord a) => List a -> List a
 findDuplicates list = 
   list
     |> List.sort 

--- a/nri-postgresql/src/Postgres/Enum.hs
+++ b/nri-postgresql/src/Postgres/Enum.hs
@@ -1,5 +1,8 @@
-{-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS -Wno-orphans #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Postgres.Enum (
+  generatePGEnum
+) where
 
 module Postgres.Enum where
 

--- a/nri-postgresql/src/Postgres/TH.hs
+++ b/nri-postgresql/src/Postgres/TH.hs
@@ -1,0 +1,13 @@
+module Postgres.TH where
+
+import qualified Environment
+import qualified Language.Haskell.TH as TH
+import Database.PostgreSQL.Typed.TH (useTPGDatabase)
+import qualified Postgres.Settings
+import qualified Prelude
+
+-- | Template Haskell to connect to the database using NRI settings at compile time.  
+useNRIDatabase :: TH.Q [TH.Dec]
+useNRIDatabase = do
+  pgDatabase <- TH.runIO (Prelude.fmap Postgres.Settings.toPGDatabase (Environment.decode Postgres.Settings.decoder))
+  useTPGDatabase pgDatabase

--- a/nri-postgresql/test/Enum.hs
+++ b/nri-postgresql/test/Enum.hs
@@ -6,29 +6,90 @@
 module Enum where
 
 import Test (Test, describe)
+import qualified Test
 import qualified Database.PostgreSQL.Typed as Core
 import Postgres.Enum (generatePGEnum)
 import qualified Postgres.TH
+import qualified Language.Haskell.TH as TH
+import qualified Expect
+import Language.Haskell.TH.TestUtils as THTest
+import qualified Prelude
 
 {- Set up an enum type on the database at compile time to test with -}
 Postgres.TH.useNRIDatabase
 
-[Core.pgSQL| CREATE TYPE test_enum as ENUM ('value_1', 'value_2', 'value_3') |]
+[Core.pgSQL| CREATE TYPE test_enum as ENUM ('value_1', 'value_2') |]
 
 data TestEnum
   = Value1
   | Value2
-  | Value3
+
+data TestNotEnum
+  = NotValue Int
+
+data UndersizedEnum 
+  = UndersizedValue1
+
+data OversizedEnum
+  = OversizedValue1
+  | OversizedValue2
+  | OversizedValue3
 
 $(generatePGEnum ''TestEnum "test_enum"
     [ ('Value1, "value_1")
     , ('Value2, "value_2")
-    , ('Value3, "value_3") 
     ]
  )
+
+-- | Tests that test cases we expect to get compile time failures for
+-- 
+-- Language.Haskell.TH has a `runQ` method which looks like it could be used
+-- to run `generatePGEnum` in a test.  But unfortunately for technical reasons
+-- `runQ` does not allow reifying names (which we use to look up the constructors of
+-- `TestEnum`).  So instead we call in the `th-test-utils` library which lets us 
+-- mock in the names that will be reified.
+generateFailureTests :: Test
+generateFailureTests =  
+  let qState = THTest.QState 
+        { THTest.mode = THTest.MockQAllowIO
+        , THTest.knownNames = []
+        , THTest.reifyInfo = $(loadNames [''TestEnum, ''UndersizedEnum, ''OversizedEnum, ''TestNotEnum])
+        }
+
+      expectCompileFailure :: TH.Q [TH.Dec] -> Expect.Expectation
+      expectCompileFailure q = do
+        either <- Expect.fromIO (THTest.tryTestQ qState q)
+        case either of 
+          Prelude.Left _ ->
+            Expect.pass
+          Prelude.Right _ -> 
+            Expect.fail "Expected a compile time error but none were generated"
+  in
+  describe "generatePGEnum [compile-time failure]" 
+  [ Test.test "data type is not an enum" <| \_ -> 
+      expectCompileFailure (generatePGEnum ''TestNotEnum "test_enum" [('NotValue, "value_1")] )
+  , Test.test "mapping contains duplicate database values" <| \_ ->
+      expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1"), ('Value2, "value_1")] )
+  , Test.test "mapping contains duplicate constructors" <| \_ ->
+      expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1"), ('Value1, "value_2")] )
+  , Test.test "constructor not from data type" <| \_ ->
+      expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1"), ('NotValue, "value_2")] )
+  , Test.test "constructor missing from mapping" <| \_ ->
+      expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1")] )
+  , Test.test "database enum name does not exist" <| \_ ->
+      expectCompileFailure (generatePGEnum ''TestEnum "not_an_enum_name" [('Value1, "value_1"), ('Value2, "value_2")] )
+  , Test.test "database name not an enum" <| \_ ->
+      expectCompileFailure (generatePGEnum ''TestEnum "boolean" [('Value1, "value_1"), ('Value2, "value_2")] )
+  , Test.test "datatype smaller than PG enum" <| \_ ->
+      expectCompileFailure (generatePGEnum ''UndersizedEnum "test_enum" [('UndersizedValue1, "value_1")] )
+  , Test.test "datatype larger than PG enum" <| \_ ->
+      expectCompileFailure (generatePGEnum ''OversizedEnum "test_enum" [('OversizedValue1, "value_1"), ('OversizedValue2, "value_2")] )
+  ] 
+
 
 tests :: Test
 tests = 
   describe
-    "Postgres.Settings"
-    [ ]
+    "Postgres.Enum"
+    [ generateFailureTests
+    ]

--- a/nri-postgresql/test/Enum.hs
+++ b/nri-postgresql/test/Enum.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS -Wno-orphans #-}
+
+module Enum where
+
+import Test (Test, describe)
+import qualified Database.PostgreSQL.Typed as Core
+import Postgres.Enum (generatePGEnum)
+import qualified Postgres.TH
+
+{- Set up an enum type on the database at compile time to test with -}
+Postgres.TH.useNRIDatabase
+
+[Core.pgSQL| CREATE TYPE test_enum as ENUM ('value_1', 'value_2', 'value_3') |]
+
+data TestEnum
+  = Value1
+  | Value2
+  | Value3
+
+$(generatePGEnum ''TestEnum "test_enum"
+    [ ('Value1, "value_1")
+    , ('Value2, "value_2")
+    , ('Value3, "value_3") 
+    ]
+ )
+
+tests :: Test
+tests = 
+  describe
+    "Postgres.Settings"
+    [ ]

--- a/nri-postgresql/test/Main.hs
+++ b/nri-postgresql/test/Main.hs
@@ -11,6 +11,7 @@ import qualified PostgresSettingsSpec
 import qualified QueryParserSpec
 import Test (Test, describe, run)
 import qualified TimeSpec
+import qualified Enum
 import qualified Prelude
 
 -- `Test.run` exits after finishing, so run other tests first.
@@ -28,5 +29,6 @@ tests postgres =
     [ PostgresSettingsSpec.tests,
       QueryParserSpec.tests,
       TimeSpec.tests,
-      ObservabilitySpec.tests postgres
+      ObservabilitySpec.tests postgres,
+      Enum.tests
     ]

--- a/nri-postgresql/test/Main.hs
+++ b/nri-postgresql/test/Main.hs
@@ -30,5 +30,5 @@ tests postgres =
       QueryParserSpec.tests,
       TimeSpec.tests,
       ObservabilitySpec.tests postgres,
-      Enum.tests
+      Enum.tests postgres
     ]


### PR DESCRIPTION
This PR adds a new TemplateHaskell function to create a bridge between Haskell enums and Postgres enums. 

```sql
CREATE TYPE display_element_type AS ENUM ('labeled', 'blank')
```

```hs
{-# LANGUAGE TemplateHaskell #-}
{-# LANGUAGE TypeFamilies #-}
{-# OPTIONS -Wno-orphans #-}

import Postgres.Enum

data DisplayElementType
  = Labeled
  | Blank
  deriving (Eq, Show, Ord)

$(generatePGEnum ''DisplayElementType "display_element_type" 
    [ ('Labeled, "labeled")
    , ('Blank, "blank")
    ]
  )
```

This allows us to go directly from the Haskell sum type to the database enum type:

```hs
Postgres.doQuery
      connection
      [Postgres.sql|!
         UPDATE content_creation.scaffolding_flows
         SET display_element = ${Labeled}
      |]
      WebServer.expectCommandSuccess
```

```hs
(x :: (List DisplayElementType)) <-
    Postgres.doQuery
      connection
      [Postgres.sql|!
        SELECT intro_button_middle_step_id
        FROM content_creation.scaffolding_flows
      |]
      WebQuery.expectQuerySuccess
```

### Caveats: 
- The `TypeFamilies` extension is required to set up the instances of [`PGRep`](https://hackage.haskell.org/package/postgresql-typed-0.6.2.1/docs/Database-PostgreSQL-Typed-Dynamic.html#t:PGRep) and [`PGType`](https://hackage.haskell.org/package/postgresql-typed-0.6.2.1/docs/Database-PostgreSQL-Typed-Types.html#t:PGType)
- The `PGType` instance will unavoidably be an orphan instance.  So `{-# OPTIONS -Wno-orphans #-}` will need to be set in the module where `generatePGEnum` is used.

### Maintenance Risks: 
- If we upgrade GHC versions, there is a risk that the TemplateHaskell library API changes and we would need to update the `Enum` module appropriately.  I think this risk is relatively low as we don't use any exotic `TH` features. I tried to leave the code very well commented so any NRIer with Haskell experience could probably do the update. 
- If the `postgresql-typed` instances get modified in a future release we may need to update the generated code as well.  Also low risk in my estimation. 

## :microscope: What do you want the reviewer to check?

Please check that we are guarding against all the following errors at compile time (with clear and understandable error messages):
- The type passed as the first argument is not a data type. 
- The type passed as the first argument contains a record constructor
- The type passed as the first argument contains a constructor with arguments
- Specifying the same PG enum value twice in the mapping (e.g. using "blank" twice in the example above)
- Specifying the same constructor name twice in the mapping
- The second argument to `generatePGEnum` is not the name of a type in PG
- The second argument to `generatePGEnum` is the name of a PG type, but not an enum type (e.g. "bool")
- The second argument to `generatePGEnum` is the name of a PG enum type with no values. 
- There are values in the PG enum not present in the mapping (e.g. not specifying "blank" in the example above)
- There are values in the mapping not present in the PG enum (e.g. adding "other" as a mapping value)
- One of the constructors in the data type is not present in the mapping
- A name specified in the mapping is not a constructor in the data type
- The `TypeFamilies` extension is required in the module that runs `generatePGEnum`.  We should show a helpful error message if it's not enabled.

Finally we also will throw a runtime exception if the database produces an unexpected enum value.  This can only happen if the database and compiled exe are out of sync, so test this would require altering the database enum definition after the Haskell is compiled.

Notes on testing this: 

I was able to get a good test setup working directly in `nri-postgresql` by setting up the vars in the .envrc: 

```
export PGHOST=localhost
export PGPORT=8088
export PGDATABASE=content_creation
export PGUSER=content_creation
export PGPASSWORD=content_creation
```

And adding a `EnumTest` module defined like this:

```
{-# LANGUAGE TemplateHaskell #-}
{-# LANGUAGE QuasiQuotes #-}
{-# LANGUAGE TypeFamilies #-}
{-# OPTIONS -Wno-orphans #-}

module Postgres.EnumTest where

import qualified Postgres
import qualified Postgres.Connection
import qualified Postgres.Settings
import Postgres.Enum
import qualified Prelude
import qualified Environment
import qualified Platform

data DisplayElementType
  = Labeled
  | Blank
  deriving (Eq, Show, Ord)

$(generatePGEnum ''DisplayElementType "display_element_type" 
    [ ('Labeled, "labeled")
    , ('Blank, "blank")
    ]
  )

resultTask :: Result a b -> Task a b
resultTask result =
  case result of 
    Ok vvv -> Task.succeed vvv 
    Err eee -> Task.fail eee

g = do 
  nriSettings <- Environment.decode Postgres.Settings.decoder
  connection <- Postgres.Connection.connectionIO nriSettings
  log <- Platform.silentHandler

  _ <- 
    Postgres.doQuery
      connection
      [Postgres.sql|!
         UPDATE content_creation.scaffolding_flows
         SET display_element = ${Labeled}
      |]
      resultTask
        |> Task.attempt log

  (x :: Result Postgres.Error (List DisplayElementType)) <-
    Postgres.doQuery
      connection
      [Postgres.sql|!
        SELECT display_element
        FROM content_creation.scaffolding_flows
      |]
      resultTask
        |> Task.attempt log

  Prelude.pure x
  ```
