### PR TITLE
Change `Task.sequence` to actually run tasks in sequence 😨 

### DIFF
--- a/nri-prelude/src/Platform/Internal.hs
+++ b/nri-prelude/src/Platform/Internal.hs
@@ -10,6 +10,7 @@ import Control.Applicative ((<|>))
 import qualified Control.AutoUpdate as AutoUpdate
 import qualified Control.Concurrent.Async as Async
 import qualified Control.Exception.Safe as Exception
+import qualified Control.Monad
 import Data.Aeson ((.:), (.:?), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encoding as Aeson.Encoding
@@ -66,21 +67,7 @@ instance Applicative (Task a) where
   pure a =
     Task (\_ -> Prelude.pure (Ok a))
 
-  (<*>) func task =
-    Task <| \key ->
-      do
-        func_ <- _run func key
-        case func_ of
-          Err x ->
-            Prelude.pure (Err x)
-          Ok okFunc ->
-            do
-              task_ <- _run task key
-              case task_ of
-                Err x ->
-                  Prelude.pure (Err x)
-                Ok okTask ->
-                  Prelude.pure (Ok (okFunc okTask))
+  (<*>) func task = Control.Monad.ap func task
 
 instance Monad (Task a) where
   task >>= func =

--- a/nri-prelude/src/Task.hs
+++ b/nri-prelude/src/Task.hs
@@ -42,7 +42,6 @@ import Basics
 import qualified Control.Concurrent.Async as Async
 import qualified Internal.Shortcut as Shortcut
 import List (List)
-import qualified List
 import Maybe (Maybe (..))
 import Platform.Internal (Task)
 import qualified Platform.Internal as Internal
@@ -184,8 +183,7 @@ andThen =
 --
 -- > sequence [ succeed 1, succeed 2 ] == succeed [ 1, 2 ]
 sequence :: List (Task x a) -> Task x (List a)
-sequence tasks =
-  List.foldr (Shortcut.map2 (:)) (succeed []) tasks
+sequence = Prelude.sequence
 
 -- | Start with a list of tasks, and turn them into a single task that returns a
 -- list. The tasks will be run in parallel and if any task fails the whole

--- a/nri-prelude/tests/TaskSpec.hs
+++ b/nri-prelude/tests/TaskSpec.hs
@@ -35,6 +35,19 @@ tests =
             Expect.equal "a" failure2
         ],
       describe
+        "map2"
+        [ test "only runs first task if that fails" <| \() -> do
+            doAnything <- Expect.fromIO Platform.doAnythingHandler
+            let shouldNeverRun = \x -> Platform.doAnything doAnything (Exception.throwString x)
+            failure <-
+              Task.map2
+                Tuple.pair
+                (Task.fail "a")
+                (shouldNeverRun "b")
+                |> Expect.fails
+            Expect.equal "a" failure
+        ],
+      describe
         "parallel"
         [ test "returns the right values" <| \() -> do
             let results = [1, 2, 3]

--- a/nri-prelude/tests/TaskSpec.hs
+++ b/nri-prelude/tests/TaskSpec.hs
@@ -48,6 +48,20 @@ tests =
             Expect.equal "a" failure
         ],
       describe
+        "map3"
+        [ test "only runs until the first task fails" <| \() -> do
+            doAnything <- Expect.fromIO Platform.doAnythingHandler
+            let shouldNeverRun = \x -> Platform.doAnything doAnything (Exception.throwString x)
+            failure <-
+              Task.map3
+                (\a b c -> (a, b, c))
+                (Task.succeed 1)
+                (Task.fail "c")
+                (shouldNeverRun "d")
+                |> Expect.fails
+            Expect.equal "c" failure
+        ],
+      describe
         "parallel"
         [ test "returns the right values" <| \() -> do
             let results = [1, 2, 3]

--- a/nri-prelude/tests/TaskSpec.hs
+++ b/nri-prelude/tests/TaskSpec.hs
@@ -1,8 +1,10 @@
 module TaskSpec (tests) where
 
+import qualified Control.Exception.Safe as Exception
 import qualified Expect
 import qualified List
 import NriPrelude
+import qualified Platform
 import qualified Process
 import qualified Task
 import Test (Test, describe, test)
@@ -15,6 +17,17 @@ tests =
   describe
     "Task"
     [ describe
+        "sequence"
+        [ test "actually runs in sequence" <| \() -> do
+            doAnything <- Expect.fromIO Platform.doAnythingHandler
+            let shouldNeverRun = \x -> Platform.doAnything doAnything (Exception.throwString x)
+            failure <-
+              [Task.succeed 1, Task.fail "a", shouldNeverRun "b"]
+                |> Task.sequence
+                |> Expect.fails
+            Expect.equal failure "a"
+        ],
+      describe
         "parallel"
         [ test "returns the right values" <| \() -> do
             let results = [1, 2, 3]

--- a/nri-prelude/tests/TaskSpec.hs
+++ b/nri-prelude/tests/TaskSpec.hs
@@ -11,6 +11,7 @@ import Test (Test, describe, test)
 import Test.Internal (Failure)
 import qualified Tuple
 import Prelude ((*>))
+import qualified Prelude
 
 tests :: Test
 tests =
@@ -25,7 +26,13 @@ tests =
               [Task.succeed 1, Task.fail "a", shouldNeverRun "b"]
                 |> Task.sequence
                 |> Expect.fails
-            Expect.equal failure "a"
+            Expect.equal "a" failure
+            -- Prelude.sequence also runs things in sequence.
+            failure2 <-
+              [Task.succeed 1, Task.fail "a", shouldNeverRun "b"]
+                |> Prelude.sequence
+                |> Expect.fails
+            Expect.equal "a" failure2
         ],
       describe
         "parallel"


### PR DESCRIPTION
This is a pretty fundamental change and there for a little scary, but I think it's the proper implementation of `Applicative` for `Task`.

## Current behavior

`Task.sequence` keeps on running tasks after a task has failed. 
This is that case because the `Applicative` instance of `Task` runs both parts before combining the `Result`s.

## Expected behavior

List of tasks given to `Task.sequence` runs until the first task fails or to completion.

## Fix

Run arguments to `(<*>)` in `Applicative` instance one after another.


Related internal discussion: https://noredink.slack.com/archives/C43KR2A5S/p1679431367295019