### PR TITLE
Add convenience types

### DIFF
--- a/nri-http/CHANGELOG.md
+++ b/nri-http/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.0.0
+
+- Add convenience types.
+
 # 0.2.0.0
 
 - Use custom errors.

--- a/nri-http/nri-http.cabal
+++ b/nri-http/nri-http.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           nri-http
-version:        0.2.0.0
+version:        0.3.0.0
 synopsis:       Make Elm style HTTP requests
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-http#readme>.
 category:       Web

--- a/nri-http/package.yaml
+++ b/nri-http/package.yaml
@@ -2,7 +2,7 @@ name: nri-http
 synopsis: Make Elm style HTTP requests
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-http#readme>.
 author: NoRedInk
-version: 0.2.0.0
+version: 0.3.0.0
 maintainer: haskell-open-source@noredink.com
 copyright: 2022 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-http

--- a/nri-http/src/Http/Internal.hs
+++ b/nri-http/src/Http/Internal.hs
@@ -17,25 +17,28 @@ import Prelude (IO)
 
 -- | A handler for making HTTP requests.
 data Handler = Handler
-  { handlerRequest :: forall e expect. (Dynamic.Typeable expect, Dynamic.Typeable e) => Request e expect -> Task e expect,
+  { handlerRequest :: forall e expect. (Dynamic.Typeable expect, Dynamic.Typeable e) => Request' e expect -> Task e expect,
     handlerWithThirdParty :: forall e a. (HTTP.Manager -> Task e a) -> Task e a,
     handlerWithThirdPartyIO :: forall a. Platform.LogHandler -> (HTTP.Manager -> IO a) -> IO a
   }
 
+-- | A simple request with the built-in 'Error' type.
+type Request a = Request' Error a
+
 -- | A custom request.
-data Request x a = Request
+data Request' x a = Request
   { -- | The request method, like @"GET"@ or @"PUT"@.
     method :: Text,
     -- | A list of request headers.
     headers :: [Header],
-    -- | The url, like @"https://fishes.com/salmon"@.
+    -- | The url, like @\"https://fishes.com/salmon\"@.
     url :: Text,
     -- | The request body.
     body :: Body,
     -- | The amount of microseconds you're willing to wait before giving up.
     timeout :: Maybe Int,
     -- | The type of response you expect back from the request.
-    expect :: Expect x a
+    expect :: Expect' x a
   }
 
 -- | An HTTP header for configuration requests.
@@ -48,14 +51,16 @@ data Body = Body
     bodyContentType :: Maybe Mime.MimeType
   }
 
--- |
--- Logic for interpreting a response body.
-data Expect x a where
-  ExpectJson :: Aeson.FromJSON a => Expect Error a
-  ExpectText :: Expect Error Text
-  ExpectWhatever :: Expect Error ()
-  ExpectTextResponse :: (Response Text -> Result x a) -> Expect x a
-  ExpectBytesResponse :: (Response Data.ByteString.ByteString -> Result x a) -> Expect x a
+-- | A simple logic for interpreting a response body with the built-in 'Error' type.
+type Expect a = Expect' Error a
+
+-- | Logic for interpreting a response body.
+data Expect' x a where
+  ExpectJson :: Aeson.FromJSON a => Expect a
+  ExpectText :: Expect Text
+  ExpectWhatever :: Expect ()
+  ExpectTextResponse :: (Response Text -> Result x a) -> Expect' x a
+  ExpectBytesResponse :: (Response Data.ByteString.ByteString -> Result x a) -> Expect' x a
 
 -- | A 'Request' can fail in a couple of ways:
 --

--- a/nri-http/test/Main.hs
+++ b/nri-http/test/Main.hs
@@ -58,7 +58,7 @@ tests =
           (constant "12" Status.ok200)
           ( \http url -> do
               err <-
-                Http.get http url (Http.expectJson :: Http.Expect Http.Error Text)
+                Http.get http url (Http.expectJson :: Http.Expect Text)
                   |> Expect.fails
               err
                 |> Expect.equal (Http.BadBody "Error in $: parsing Text failed, expected String, but encountered Number")

--- a/nri-http/test/golden-results/expected-http-span
+++ b/nri-http/test/golden-results/expected-http-span
@@ -31,9 +31,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Http"
                     , srcLocFile = "src/Http.hs"
-                    , srcLocStartLine = 434
+                    , srcLocStartLine = 436
                     , srcLocStartCol = 11
-                    , srcLocEndLine = 446
+                    , srcLocEndLine = 448
                     , srcLocEndCol = 14
                     }
                 )


### PR DESCRIPTION
This PR set the following convenience types in `nri-http`:
```haskell
type Request a = Request' Error a
type Expect a = Expect' Error a
```

Unfortunately this is a breaking change again, but it should make upgrades much easier.