### PR TITLE
Add `expectTextResponse` and `expectBytesResponse`

### DIFF
--- a/nri-http/nri-http.cabal
+++ b/nri-http/nri-http.cabal
@@ -57,6 +57,7 @@ library
       aeson >=1.4.6.0 && <2.1
     , base >=4.12.0.0 && <4.17
     , bytestring >=0.10.8.2 && <0.12
+    , case-insensitive >=1.1 && <2.0
     , conduit >=1.3.0 && <1.4
     , http-client >=0.6.0 && <0.8
     , http-client-tls >=0.3.0 && <0.4
@@ -101,6 +102,7 @@ test-suite spec
       aeson >=1.4.6.0 && <2.1
     , base >=4.12.0.0 && <4.17
     , bytestring >=0.10.8.2 && <0.12
+    , case-insensitive >=1.1 && <2.0
     , conduit >=1.3.0 && <1.4
     , http-client >=0.6.0 && <0.8
     , http-client-tls >=0.3.0 && <0.4

--- a/nri-http/package.yaml
+++ b/nri-http/package.yaml
@@ -20,6 +20,7 @@ library:
   - nri-prelude >= 0.1.0.0 && < 0.7
   - nri-observability >= 0.1.0.0 && < 0.2
   - conduit >= 1.3.0 && < 1.4
+  - case-insensitive >= 1.1 && < 2.0
   - http-client >= 0.6.0 && < 0.8
   - http-client-tls >= 0.3.0 && < 0.4
   - http-types >= 0.12 && < 0.13
@@ -40,6 +41,7 @@ tests:
     - nri-prelude >= 0.1.0.0 && < 0.7
     - nri-observability >= 0.1.0.0 && < 0.2
     - conduit >= 1.3.0 && < 1.4
+    - case-insensitive >= 1.1 && < 2.0
     - http-client >= 0.6.0 && < 0.8
     - http-client-tls >= 0.3.0 && < 0.4
     - http-types >= 0.12 && < 0.13

--- a/nri-http/src/Http.hs
+++ b/nri-http/src/Http.hs
@@ -30,11 +30,12 @@ module Http
     expectJson,
     expectText,
     expectWhatever,
-    expectTextResponse,
-    expectBytesResponse,
 
     -- * Elaborate Expectations
-    Internal.Response,
+    expectTextResponse,
+    expectBytesResponse,
+    Internal.Response (..),
+    Internal.Metadata (..),
 
     -- * Use with external libraries
     withThirdParty,

--- a/nri-http/src/Http.hs
+++ b/nri-http/src/Http.hs
@@ -31,6 +31,9 @@ module Http
     expectText,
     expectWhatever,
 
+    -- * Elaborate Expectations
+    Internal.Response,
+
     -- * Use with external libraries
     withThirdParty,
     withThirdPartyIO,
@@ -60,6 +63,7 @@ import qualified Network.URI
 import qualified Platform
 import qualified Task
 import Prelude (Either (Left, Right), IO, fromIntegral, pure, show)
+import qualified Dict
 
 -- | Create a 'Handler' for making HTTP requests.
 handler :: Conduit.Acquire Handler
@@ -100,7 +104,7 @@ _withThirdPartyIO manager log library = do
 -- QUICKS
 
 -- | Create a @GET@ request.
-get :: Dynamic.Typeable a => Handler -> Text -> Expect a -> Task Error a
+get :: (Dynamic.Typeable x, Dynamic.Typeable a) => Handler -> Text -> Expect x a -> Task x a
 get handler' url expect =
   request
     handler'
@@ -114,7 +118,7 @@ get handler' url expect =
       }
 
 -- | Create a @POST@ request.
-post :: Dynamic.Typeable a => Handler -> Text -> Body -> Expect a -> Task Error a
+post :: (Dynamic.Typeable x, Dynamic.Typeable a) => Handler -> Text -> Body -> Expect x a -> Task x a
 post handler' url body expect =
   request
     handler'
@@ -179,13 +183,13 @@ bytesBody mimeType bytes =
 
 -- | Create a custom request.
 request ::
