### PR TITLE
Add custom errors.

### DIFF
--- a/nri-http/test/Main.hs
+++ b/nri-http/test/Main.hs
@@ -58,7 +58,7 @@ tests =
           (constant "12" Status.ok200)
           ( \http url -> do
               err <-
-                Http.get http url (Http.expectJson :: Http.Expect Text)
+                Http.get http url (Http.expectJson :: Http.Expect Http.Error Text)
                   |> Expect.fails
               err
                 |> Expect.equal (Http.BadBody "Error in $: parsing Text failed, expected String, but encountered Number")
@@ -114,7 +114,7 @@ tests =
       test "Http.Mock.stub" <| \_ -> do
         urlsAccessed <-
           Http.Mock.stub
-            [Http.Mock.mkStub (\req -> Task.succeed (Http.url req, "Response!" :: Text))]
+            [Http.Mock.mkStub (\req -> Task.succeed (Http.url req, "Response!") :: Task Http.Error (Text, Text))]
             ( \http ->
                 Expect.succeeds <| do
                   _ <- Http.get http "example.com/one" Http.expectText
@@ -127,33 +127,45 @@ tests =
         withServer
           (constant "Some text" Status.ok200)
           ( \http url -> do
-            res <-
-              Http.get http url (Http.expectTextResponse Ok)
-                |> Expect.succeeds
-            case res of
-              Http.GoodStatus_ metadata body -> do
-                Expect.equal 200 (Http.metadataStatusCode metadata)
-                Expect.equal "OK" (Http.metadataStatusText metadata)
-                Expect.equal "Some text" body
-              other ->
-                Expect.fail <| "Unexpected response: " ++ (Text.fromList <| Prelude.show other)
+              res <-
+                Http.get http url (Http.expectTextResponse Ok)
+                  |> Expect.succeeds
+              case res of
+                Http.GoodStatus_ metadata body -> do
+                  Expect.equal 200 (Http.metadataStatusCode metadata)
+                  Expect.equal "OK" (Http.metadataStatusText metadata)
+                  Expect.equal "Some text" body
+                other ->
+                  Expect.fail <| "Unexpected response: " ++ (Text.fromList <| Prelude.show other)
           ),
       test "Using expectBytesResponse, we can read the body when the request is not successful" <| \() ->
         withServer
           (constant "This is a bad request" Status.badRequest400)
           ( \http url -> do
-            res <-
-              Http.get http url (Http.expectBytesResponse Ok)
-                |> Expect.succeeds
-            case res of
-              Http.BadStatus_ metadata body -> do
-                Expect.equal 400 (Http.metadataStatusCode metadata)
-                Expect.equal "Bad Request" (Http.metadataStatusText metadata)
-                Expect.equal "This is a bad request" body
-              other ->
-                Expect.fail <| "Unexpected response: " ++ (Text.fromList <| Prelude.show other)
+              res <-
+                Http.get http url (Http.expectBytesResponse Ok)
+                  |> Expect.succeeds
+              case res of
+                Http.BadStatus_ metadata body -> do
+                  Expect.equal 400 (Http.metadataStatusCode metadata)
+                  Expect.equal "Bad Request" (Http.metadataStatusText metadata)
+                  Expect.equal "This is a bad request" body
+                other ->
+                  Expect.fail <| "Unexpected response: " ++ (Text.fromList <| Prelude.show other)
+          ),
+      test "We can use a custom error type" <| \() ->
+        withServer
+          (constant "This is a bad request" Status.badRequest400)
+          ( \http url -> do
+              res <-
+                Http.get http url (Http.expectTextResponse (\_ -> Err CustomResponseError)) |> Expect.fails
+              case res of
+                CustomResponseError ->
+                  Expect.pass
           )
     ]
+
+data CustomResponseError = CustomResponseError
 
 -- # Wai applications to test against
 -- WAI NOT?

--- a/nri-http/test/golden-results/expected-http-span
+++ b/nri-http/test/golden-results/expected-http-span
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "main"
             , srcLocModule = "Main"
             , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 221
+            , srcLocStartLine = 233
             , srcLocStartCol = 7
-            , srcLocEndLine = 225
+            , srcLocEndLine = 237
             , srcLocEndCol = 40
             }
         )
@@ -31,9 +31,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Http"
                     , srcLocFile = "src/Http.hs"
-                    , srcLocStartLine = 428
+                    , srcLocStartLine = 434
                     , srcLocStartCol = 11
-                    , srcLocEndLine = 440
+                    , srcLocEndLine = 446
                     , srcLocEndCol = 14
                     }
                 )


### PR DESCRIPTION
This PR adds custom errors to `expectTextResponse` and `expectStringResponse`.

Instead of returning an `Http.Error`, we can now return any error:

```haskell
data MyCustomError
  = ClassroomDisabled
  | AnyOtherError

call :: Http.Handler -> Text -> Task MyCustomError Text
call handler url =
  Http.get
    handler
    url
    Http.expectTextResponse
      ( \response ->
        case response of
          BadStatus_ metadata body ->
            case Http.metadataStatusCode metadata of
              403 ->
                ClassroomDisabled
              _ ->
                AnyOtherError
          GoodStatus _ body ->
            Ok body
          _ ->
            AnyOtherError
      )
```