### PR TITLE
Share compression settings between worker and none-worker settings

### DIFF
--- a/nri-kafka/src/Kafka/Settings.hs
+++ b/nri-kafka/src/Kafka/Settings.hs
@@ -11,7 +11,6 @@ where
 import qualified Environment
 import qualified Kafka.Producer
 import qualified Kafka.Settings.Internal as Internal
-import Kafka.Types (KafkaCompressionCodec (..))
 
 -- | Settings required to write to Kafka
 data Settings = Settings
@@ -24,7 +23,7 @@ data Settings = Settings
     -- | Number of messages to batch together before sending to Kafka.
     batchNumMessages :: BatchNumMessages,
     -- | Compression codec used for topics
-    compressionCodec :: KafkaCompressionCodec
+    compressionCodec :: Internal.KafkaCompressionCodec
   }
 
 -- | Number of messages to batch together before sending to Kafka.
@@ -47,7 +46,7 @@ decoder =
     Internal.decoderKafkaLogLevel
     decoderDeliveryTimeout
     decoderBatchNumMessages
-    decodeCompressionCodec
+    Internal.decoderCompressionCodec
 
 decoderDeliveryTimeout :: Environment.Decoder Kafka.Producer.Timeout
 decoderDeliveryTimeout =
@@ -68,23 +67,3 @@ decoderBatchNumMessages =
         Environment.defaultValue = "10000"
       }
     (map BatchNumMessages Environment.int)
-
-decodeCompressionCodec :: Environment.Decoder KafkaCompressionCodec
-decodeCompressionCodec =
-  Environment.variable
-    Environment.Variable
-      { Environment.name = "KAFKA_COMPRESSION_CODEC",
-        Environment.description = "Compression codec used for topics. Supported values are: NoCopmression, Gzip, Snappy and Lz4",
-        Environment.defaultValue = "Snappy"
-      }
-    ( Environment.custom
-        Environment.text
-        ( \text ->
-            case text of
-              "NoCompression" -> Ok NoCompression
-              "Gzip" -> Ok Gzip
-              "Snappy" -> Ok Snappy
-              "Lz4" -> Ok Lz4
-              _ -> Err ("Unrecognized compression codec: " ++ text)
-        )
-    )

--- a/nri-kafka/src/Kafka/Settings/Internal.hs
+++ b/nri-kafka/src/Kafka/Settings/Internal.hs
@@ -28,20 +28,17 @@ decoderKafkaLogLevel =
         Environment.description = "Kafka log level",
         Environment.defaultValue = "Debug"
       }
-    (map kafkaLogLevelFromText Environment.text)
-
-kafkaLogLevelFromText :: Text -> Kafka.Types.KafkaLogLevel
-kafkaLogLevelFromText text =
-  case text of
-    "Emerg" -> Kafka.Types.KafkaLogEmerg
-    "Alert" -> Kafka.Types.KafkaLogAlert
-    "Crit" -> Kafka.Types.KafkaLogCrit
-    "Err" -> Kafka.Types.KafkaLogErr
-    "Warning" -> Kafka.Types.KafkaLogWarning
-    "Notice" -> Kafka.Types.KafkaLogNotice
-    "Info" -> Kafka.Types.KafkaLogInfo
-    "Debug" -> Kafka.Types.KafkaLogDebug
-    _ -> Kafka.Types.KafkaLogDebug
+    ( Environment.enum
+        [ ("Emerg", Kafka.Types.KafkaLogEmerg),
+          ("Alert", Kafka.Types.KafkaLogAlert),
+          ("Crit", Kafka.Types.KafkaLogCrit),
+          ("Err", Kafka.Types.KafkaLogErr),
+          ("Warning", Kafka.Types.KafkaLogWarning),
+          ("Notice", Kafka.Types.KafkaLogNotice),
+          ("Info", Kafka.Types.KafkaLogInfo),
+          ("Debug", Kafka.Types.KafkaLogDebug)
+        ]
+    )
 
 decoderCompressionCodec :: Environment.Decoder Kafka.Types.KafkaCompressionCodec
 decoderCompressionCodec =
@@ -51,14 +48,10 @@ decoderCompressionCodec =
         Environment.description = "Compression codec used for topics. Supported values are: NoCopmression, Gzip, Snappy and Lz4",
         Environment.defaultValue = "Snappy"
       }
-    ( Environment.custom
-        Environment.text
-        ( \text ->
-            case text of
-              "NoCompression" -> Ok Kafka.Types.NoCompression
-              "Gzip" -> Ok Kafka.Types.Gzip
-              "Snappy" -> Ok Kafka.Types.Snappy
-              "Lz4" -> Ok Kafka.Types.Lz4
-              _ -> Err ("Unrecognized compression codec: " ++ text)
-        )
+    ( Environment.enum
+        [ ("NoCompression", Kafka.Types.NoCompression),
+          ("Gzip", Kafka.Types.Gzip),
+          ("Snappy", Kafka.Types.Snappy),
+          ("Lz4", Kafka.Types.Lz4)
+        ]
     )

--- a/nri-kafka/src/Kafka/Settings/Internal.hs
+++ b/nri-kafka/src/Kafka/Settings/Internal.hs
@@ -1,7 +1,9 @@
 module Kafka.Settings.Internal
   ( Kafka.Types.KafkaLogLevel (..),
+    Kafka.Types.KafkaCompressionCodec (..),
     decoderBrokerAddresses,
     decoderKafkaLogLevel,
+    decoderCompressionCodec,
   )
 where
 
@@ -40,3 +42,23 @@ kafkaLogLevelFromText text =
     "Info" -> Kafka.Types.KafkaLogInfo
     "Debug" -> Kafka.Types.KafkaLogDebug
     _ -> Kafka.Types.KafkaLogDebug
+
+decoderCompressionCodec :: Environment.Decoder Kafka.Types.KafkaCompressionCodec
+decoderCompressionCodec =
+  Environment.variable
+    Environment.Variable
+      { Environment.name = "KAFKA_COMPRESSION_CODEC",
+        Environment.description = "Compression codec used for topics. Supported values are: NoCopmression, Gzip, Snappy and Lz4",
+        Environment.defaultValue = "Snappy"
+      }
+    ( Environment.custom
+        Environment.text
+        ( \text ->
+            case text of
+              "NoCompression" -> Ok Kafka.Types.NoCompression
+              "Gzip" -> Ok Kafka.Types.Gzip
+              "Snappy" -> Ok Kafka.Types.Snappy
+              "Lz4" -> Ok Kafka.Types.Lz4
+              _ -> Err ("Unrecognized compression codec: " ++ text)
+        )
+    )


### PR DESCRIPTION
This is based on #66 (merge that first)
Cleaning up nri-kafka settings. There was a shared module (I forgot).