-  Dynamic.Typeable expect =>
+  (Dynamic.Typeable x, Dynamic.Typeable expect) =>
   Handler ->
-  Internal.Request expect ->
-  Task Error expect
+  Internal.Request x expect ->
+  Task x expect
 request Internal.Handler {Internal.handlerRequest} settings = handlerRequest settings
 
-_request :: Platform.DoAnythingHandler -> HTTP.Manager -> Internal.Request expect -> Task Error expect
+_request :: Platform.DoAnythingHandler -> HTTP.Manager -> Internal.Request x expect -> Task x expect
 _request doAnythingHandler manager settings = do
   requestManager <- prepareManagerForRequest manager
   Platform.doAnything doAnythingHandler <| do
@@ -212,51 +216,73 @@ _request doAnythingHandler manager settings = do
                       |> HTTP.responseTimeoutMicro
                 }
         HTTP.httpLbs finalRequest requestManager
-    pure <| case response of
-      Right okResponse ->
-        case decode (Internal.expect settings) (HTTP.responseBody okResponse) of
-          Ok decodedBody ->
-            Ok decodedBody
-          Err message ->
-            Err (Internal.BadBody message)
-      Left (HTTP.HttpExceptionRequest _ content) ->
-        case content of
-          HTTP.StatusCodeException res _ ->
-            let statusCode = fromIntegral << Status.statusCode << HTTP.responseStatus
-             in Err (Internal.BadStatus (statusCode res))
-          HTTP.ResponseTimeout ->
-            Err Internal.Timeout
-          HTTP.ConnectionTimeout ->
-            Err (Internal.NetworkError "ConnectionTimeout")
-          HTTP.ConnectionFailure err ->
-            Err (Internal.NetworkError (Text.fromList (Exception.displayException err)))
-          err ->
-            Err (Internal.NetworkError (Text.fromList (show err)))
-      Left (HTTP.InvalidUrlException _ message) ->
-        Err (Internal.BadUrl (Text.fromList message))
+    pure <| handleResponse (Internal.expect settings) response
+    -- pure <| case response of
+    --   Right okResponse ->
+    --     decode (Internal.expect settings) (HTTP.responseBody okResponse)
+    --   Left (HTTP.HttpExceptionRequest _ content) ->
+    --     case content of
+    --       HTTP.StatusCodeException res _ ->
+    --         let statusCode = fromIntegral << Status.statusCode << HTTP.responseStatus
+    --          in Err (Internal.BadStatus (statusCode res))
+    --       HTTP.ResponseTimeout ->
+    --         Err Internal.Timeout
+    --       HTTP.ConnectionTimeout ->
+    --         Err (Internal.NetworkError "ConnectionTimeout")
+    --       HTTP.ConnectionFailure err ->
+    --         Err (Internal.NetworkError (Text.fromList (Exception.displayException err)))
+    --       err ->
+    --         Err (Internal.NetworkError (Text.fromList (show err)))
+    --   Left (HTTP.InvalidUrlException _ message) ->
+    --     Err (Internal.BadUrl (Text.fromList message))
 
-decode :: Expect a -> Data.ByteString.Lazy.ByteString -> Result Text a
+decode :: Expect x a -> Data.ByteString.Lazy.ByteString -> Result x a
 decode Internal.ExpectJson bytes =
   case Aeson.eitherDecode bytes of
-    Left err -> Err (Text.fromList err)
+    Left err -> Err (Internal.BadBody (Text.fromList err))
     Right x -> Ok x
 decode Internal.ExpectText bytes = (Ok << Data.Text.Lazy.toStrict << Data.Text.Lazy.Encoding.decodeUtf8) bytes
 decode Internal.ExpectWhatever _ = Ok ()
 
