### PR TITLE
Support testing conflicts in Postgres transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,12 @@ nri-postgresql/nri-postgresql.cabal: nri-postgresql/package.yaml
 ghcid-nri-postgresql: nri-postgresql/nri-postgresql.cabal
 	cd nri-postgresql && ghcid
 
+setup-postgresql:
+	cd nri-postgresql && ./setup-postgres.sh
+
+ghcid-nri-postgresql-test: setup-postgresql nri-postgresql/nri-postgresql.cabal
+	cd nri-postgresql && ghcid --command "PGDATABASE=testdb PGPORT=5432 PGHOST=localhost cabal repl nri-postgresql:test:tests" --test Main.main
+
 nri-redis/nri-redis.cabal: nri-redis/package.yaml
 	hpack nri-redis
 

--- a/nri-http/src/Http.hs
+++ b/nri-http/src/Http.hs
@@ -58,7 +58,7 @@ import qualified Data.Text.Encoding
 import qualified Data.Text.Lazy
 import qualified Data.Text.Lazy.Encoding
 import qualified Dict
-import Http.Internal (Body, Expect, Handler, Expect')
+import Http.Internal (Body, Expect, Expect', Handler)
 import qualified Http.Internal as Internal
 import qualified Log.HttpRequest as HttpRequest
 import qualified Maybe

--- a/nri-postgresql/nri-postgresql.cabal
+++ b/nri-postgresql/nri-postgresql.cabal
@@ -90,6 +90,7 @@ test-suite tests
       Postgres.Test
       Postgres.TH
       Postgres.Time
+      ConflictTest
       Enum
       ObservabilitySpec
       PostgresSettingsSpec

--- a/nri-postgresql/run-tests.sh
+++ b/nri-postgresql/run-tests.sh
@@ -2,29 +2,7 @@
 
 set -euxo pipefail
 
-## start postgres
-mkdir -p "../_build/postgres/data"
-PGDATA="$(realpath ../_build/postgres/data)"
-export PGDATA
-export PGUSER=$USER
-pg_ctl stop || true
-rm -rf "$PGDATA"
-initdb --no-locale --encoding=UTF8
-pg_ctl start -o '-k . -p 5432'
-
-createdb testdb --host=localhost --port=5432 --username=$USER
-
-export PGHOST=localhost
-export PGPORT=5432
-export PGDATABASE=testdb
-
-## Setup for test/Enum.hs
-psql -c "CREATE TYPE test_enum as ENUM ('value_1', 'value_2')"
-psql -c "CREATE TABLE test_table (enum_col test_enum NOT NULL)"
-psql -c "CREATE TABLE test_table2 (enum_array_col test_enum[] NOT NULL)"
-
-## Setup for test/Test.hs
-psql -c "CREATE TABLE constraints_table (user_id int PRIMARY KEY)"
+./setup-postgres.sh
 
 cabal build
 cabal test

--- a/nri-postgresql/run-tests.sh
+++ b/nri-postgresql/run-tests.sh
@@ -23,6 +23,8 @@ psql -c "CREATE TYPE test_enum as ENUM ('value_1', 'value_2')"
 psql -c "CREATE TABLE test_table (enum_col test_enum NOT NULL)"
 psql -c "CREATE TABLE test_table2 (enum_array_col test_enum[] NOT NULL)"
 
+## Setup for test/Test.hs
+psql -c "CREATE TABLE constraints_table (user_id int PRIMARY KEY)"
 
 cabal build
 cabal test

--- a/nri-postgresql/run-tests.sh
+++ b/nri-postgresql/run-tests.sh
@@ -10,7 +10,18 @@ export PGUSER=$USER
 pg_ctl stop || true
 rm -rf "$PGDATA"
 initdb --no-locale --encoding=UTF8
-pg_ctl start -o '-k .'
+pg_ctl start -o '-k . -p 5432'
+
+createdb testdb --host=localhost --port=5432 --username=$USER
+
+export PGHOST=localhost
+export PGPORT=5432
+export PGDATABASE=testdb
+
+## Setup for test/Enum.hs
+psql -c "CREATE TYPE test_enum as ENUM ('value_1', 'value_2')"
+psql -c "CREATE TABLE test_table (enum_col test_enum NOT NULL)"
+psql -c "CREATE TABLE test_table2 (enum_array_col test_enum[] NOT NULL)"
 
 
 cabal build

--- a/nri-postgresql/setup-postgres.sh
+++ b/nri-postgresql/setup-postgres.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+## start postgres
+mkdir -p "../_build/postgres/data"
+PGDATA="$(realpath ../_build/postgres/data)"
+export PGDATA
+export PGUSER=$USER
+pg_ctl stop || true
+rm -rf "$PGDATA"
+initdb --no-locale --encoding=UTF8
+pg_ctl start -o '-k . -p 5432'
+
+createdb testdb --host=localhost --port=5432 --username=$USER
+
+export PGHOST=localhost
+export PGPORT=5432
+export PGDATABASE=testdb
+
+## Setup for test/Enum.hs
+psql -c "CREATE TYPE test_enum as ENUM ('value_1', 'value_2')"
+psql -c "CREATE TABLE test_table (enum_col test_enum NOT NULL)"
+psql -c "CREATE TABLE test_table2 (enum_array_col test_enum[] NOT NULL)"
+
+## Setup for test/Test.hs
+psql -c "CREATE TABLE constraints_table (user_id int PRIMARY KEY)"

--- a/nri-postgresql/setup-postgres.sh
+++ b/nri-postgresql/setup-postgres.sh
@@ -17,9 +17,9 @@ export PGPORT=5432
 export PGDATABASE=testdb
 
 ## Setup for test/Enum.hs
-psql -c "CREATE TYPE test_enum as ENUM ('value_1', 'value_2')"
-psql -c "CREATE TABLE test_table (enum_col test_enum NOT NULL)"
-psql -c "CREATE TABLE test_table2 (enum_array_col test_enum[] NOT NULL)"
+psql -c "CREATE TYPE test_enum as ENUM ('value_1', 'value_2')" || true
+psql -c "CREATE TABLE test_table (enum_col test_enum NOT NULL)" || true
+psql -c "CREATE TABLE test_table2 (enum_array_col test_enum[] NOT NULL)" || true
 
 ## Setup for test/Test.hs
-psql -c "CREATE TABLE constraints_table (user_id int PRIMARY KEY)"
+psql -c "CREATE TABLE constraints_table (user_id int PRIMARY KEY)" || true

--- a/nri-postgresql/src/Postgres.hs
+++ b/nri-postgresql/src/Postgres.hs
@@ -89,7 +89,7 @@ inTestTransaction conn func =
       --
       end :: Platform.Succeeded -> PGConnection -> Task x ()
       end _ c =
-        rollbackAllSafe conn c
+        doIO conn <| pgRollbackAll c
       --
       setSingle :: PGConnection -> Connection
       setSingle c =

--- a/nri-postgresql/src/Postgres/Enum.hs
+++ b/nri-postgresql/src/Postgres/Enum.hs
@@ -3,11 +3,11 @@
 -- | Provides a functionality for generating a bridge between a Haskell type and a Postgres enum type using Template Haskell.
 --
 -- Image that we have an `animal_type` defined on our Postgres database:
--- 
+--
 -- > CREATE TYPE schema_name.animal_type AS ENUM ('cat', 'dog', 'snake')
 --
--- Then we can define an equivalent type in Haskell like so: 
--- 
+-- Then we can define an equivalent type in Haskell like so:
+--
 -- > {-# LANGUAGE TemplateHaskell #-}
 -- > {-# LANGUAGE TypeFamilies #-}
 -- > {-# OPTIONS -Wno-orphans #-}
@@ -19,125 +19,122 @@
 -- >   | Dog
 -- >   | Snake
 -- >
--- > $(generatePGEnum ''AnimalType "schema_name.animal_type" 
+-- > $(generatePGEnum ''AnimalType "schema_name.animal_type"
 -- >    [ ('Cat, "cat")
 -- >    , ('Dog, "dog")
 -- >    , ('Snake, "snake")
 -- >    ]
 -- >  )
 --
--- Note: Having the same type name in different schema's might cause overlapping instances in different modules! 
+-- Note: Having the same type name in different schema's might cause overlapping instances in different modules!
 -- (It's not our fault, this is how postgresql-typed works 🤷‍♂️)
-module Postgres.Enum (
-  generatePGEnum
-) where
+module Postgres.Enum
+  ( generatePGEnum,
+  )
+where
 
-import qualified Environment
-import qualified Postgres.Settings
+import qualified Control.Exception
 import qualified Data.ByteString.Lazy as BSL
 import Data.List (group)
 import qualified Data.Text.Encoding as Encoding
-import qualified Language.Haskell.TH as TH
 import Database.PostgreSQL.Typed.Array (PGArray, PGArrayType, PGElemType)
+import Database.PostgreSQL.Typed.Dynamic (PGRep, PGRepType, pgDecodeRep)
 import Database.PostgreSQL.Typed.Protocol (pgSimpleQuery)
-import Database.PostgreSQL.Typed.TH (withTPGConnection, useTPGDatabase)
-import Database.PostgreSQL.Typed.Dynamic (pgDecodeRep, PGRepType, PGRep)
-import Database.PostgreSQL.Typed.Types (PGType, PGVal, PGParameter, pgEncode, PGColumn, pgDecode)
+import Database.PostgreSQL.Typed.TH (useTPGDatabase, withTPGConnection)
+import Database.PostgreSQL.Typed.Types (PGColumn, PGParameter, PGType, PGVal, pgDecode, pgEncode)
+import qualified Environment
+import qualified Language.Haskell.TH as TH
+import qualified Postgres.Settings
 import qualified Set
-import Prelude (pure, fail, Either(..), String, show, error, traverse)
-import qualified Control.Exception 
+import Prelude (Either (..), String, error, fail, pure, show, traverse)
 
 quote :: String -> String
 quote t = "\"" ++ t ++ "\""
 
 findDuplicates :: (Ord a) => List a -> List a
-findDuplicates list = 
+findDuplicates list =
   list
-    |> List.sort 
+    |> List.sort
     |> group
     |> List.filterMap (List.drop 1 >> List.head)
 
 unexpectedValue :: String -> a
-unexpectedValue value = 
+unexpectedValue value =
   error <| "Unexpected enum value " ++ quote value ++ " encountered. Perhaps your database is out of sync with your compiled executabe?"
 
 -- | Generate the bridge to allow converting back and forth between the given Haskell data type and Postgres enum type.
--- 
+--
 -- This is intended to be used in a TemplateHaskell splice and will generate the `PGType`, `PGParameter`, `PGColumn`, and `PGRep` instances.
 --
 -- `generatePGEnum` will check at compile time that our mapping is one-to-one between the Haskell datatype and Postgres enum type.
-generatePGEnum :: TH.Name           -- ^ The name of the Haskell data type
-               -> Text              -- ^ The name of the Postgres enum type (optionally can have a schema)
-               -> [(TH.Name, Text)] -- ^ A list of mappings between constructors of the datatype and enum values from Postgres
-               -> TH.Q [TH.Dec]
-generatePGEnum hsTypeName databaseTypeName mapping = do 
+generatePGEnum ::
+  -- | The name of the Haskell data type
+  TH.Name ->
+  -- | The name of the Postgres enum type (optionally can have a schema)
+  Text ->
+  -- | A list of mappings between constructors of the datatype and enum values from Postgres
+  [(TH.Name, Text)] ->
+  TH.Q [TH.Dec]
+generatePGEnum hsTypeName databaseTypeName mapping = do
   let hsTypeString = show hsTypeName
 
   info <- TH.reify hsTypeName
 
   conNames <-
-    case info of 
+    case info of
       TH.TyConI (TH.DataD _ _ _ _ constructors _) ->
         constructors
-          |> traverse (\con -> case con of 
+          |> traverse
+            ( \con -> case con of
                 TH.NormalC name [] ->
                   pure name
-
                 TH.NormalC name _ ->
                   fail <| "Constructor " ++ quote (show name) ++ " cannot have any arguments in order to be mapped to an enum."
-
-                _ -> 
+                _ ->
                   fail <| "Data type " ++ quote hsTypeString ++ " must contain only simple constructors with no arguments."
-              )
-
+            )
       _ ->
         fail <| "The datatype name " ++ quote hsTypeString ++ " must be a data declaration."
 
   -- Check for duplicate values specified in the mapping
-  _ <- 
-    case findDuplicates (List.map Tuple.second mapping) of 
-      [] -> 
-        pure () 
-
+  _ <-
+    case findDuplicates (List.map Tuple.second mapping) of
+      [] ->
+        pure ()
       duplicates ->
         fail <| "The following values in the mapping are duplicated: " ++ show duplicates
 
   -- Check for duplicate constructor names specified in the mapping
   _ <-
     case findDuplicates (List.map Tuple.first mapping) of
-      [] -> 
+      [] ->
         pure ()
-
       duplicates ->
         fail <| "The following constructors in the mapping are duplicated: " ++ show duplicates
 
   let hsConSet = Set.fromList conNames
   let mappingConSet = Set.fromList (List.map Tuple.first mapping)
 
-  _ <- 
-    case (Set.toList (Set.diff hsConSet mappingConSet), Set.toList (Set.diff mappingConSet hsConSet)) of 
-      ([], []) -> 
+  _ <-
+    case (Set.toList (Set.diff hsConSet mappingConSet), Set.toList (Set.diff mappingConSet hsConSet)) of
+      ([], []) ->
         pure ()
-
       ([], mappingOnlyCons) ->
         fail <| "The following names in the mapping are not constructors from the data type " ++ quote hsTypeString ++ ": " ++ show mappingOnlyCons
-
-      (hsOnlyCons, _) -> 
+      (hsOnlyCons, _) ->
         fail <| "The following constructors are not present in the mapping: " ++ show hsOnlyCons
 
   (type_schema_name, type_enum_name) <-
-        case Text.split "." databaseTypeName of 
-          [schema, enum] ->
-            pure (schema, enum)
-
-          [enum] ->
-            pure ("public", enum)
-
-          _ ->
-            fail <| "Invalid database enum name \"" ++ (show databaseTypeName) ++ "\""
+    case Text.split "." databaseTypeName of
+      [schema, enum] ->
+        pure (schema, enum)
+      [enum] ->
+        pure ("public", enum)
+      _ ->
+        fail <| "Invalid database enum name \"" ++ (show databaseTypeName) ++ "\""
 
   pgDatabase <-
-    TH.runIO <| do 
+    TH.runIO <| do
       nriSettings <- Environment.decode Postgres.Settings.decoder
       pure (Postgres.Settings.toPGDatabase nriSettings)
 
@@ -145,85 +142,97 @@ generatePGEnum hsTypeName databaseTypeName mapping = do
 
   -- Note: We make sure to capture IO errors and re-throw them below in the Q monad so that our test framework can capture them
   (maybePGEnumValues :: Either Control.Exception.IOException (List Text)) <-
-    TH.runIO <| Control.Exception.try <| withTPGConnection (\connection -> do 
-      -- Check if the databaseTypeName exists on the PG database and is an enum
-      -- See https://www.postgresql.org/docs/current/catalog-pg-type.html
-      typeType <-
-        pgSimpleQuery connection (BSL.fromChunks
-          [ "SELECT typtype"
-          , " FROM pg_catalog.pg_type"
-          , " JOIN pg_catalog.pg_namespace ON pg_namespace.oid = pg_type.typnamespace"
-          , " WHERE pg_type.typname = '", Encoding.encodeUtf8 type_enum_name, "'", " AND pg_namespace.nspname = '", Encoding.encodeUtf8 type_schema_name, "'"
-          ])
-          |> fmap (\(_, rows) ->
-                rows
-                  |> List.filterMap (\cols ->
-                      case cols of 
-                        [enumlabel] ->
-                          Just (pgDecodeRep enumlabel)
+    TH.runIO <| Control.Exception.try
+      <| withTPGConnection
+        ( \connection -> do
+            -- Check if the databaseTypeName exists on the PG database and is an enum
+            -- See https://www.postgresql.org/docs/current/catalog-pg-type.html
+            typeType <-
+              pgSimpleQuery
+                connection
+                ( BSL.fromChunks
+                    [ "SELECT typtype",
+                      " FROM pg_catalog.pg_type",
+                      " JOIN pg_catalog.pg_namespace ON pg_namespace.oid = pg_type.typnamespace",
+                      " WHERE pg_type.typname = '",
+                      Encoding.encodeUtf8 type_enum_name,
+                      "'",
+                      " AND pg_namespace.nspname = '",
+                      Encoding.encodeUtf8 type_schema_name,
+                      "'"
+                    ]
+                )
+                |> fmap
+                  ( \(_, rows) ->
+                      rows
+                        |> List.filterMap
+                          ( \cols ->
+                              case cols of
+                                [enumlabel] ->
+                                  Just (pgDecodeRep enumlabel)
+                                _ ->
+                                  Nothing
+                          )
+                  )
 
-                        _ -> 
-                          Nothing   
-                    )
-          )
+            _ <- case typeType of
+              [] ->
+                fail ("Type " ++ quote (Text.toList databaseTypeName) ++ " does not exist on the database.")
+              -- 'e' means enum type
+              ['e'] ->
+                pure ()
+              _ ->
+                fail ("Type " ++ quote (Text.toList databaseTypeName) ++ " is not an enum type.")
 
-      _ <- case typeType of 
-        [] -> 
-          fail ("Type " ++ quote (Text.toList databaseTypeName) ++ " does not exist on the database.")
-        
-        -- 'e' means enum type
-        ['e'] -> 
-          pure ()
-        
-        _ -> 
-          fail ("Type " ++ quote (Text.toList databaseTypeName) ++ " is not an enum type.")
+            enumLabels <-
+              pgSimpleQuery
+                connection
+                ( BSL.fromChunks
+                    [ "SELECT enumlabel",
+                      " FROM pg_catalog.pg_enum",
+                      " WHERE enumtypid = '",
+                      Encoding.encodeUtf8 databaseTypeName,
+                      "'::regtype",
+                      " ORDER BY enumsortorder"
+                    ]
+                )
+                |> fmap
+                  ( \(_, rows) ->
+                      rows
+                        |> List.filterMap
+                          ( \cols ->
+                              case cols of
+                                [enumlabel] ->
+                                  Just (pgDecodeRep enumlabel)
+                                _ ->
+                                  Nothing
+                          )
+                  )
 
-      enumLabels <- 
-        pgSimpleQuery connection (BSL.fromChunks
-          [ "SELECT enumlabel"
-          , " FROM pg_catalog.pg_enum"
-          , " WHERE enumtypid = '", Encoding.encodeUtf8 databaseTypeName, "'::regtype"
-          , " ORDER BY enumsortorder"
-          ])
-          |> fmap (\(_, rows) ->
-                rows
-                  |> List.filterMap (\cols ->
-                      case cols of 
-                        [enumlabel] ->
-                          Just (pgDecodeRep enumlabel)
-
-                        _ -> 
-                          Nothing   
-                    )
-          )
-        
-      case enumLabels of 
-        [] -> 
-          fail ("Enum type " ++ quote (Text.toList databaseTypeName) ++ " does not contain any values.")
-
-        vs -> 
-          pure vs
-    )
+            case enumLabels of
+              [] ->
+                fail ("Enum type " ++ quote (Text.toList databaseTypeName) ++ " does not contain any values.")
+              vs ->
+                pure vs
+        )
 
   (pgEnumValues :: List Text) <-
-    case maybePGEnumValues of 
-      Left err -> 
+    case maybePGEnumValues of
+      Left err ->
         fail (show err)
       Right vals ->
         pure vals
 
   let pgValuesSet = Set.fromList pgEnumValues
-  let mappingValuesSet = Set.fromList (List.map Tuple.second mapping) 
+  let mappingValuesSet = Set.fromList (List.map Tuple.second mapping)
 
-  _ <- 
-    case (Set.toList (Set.diff pgValuesSet mappingValuesSet), Set.toList (Set.diff mappingValuesSet pgValuesSet)) of 
-      ([], []) -> 
+  _ <-
+    case (Set.toList (Set.diff pgValuesSet mappingValuesSet), Set.toList (Set.diff mappingValuesSet pgValuesSet)) of
+      ([], []) ->
         pure ()
-
       ([], hsOnlyValues) ->
         fail <| "The following values of type " ++ quote hsTypeString ++ " are not mapped to values of pg enum type " ++ quote (Text.toList databaseTypeName) ++ ": " ++ show hsOnlyValues
-
-      (pgOnlyValues, _) -> 
+      (pgOnlyValues, _) ->
         fail <| "The following values from the pg enum type " ++ quote (Text.toList databaseTypeName) ++ " are not mapped to values of " ++ quote hsTypeString ++ ": " ++ show pgOnlyValues
 
   -- Validation passed! Let's generate some instances
@@ -240,27 +249,41 @@ generatePGEnum hsTypeName databaseTypeName mapping = do
 
   -- Note: Most of these instance definitions borrowed from https://hackage.haskell.org/package/postgresql-typed-0.6.2.1/docs/src/Database.PostgreSQL.Typed.Enum.html
 
-  -- case x of 
+  -- case x of
   --   Labeled -> "labeled"
   --   Blank -> "blank"
-  let hsToPg = TH.CaseE (TH.VarE varX) (mapping |> List.map (\(conName, pgValue) -> 
-                  TH.Match (TH.ConP conName []) (TH.NormalB <| TH.LitE <| TH.StringL <| Text.toList pgValue) [] 
-                ))
+  let hsToPg =
+        TH.CaseE
+          (TH.VarE varX)
+          ( mapping
+              |> List.map
+                ( \(conName, pgValue) ->
+                    TH.Match (TH.ConP conName []) (TH.NormalB <| TH.LitE <| TH.StringL <| Text.toList pgValue) []
+                )
+          )
 
-  --  case x of 
+  --  case x of
   --    "labeled" -> Labeled
   --    "blank" -> Blank
   --    _ -> unexpectedValue (Prelude.show x)
-  let pgToHs = TH.CaseE (TH.VarE varX) ((mapping |> List.map (\(conName, pgValue) ->
-                  TH.Match (TH.LitP <| TH.StringL <| Text.toList pgValue) (TH.NormalB <| TH.ConE conName) []
-                )) ++ [TH.Match TH.WildP (TH.NormalB <| TH.AppE (TH.VarE 'unexpectedValue) (TH.AppE (TH.VarE 'show) (TH.VarE varX))) [] ] )
-  
+  let pgToHs =
+        TH.CaseE
+          (TH.VarE varX)
+          ( ( mapping
+                |> List.map
+                  ( \(conName, pgValue) ->
+                      TH.Match (TH.LitP <| TH.StringL <| Text.toList pgValue) (TH.NormalB <| TH.ConE conName) []
+                  )
+            )
+              ++ [TH.Match TH.WildP (TH.NormalB <| TH.AppE (TH.VarE 'unexpectedValue) (TH.AppE (TH.VarE 'show) (TH.VarE varX))) []]
+          )
+
   [d|
     instance PGType $pgTypeString where
       type PGVal $pgTypeString = $hsType
 
     instance PGParameter $pgTypeString $hsType where
-      pgEncode _ $varXPattern = 
+      pgEncode _ $varXPattern =
         $(pure hsToPg)
 
     instance PGColumn $pgTypeString $hsType where

--- a/nri-postgresql/src/Postgres/TH.hs
+++ b/nri-postgresql/src/Postgres/TH.hs
@@ -1,12 +1,12 @@
 module Postgres.TH where
 
+import Database.PostgreSQL.Typed.TH (useTPGDatabase)
 import qualified Environment
 import qualified Language.Haskell.TH as TH
-import Database.PostgreSQL.Typed.TH (useTPGDatabase)
 import qualified Postgres.Settings
 import qualified Prelude
 
--- | Template Haskell to connect to the database using NRI settings at compile time.  
+-- | Template Haskell to connect to the database using NRI settings at compile time.
 useNRIDatabase :: TH.Q [TH.Dec]
 useNRIDatabase = do
   pgDatabase <- TH.runIO (Prelude.fmap Postgres.Settings.toPGDatabase (Environment.decode Postgres.Settings.decoder))

--- a/nri-postgresql/test/ConflictTest.hs
+++ b/nri-postgresql/test/ConflictTest.hs
@@ -2,34 +2,34 @@
 
 module ConflictTest where
 
+import qualified Expect
+import qualified Postgres
 import Test (Test)
 import qualified Test
-import qualified Postgres
-import qualified Expect
 
 expectSuccess :: Result Postgres.Error [row] -> Task Text [row]
-expectSuccess result = 
-  case result of 
+expectSuccess result =
+  case result of
     Ok rows -> Task.succeed rows
     Err err -> Task.fail <| "Unexpected postgres error: " ++ (Debug.toString err)
 
 expectError :: Result Postgres.Error [row] -> Task Text Postgres.Error
 expectError result =
-  case result of 
+  case result of
     Ok _ -> Task.fail "Expected to encounter an error"
     Err err -> Task.succeed err
 
 tests :: Postgres.Connection -> Test
 tests rawConnection =
-    Test.describe
-      "Postgres.Test"
-      [ Test.test "test transaction can recover from a conflict" <| \_ ->
-          Postgres.inTestTransaction 
-            rawConnection
-            (\connection -> do
+  Test.describe
+    "Postgres.Test"
+    [ Test.test "test transaction can recover from a conflict" <| \_ ->
+        Postgres.inTestTransaction
+          rawConnection
+          ( \connection -> do
               _ <- Postgres.doQuery connection [Postgres.sql| INSERT INTO constraints_table (user_id) VALUES (1) |] expectSuccess
               _ <- Postgres.doQuery connection [Postgres.sql| INSERT INTO constraints_table (user_id) VALUES (1) |] expectError
               Task.succeed ()
-            )
-            |> Expect.succeeds
-      ]
+          )
+          |> Expect.succeeds
+    ]

--- a/nri-postgresql/test/ConflictTest.hs
+++ b/nri-postgresql/test/ConflictTest.hs
@@ -7,11 +7,17 @@ import qualified Test
 import qualified Postgres
 import qualified Expect
 
-expectSuccess :: Result Postgres.Error [row] -> Task Postgres.Error [row]
+expectSuccess :: Result Postgres.Error [row] -> Task Text [row]
 expectSuccess result = 
   case result of 
     Ok rows -> Task.succeed rows
-    Err err -> Task.fail err
+    Err err -> Task.fail <| "Unexpected postgres error: " ++ (Debug.toString err)
+
+expectError :: Result Postgres.Error [row] -> Task Text Postgres.Error
+expectError result =
+  case result of 
+    Ok _ -> Task.fail "Expected to encounter an error"
+    Err err -> Task.succeed err
 
 tests :: Postgres.Connection -> Test
 tests rawConnection =
@@ -22,7 +28,7 @@ tests rawConnection =
             rawConnection
             (\connection -> do
               _ <- Postgres.doQuery connection [Postgres.sql| INSERT INTO constraints_table (user_id) VALUES (1) |] expectSuccess
-              _ <- Postgres.doQuery connection [Postgres.sql| INSERT INTO constraints_table (user_id) VALUES (1) |] expectSuccess
+              _ <- Postgres.doQuery connection [Postgres.sql| INSERT INTO constraints_table (user_id) VALUES (1) |] expectError
               Task.succeed ()
             )
             |> Expect.succeeds

--- a/nri-postgresql/test/ConflictTest.hs
+++ b/nri-postgresql/test/ConflictTest.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module ConflictTest where
+
+import Test (Test)
+import qualified Test
+import qualified Postgres
+import qualified Expect
+
+expectSuccess :: Result Postgres.Error [row] -> Task Postgres.Error [row]
+expectSuccess result = 
+  case result of 
+    Ok rows -> Task.succeed rows
+    Err err -> Task.fail err
+
+tests :: Postgres.Connection -> Test
+tests rawConnection =
+    Test.describe
+      "Postgres.Test"
+      [ Test.test "test transaction can recover from a conflict" <| \_ ->
+          Postgres.inTestTransaction 
+            rawConnection
+            (\connection -> do
+              _ <- Postgres.doQuery connection [Postgres.sql| INSERT INTO constraints_table (user_id) VALUES (1) |] expectSuccess
+              _ <- Postgres.doQuery connection [Postgres.sql| INSERT INTO constraints_table (user_id) VALUES (1) |] expectSuccess
+              Task.succeed ()
+            )
+            |> Expect.succeeds
+      ]

--- a/nri-postgresql/test/ConflictTest.hs
+++ b/nri-postgresql/test/ConflictTest.hs
@@ -4,32 +4,18 @@ module ConflictTest where
 
 import qualified Expect
 import qualified Postgres
+import qualified Postgres.Test
 import Test (Test)
 import qualified Test
 
-expectSuccess :: Result Postgres.Error [row] -> Task Text [row]
-expectSuccess result =
-  case result of
-    Ok rows -> Task.succeed rows
-    Err err -> Task.fail <| "Unexpected postgres error: " ++ (Debug.toString err)
-
-expectError :: Result Postgres.Error [row] -> Task Text Postgres.Error
-expectError result =
-  case result of
-    Ok _ -> Task.fail "Expected to encounter an error"
-    Err err -> Task.succeed err
-
-tests :: Postgres.Connection -> Test
-tests rawConnection =
+tests :: a -> Test
+tests _ =
   Test.describe
     "Postgres.Test"
-    [ Test.test "test transaction can recover from a conflict" <| \_ ->
-        Postgres.inTestTransaction
-          rawConnection
-          ( \connection -> do
-              _ <- Postgres.doQuery connection [Postgres.sql| INSERT INTO constraints_table (user_id) VALUES (1) |] expectSuccess
-              _ <- Postgres.doQuery connection [Postgres.sql| INSERT INTO constraints_table (user_id) VALUES (1) |] expectError
-              Task.succeed ()
-          )
-          |> Expect.succeeds
+    [ Postgres.Test.test "test transaction can recover from a conflict" <| \connection -> do
+        _ <-
+          Postgres.doQuery connection [Postgres.sql| INSERT INTO constraints_table (user_id) VALUES (1) |] Task.succeed
+            |> Expect.andCheck Expect.ok
+        Postgres.doQuery connection [Postgres.sql| INSERT INTO constraints_table (user_id) VALUES (1) |] Task.succeed
+          |> Expect.andCheck Expect.err
     ]

--- a/nri-postgresql/test/Enum.hs
+++ b/nri-postgresql/test/Enum.hs
@@ -7,7 +7,6 @@ module Enum where
 
 import Test (Test, describe)
 import qualified Test
-import qualified Database.PostgreSQL.Typed as Core
 import Postgres.Enum (generatePGEnum)
 import qualified Postgres.TH
 import qualified Language.Haskell.TH as TH
@@ -18,10 +17,6 @@ import qualified Postgres
 
 {- Set up an enum type on the database at compile time to test with -}
 Postgres.TH.useNRIDatabase
-
-[Core.pgSQL| CREATE TYPE test_enum as ENUM ('value_1', 'value_2') |]
-[Core.pgSQL| CREATE TABLE test_table (enum_col test_enum NOT NULL) |]
-[Core.pgSQL| CREATE TABLE test_table2 (enum_array_col test_enum[] NOT NULL) |]
 
 data TestEnum
   = Value1
@@ -100,7 +95,7 @@ queryTests rawConnection =
 
       -- | I'm seeing flaky results with regards to `test_table` and `test_enum` existing on the db 
       -- at the point the test is run.  Let's just drop them and re-create in each test. Since the 
-      -- compilers see's them being created at the top level above this will all typecheck.
+      -- compilers see's them being created in ./run-tests.sh above this will all typecheck.
       withContext :: (Postgres.Connection -> Task Postgres.Error a) -> Task Postgres.Error a
       withContext todo =
          Postgres.inTestTransaction rawConnection (\connection -> do

--- a/nri-postgresql/test/Enum.hs
+++ b/nri-postgresql/test/Enum.hs
@@ -1,19 +1,20 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+
 {-# OPTIONS -Wno-orphans #-}
 
 module Enum where
 
-import Test (Test, describe)
-import qualified Test
+import qualified Expect
+import qualified Language.Haskell.TH as TH
+import Language.Haskell.TH.TestUtils as THTest
+import qualified Postgres
 import Postgres.Enum (generatePGEnum)
 import qualified Postgres.TH
-import qualified Language.Haskell.TH as TH
-import qualified Expect
-import Language.Haskell.TH.TestUtils as THTest
+import Test (Test, describe)
+import qualified Test
 import qualified Prelude
-import qualified Postgres
 
 {- Set up an enum type on the database at compile time to test with -}
 Postgres.TH.useNRIDatabase
@@ -26,7 +27,7 @@ data TestEnum
 data TestNotEnum
   = NotValue Int
 
-data UndersizedEnum 
+data UndersizedEnum
   = UndersizedValue1
 
 data OversizedEnum
@@ -34,134 +35,144 @@ data OversizedEnum
   | OversizedValue2
   | OversizedValue3
 
-$(generatePGEnum ''TestEnum "test_enum"
-    [ ('Value1, "value_1")
-    , ('Value2, "value_2")
-    ]
+$( generatePGEnum
+     ''TestEnum
+     "test_enum"
+     [ ('Value1, "value_1"),
+       ('Value2, "value_2")
+     ]
  )
 
 -- | Tests that test cases we expect to get compile time failures for
--- 
+--
 -- Language.Haskell.TH has a `runQ` method which looks like it could be used
 -- to run `generatePGEnum` in a test.  But unfortunately for technical reasons
 -- `runQ` does not allow reifying names (which we use to look up the constructors of
--- `TestEnum`).  So instead we call in the `th-test-utils` library which lets us 
+-- `TestEnum`).  So instead we call in the `th-test-utils` library which lets us
 -- mock in the names that will be reified.
 generateFailureTests :: Test
-generateFailureTests =  
-  let qState = THTest.QState 
-        { THTest.mode = THTest.MockQAllowIO
-        , THTest.knownNames = []
-        , THTest.reifyInfo = $(loadNames [''TestEnum, ''UndersizedEnum, ''OversizedEnum, ''TestNotEnum])
-        }
+generateFailureTests =
+  let qState =
+        THTest.QState
+          { THTest.mode = THTest.MockQAllowIO,
+            THTest.knownNames = [],
+            THTest.reifyInfo = $(loadNames [''TestEnum, ''UndersizedEnum, ''OversizedEnum, ''TestNotEnum])
+          }
 
       expectCompileFailure :: TH.Q [TH.Dec] -> Expect.Expectation
       expectCompileFailure q = do
         either <- Expect.fromIO (THTest.tryTestQ qState q)
-        case either of 
+        case either of
           Prelude.Left _ ->
             Expect.pass
-          Prelude.Right _ -> 
+          Prelude.Right _ ->
             Expect.fail "Expected a compile time error but none were generated"
-  in
-  describe "generatePGEnum [compile-time failure]" 
-  [ Test.test "data type is not an enum" <| \_ -> 
-      expectCompileFailure (generatePGEnum ''TestNotEnum "test_enum" [('NotValue, "value_1")] )
-  , Test.test "mapping contains duplicate database values" <| \_ ->
-      expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1"), ('Value2, "value_1")] )
-  , Test.test "mapping contains duplicate constructors" <| \_ ->
-      expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1"), ('Value1, "value_2")] )
-  , Test.test "constructor not from data type" <| \_ ->
-      expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1"), ('NotValue, "value_2")] )
-  , Test.test "constructor missing from mapping" <| \_ ->
-      expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1")] )
-  , Test.test "database enum name does not exist" <| \_ ->
-      expectCompileFailure (generatePGEnum ''TestEnum "not_an_enum_name" [('Value1, "value_1"), ('Value2, "value_2")] )
-  , Test.test "database name not an enum" <| \_ ->
-      expectCompileFailure (generatePGEnum ''TestEnum "boolean" [('Value1, "value_1"), ('Value2, "value_2")] )
-  , Test.test "datatype smaller than PG enum" <| \_ ->
-      expectCompileFailure (generatePGEnum ''UndersizedEnum "test_enum" [('UndersizedValue1, "value_1")] )
-  , Test.test "datatype larger than PG enum" <| \_ ->
-      expectCompileFailure (generatePGEnum ''OversizedEnum "test_enum" [('OversizedValue1, "value_1"), ('OversizedValue2, "value_2")] )
-  ] 
+   in describe
+        "generatePGEnum [compile-time failure]"
+        [ Test.test "data type is not an enum" <| \_ ->
+            expectCompileFailure (generatePGEnum ''TestNotEnum "test_enum" [('NotValue, "value_1")]),
+          Test.test "mapping contains duplicate database values" <| \_ ->
+            expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1"), ('Value2, "value_1")]),
+          Test.test "mapping contains duplicate constructors" <| \_ ->
+            expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1"), ('Value1, "value_2")]),
+          Test.test "constructor not from data type" <| \_ ->
+            expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1"), ('NotValue, "value_2")]),
+          Test.test "constructor missing from mapping" <| \_ ->
+            expectCompileFailure (generatePGEnum ''TestEnum "test_enum" [('Value1, "value_1")]),
+          Test.test "database enum name does not exist" <| \_ ->
+            expectCompileFailure (generatePGEnum ''TestEnum "not_an_enum_name" [('Value1, "value_1"), ('Value2, "value_2")]),
+          Test.test "database name not an enum" <| \_ ->
+            expectCompileFailure (generatePGEnum ''TestEnum "boolean" [('Value1, "value_1"), ('Value2, "value_2")]),
+          Test.test "datatype smaller than PG enum" <| \_ ->
+            expectCompileFailure (generatePGEnum ''UndersizedEnum "test_enum" [('UndersizedValue1, "value_1")]),
+          Test.test "datatype larger than PG enum" <| \_ ->
+            expectCompileFailure (generatePGEnum ''OversizedEnum "test_enum" [('OversizedValue1, "value_1"), ('OversizedValue2, "value_2")])
+        ]
 
 queryTests :: Postgres.Connection -> Test
-queryTests rawConnection = 
+queryTests rawConnection =
   let expectSuccess :: Result Postgres.Error [row] -> Task Postgres.Error [row]
-      expectSuccess result = 
-        case result of 
+      expectSuccess result =
+        case result of
           Ok rows -> Task.succeed rows
           Err err -> Task.fail err
-
-      -- | I'm seeing flaky results with regards to `test_table` and `test_enum` existing on the db 
-      -- at the point the test is run.  Let's just drop them and re-create in each test. Since the 
-      -- compilers see's them being created in ./run-tests.sh above this will all typecheck.
       withContext :: (Postgres.Connection -> Task Postgres.Error a) -> Task Postgres.Error a
       withContext todo =
-         Postgres.inTestTransaction rawConnection (\connection -> do
-          _ <- Postgres.doQuery connection [Postgres.sql| DROP TABLE test_table |] expectSuccess
-          _ <- Postgres.doQuery connection [Postgres.sql| DROP TABLE test_table2 |] expectSuccess
-          _ <- Postgres.doQuery connection [Postgres.sql| DROP TYPE test_enum |] expectSuccess
-          _ <- Postgres.doQuery connection [Postgres.sql| CREATE TYPE test_enum as ENUM ('value_1', 'value_2') |] expectSuccess
-          _ <- Postgres.doQuery connection [Postgres.sql| CREATE TABLE test_table (enum_col test_enum NOT NULL) |] expectSuccess
-          _ <- Postgres.doQuery connection [Postgres.sql| CREATE TABLE test_table2 (enum_array_col test_enum[] NOT NULL) |] expectSuccess
-          todo connection
-         )
-
-  in
-  describe "Query Tests"
-  [ Test.test "Insert into column" <| \_ -> do
-      _ <- withContext (\connection ->
-            Postgres.doQuery
-              connection
-              [Postgres.sql|
+        Postgres.inTestTransaction
+          rawConnection
+          ( \connection -> do
+              _ <- Postgres.doQuery connection [Postgres.sql| DROP TABLE test_table |] expectSuccess
+              _ <- Postgres.doQuery connection [Postgres.sql| DROP TABLE test_table2 |] expectSuccess
+              _ <- Postgres.doQuery connection [Postgres.sql| DROP TYPE test_enum |] expectSuccess
+              _ <- Postgres.doQuery connection [Postgres.sql| CREATE TYPE test_enum as ENUM ('value_1', 'value_2') |] expectSuccess
+              _ <- Postgres.doQuery connection [Postgres.sql| CREATE TABLE test_table (enum_col test_enum NOT NULL) |] expectSuccess
+              _ <- Postgres.doQuery connection [Postgres.sql| CREATE TABLE test_table2 (enum_array_col test_enum[] NOT NULL) |] expectSuccess
+              todo connection
+          )
+   in describe
+        "Query Tests"
+        [ Test.test "Insert into column" <| \_ -> do
+            _ <-
+              withContext
+                ( \connection ->
+                    Postgres.doQuery
+                      connection
+                      [Postgres.sql|
                 INSERT INTO test_table (enum_col)
                 VALUES (${Value1})
               |]
-              expectSuccess
-          ) |> Expect.succeeds
+                      expectSuccess
+                )
+                |> Expect.succeeds
 
-      Expect.pass
-  , Test.test "Select from column" <| \_ -> do 
-      rows <- withContext (\connection -> do
-            _ <- Postgres.doQuery
-              connection
-              [Postgres.sql|
+            Expect.pass,
+          Test.test "Select from column" <| \_ -> do
+            rows <-
+              withContext
+                ( \connection -> do
+                    _ <-
+                      Postgres.doQuery
+                        connection
+                        [Postgres.sql|
                 INSERT INTO test_table (enum_col)
                 VALUES (${Value1}), (${Value2})
               |]
-              expectSuccess
-            
-            Postgres.doQuery
-              connection
-              [Postgres.sql|
+                        expectSuccess
+
+                    Postgres.doQuery
+                      connection
+                      [Postgres.sql|
                 SELECT enum_col
                 FROM test_table
               |]
-              expectSuccess
-          ) |> Expect.succeeds
-      
-      Expect.equal rows [Value1, Value2]
-    , Test.test "Enum array test" <| \_ -> do
-      rows <- withContext (\connection -> do 
-            Postgres.doQuery
-              connection
-              [Postgres.sql|
+                      expectSuccess
+                )
+                |> Expect.succeeds
+
+            Expect.equal rows [Value1, Value2],
+          Test.test "Enum array test" <| \_ -> do
+            rows <-
+              withContext
+                ( \connection -> do
+                    Postgres.doQuery
+                      connection
+                      [Postgres.sql|
                 INSERT INTO test_table2 (enum_array_col)
                 VALUES (ARRAY[${Value1}] :: test_enum[])
                      , (ARRAY[${Value1}, ${Value2}] :: test_enum[])
                 RETURNING enum_array_col
               |]
-              expectSuccess
-          ) |> Expect.succeeds 
+                      expectSuccess
+                )
+                |> Expect.succeeds
 
-      Expect.equal rows [[Just Value1], [Just Value1, Just Value2]]
-  ]
+            Expect.equal rows [[Just Value1], [Just Value1, Just Value2]]
+        ]
 
 tests :: Postgres.Connection -> Test
-tests connection = 
+tests connection =
   describe
     "Postgres.Enum"
-    [ generateFailureTests
-    , queryTests connection
+    [ generateFailureTests,
+      queryTests connection
     ]

--- a/nri-postgresql/test/Main.hs
+++ b/nri-postgresql/test/Main.hs
@@ -13,6 +13,7 @@ import Test (Test, describe, run)
 import qualified TimeSpec
 import qualified Enum
 import qualified Prelude
+import qualified ConflictTest
 
 -- `Test.run` exits after finishing, so run other tests first.
 main :: Prelude.IO ()
@@ -30,5 +31,6 @@ tests postgres =
       QueryParserSpec.tests,
       TimeSpec.tests,
       ObservabilitySpec.tests postgres,
-      Enum.tests postgres
+      Enum.tests postgres,
+      ConflictTest.tests postgres
     ]

--- a/nri-postgresql/test/Main.hs
+++ b/nri-postgresql/test/Main.hs
@@ -3,7 +3,9 @@ module Main
   )
 where
 
+import qualified ConflictTest
 import qualified Data.Acquire as Acquire
+import qualified Enum
 import qualified Environment
 import qualified ObservabilitySpec
 import qualified Postgres
@@ -11,9 +13,7 @@ import qualified PostgresSettingsSpec
 import qualified QueryParserSpec
 import Test (Test, describe, run)
 import qualified TimeSpec
-import qualified Enum
 import qualified Prelude
-import qualified ConflictTest
 
 -- `Test.run` exits after finishing, so run other tests first.
 main :: Prelude.IO ()

--- a/nri-postgresql/test/golden-results/observability-spec-postgres-reporting
+++ b/nri-postgresql/test/golden-results/observability-spec-postgres-reporting
@@ -55,9 +55,9 @@ TracingSpan
                             { srcLocPackage = "main"
                             , srcLocModule = "Postgres"
                             , srcLocFile = "src/Postgres.hs"
-                            , srcLocStartLine = 220
+                            , srcLocStartLine = 224
                             , srcLocStartCol = 9
-                            , srcLocEndLine = 220
+                            , srcLocEndLine = 224
                             , srcLocEndCol = 69
                             }
                         )

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,15 +2,7 @@
 
 set -euxo pipefail
 
-## start postgres
-mkdir -p "_build/postgres/data"
-PGDATA="$(realpath _build/postgres/data)"
-export PGDATA
-export PGUSER=$USER
-pg_ctl stop || true
-rm -rf "$PGDATA"
-initdb --no-locale --encoding=UTF8
-pg_ctl start -o '-k .'
+(cd nri-postgresql && ./setup-postgres.sh)
 
 ## start redis
 mkdir -p ./_build/redis/data


### PR DESCRIPTION
In recent Phoenix work, we've made heavy use of database constraints to enforce consistency.  However, we're having trouble testing them!  Specifically `Postgres.Test.test` cannot recover from a transaction when a database error happens and gives this exception: 

```
PGERROR [25P02]: current transaction is aborted, commands ignored until end of transaction block
```

This is because at the end of `inTestTransaction` we are calling `rollbackAllSafe` ... which, counterintuitively, is not in fact safe.  `rollbackAllSafe` attempts to start a transaction with `pgBegin` to ensure there always is one, but this will fail if the transaction has already been aborted!

So the fix in this PR is to only call `rollbackAllSafe` when starting `inTestTransaction`, but make a normal call to `pgRollbackAll c` when wrapping up.  We should always have a transaction anyways when we reach the cleanup phase because the library doesn't expose a way to rollback the transaction to users. 