+handleResponse :: Expect x a -> Either HTTP.HttpException (HTTP.Response Data.ByteString.Lazy.ByteString) -> Result x a
+handleResponse Internal.ExpectWhatever _ = Ok ()  
+handleResponse (Internal.ExpectStringResponse f) (Right settings) = f (mkResponse settings)
+
+mkResponse :: HTTP.Response Data.ByteString.Lazy.ByteString -> Internal.Response body
+mkResponse response =
+  Internal.Timeout_
+
+mkMetadata :: HTTP.Response Data.ByteString.Lazy.ByteString -> Internal.Metadata
+mkMetadata response = Internal.Metadata
+  { Internal.metadataUrl = ""
+  -- , Internal.metadataStatusCode = (fromIntegral << Status.statusCode << HTTP.responseStatus) response
+  , Internal.metadataStatusCode = 200
+  , Internal.metadataStatusText = ""
+  -- , Internal.metadataHeaders = Dict.fromList <| HTTP.responseHeaders response
+  , Internal.metadataHeaders = Dict.empty
+  }
+
+
+
 -- |
 -- Expect the response body to be JSON.
-expectJson :: Aeson.FromJSON a => Expect a
+expectJson :: Aeson.FromJSON a => Expect Error a
 expectJson = Internal.ExpectJson
 
 -- |
 -- Expect the response body to be a `Text`.
-expectText :: Expect Text
+expectText :: Expect Error Text
 expectText = Internal.ExpectText
 
 -- |
 -- Expect the response body to be whatever. It does not matter. Ignore it!
-expectWhatever :: Expect ()
+expectWhatever :: Expect Error ()
 expectWhatever = Internal.ExpectWhatever
+
+-- |
+-- Expect a `Response` with a `Text` body.
+expectTextResponse :: (Internal.Response Text -> Result x a) -> Expect x a
+expectTextResponse f = Internal.ExpectStringResponse f
 
 -- |
 type Error = Internal.Error

--- a/nri-http/src/Http/Internal.hs
+++ b/nri-http/src/Http/Internal.hs
@@ -5,16 +5,15 @@ module Http.Internal where
 
 import qualified Control.Exception.Safe as Exception
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString
 import qualified Data.ByteString.Lazy
 import qualified Data.Dynamic as Dynamic
+import Dict (Dict)
 import qualified Network.HTTP.Client as HTTP
 import qualified Network.HTTP.Types.Header as Header
 import qualified Network.Mime as Mime
 import qualified Platform
 import Prelude (IO)
-import Dict (Dict)
-
-
 
 -- | A handler for making HTTP requests.
 data Handler = Handler
@@ -22,8 +21,6 @@ data Handler = Handler
     handlerWithThirdParty :: forall e a. (HTTP.Manager -> Task e a) -> Task e a,
     handlerWithThirdPartyIO :: forall a. Platform.LogHandler -> (HTTP.Manager -> IO a) -> IO a
   }
-
-
 
 -- | A custom request.
 data Request a = Request
@@ -58,6 +55,7 @@ data Expect a where
   ExpectText :: Expect Text
   ExpectWhatever :: Expect ()
   ExpectTextResponse :: (Response Text -> Result Error a) -> Expect a
+  ExpectBytesResponse :: (Response Data.ByteString.ByteString -> Result Error a) -> Expect a
 
 -- | A 'Request' can fail in a couple of ways:
 --

--- a/nri-http/src/Http/Internal.hs
+++ b/nri-http/src/Http/Internal.hs
@@ -98,7 +98,7 @@ instance (Aeson.ToJSON body) => Aeson.ToJSON (Response body)
 
 -- Extra information about the response:
 --
--- Note: It is possible for a response to have the same header multiple times. In that case, all the values end up in a single entry in the headers dictionary. The values are separated by commas, following the rules outlined here.
+-- Note: It is possible for a response to have the same header multiple times. In that case, all the values end up in a single entry in the headers dictionary. The values are separated by commas, following the rules outlined [here](https://stackoverflow.com/questions/4371328/are-duplicate-http-response-headers-acceptable).
 data Metadata = Metadata
   { -- statusCode like 200 or 404
     metadataStatusCode :: Int,

--- a/nri-http/src/Http/Internal.hs
+++ b/nri-http/src/Http/Internal.hs
@@ -17,8 +17,8 @@ import Prelude (IO)
 
 -- | A handler for making HTTP requests.
 data Handler = Handler
-  { handlerRequest :: forall expect. (Dynamic.Typeable expect) => Request expect -> Task Error expect,
-    handlerWithThirdParty :: forall e a. (HTTP.Manager -> Task e a) -> Task e a,
+  { handlerRequest :: forall expect. Dynamic.Typeable expect => Request expect -> Task Error expect,
+    handlerWithThirdParty :: forall a e. (HTTP.Manager -> Task e a) -> Task e a,
     handlerWithThirdPartyIO :: forall a. Platform.LogHandler -> (HTTP.Manager -> IO a) -> IO a
   }
 

--- a/nri-http/src/Http/Mock.hs
+++ b/nri-http/src/Http/Mock.hs
@@ -34,13 +34,13 @@ import qualified Prelude
 -- different kinds of http requests, you'll want one of these per request type.
 data Stub a where
   Stub ::
-    ( Dynamic.Typeable expect ) =>
+    (Dynamic.Typeable expect) =>
     (Internal.Request expect -> Task Internal.Error (a, expect)) ->
     Stub a
 
 -- | Create a 'Stub'.
 mkStub ::
-  ( Dynamic.Typeable expect ) =>
+  (Dynamic.Typeable expect) =>
   (Internal.Request expect -> Task Internal.Error (a, expect)) ->
   Stub a
 mkStub = Stub
@@ -143,12 +143,14 @@ tryRespond ::
   List (Stub a) ->
   Internal.Request expect ->
   Task Internal.Error (a, expect)
-tryRespond [] req = Task.fail (Internal.NetworkError
-                      (  "Http request was made with expected return type "
-                          ++ printType req
-                          ++ ", but I don't know how to create a mock response of this type. Please add a `mkStub` entry for this type in the test."
-                      )
-                  )
+tryRespond [] req =
+  Task.fail
+    ( Internal.NetworkError
+        ( "Http request was made with expected return type "
+            ++ printType req
+            ++ ", but I don't know how to create a mock response of this type. Please add a `mkStub` entry for this type in the test."
+        )
+    )
 tryRespond (Stub respond : rest) req =
   Dynamic.dynApply (Dynamic.toDyn respond) (Dynamic.toDyn req)
     |> Maybe.andThen Dynamic.fromDynamic

--- a/nri-http/test/golden-results/expected-http-span
+++ b/nri-http/test/golden-results/expected-http-span
@@ -31,9 +31,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Http"
                     , srcLocFile = "src/Http.hs"
-                    , srcLocStartLine = 344
+                    , srcLocStartLine = 419
                     , srcLocStartCol = 11
-                    , srcLocEndLine = 356
+                    , srcLocEndLine = 431
                     , srcLocEndCol = 14
                     }
                 )

--- a/nri-http/test/golden-results/expected-http-span
+++ b/nri-http/test/golden-results/expected-http-span
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "main"
             , srcLocModule = "Main"
             , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 191
+            , srcLocStartLine = 221
             , srcLocStartCol = 7
-            , srcLocEndLine = 195
+            , srcLocEndLine = 225
             , srcLocEndCol = 40
             }
         )

--- a/nri-http/test/golden-results/expected-http-span
+++ b/nri-http/test/golden-results/expected-http-span
@@ -31,9 +31,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Http"
                     , srcLocFile = "src/Http.hs"
-                    , srcLocStartLine = 419
+                    , srcLocStartLine = 428
                     , srcLocStartCol = 11
-                    , srcLocEndLine = 431
+                    , srcLocEndLine = 440
                     , srcLocEndCol = 14
                     }
                 )


### PR DESCRIPTION
Following the elm/http package, this PR adds those two functions:

```haskell
expectTextResponse :: (Response Text -> Result Error a) -> Expect a
```

```haskell
expectBytesResponse :: (Response ByteString -> Result Error a) -> Expect a
```

The `Response` is also very similar to its Elm counterpart and give the user more flexibility over the response.
The notable difference for now is that we cannot use a custom error but have to stick with the `Http.Error` instead.