### PR TITLE
[nri-http] Avoid buffer duplications

### DIFF
--- a/nri-http/CHANGELOG.md
+++ b/nri-http/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.0.0
+
+- Avoid unnecessary buffer duplication.
+- `expectBytesResponse` receives a lazy `ByteString`.
+
 # 0.3.0.0
 
 - Add convenience types.

--- a/nri-http/nri-http.cabal
+++ b/nri-http/nri-http.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           nri-http
-version:        0.3.0.0
+version:        0.4.0.0
 synopsis:       Make Elm style HTTP requests
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-http#readme>.
 category:       Web

--- a/nri-http/package.yaml
+++ b/nri-http/package.yaml
@@ -2,7 +2,7 @@ name: nri-http
 synopsis: Make Elm style HTTP requests
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-http#readme>.
 author: NoRedInk
-version: 0.3.0.0
+version: 0.4.0.0
 maintainer: haskell-open-source@noredink.com
 copyright: 2022 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-http

--- a/nri-http/src/Http.hs
+++ b/nri-http/src/Http.hs
@@ -231,15 +231,14 @@ handleResponse expect response =
   case response of
     Right okResponse ->
       let bytes = HTTP.responseBody okResponse
-          bodyAsText = Data.Text.Lazy.toStrict <| Data.Text.Lazy.Encoding.decodeUtf8 bytes
        in case expect of
             Internal.ExpectJson ->
               case Aeson.eitherDecode bytes of
                 Left err -> Err (Internal.BadBody (Text.fromList err))
                 Right x -> Ok x
-            Internal.ExpectText -> Ok bodyAsText
+            Internal.ExpectText -> Ok (Data.Text.Lazy.toStrict <| Data.Text.Lazy.Encoding.decodeUtf8 bytes)
             Internal.ExpectWhatever -> Ok ()
-            Internal.ExpectTextResponse mkResult -> mkResult (Internal.GoodStatus_ (mkMetadata okResponse) bodyAsText)
+            Internal.ExpectTextResponse mkResult -> mkResult (Internal.GoodStatus_ (mkMetadata okResponse) (Data.Text.Lazy.toStrict <| Data.Text.Lazy.Encoding.decodeUtf8 bytes))
             Internal.ExpectBytesResponse mkResult -> mkResult (Internal.GoodStatus_ (mkMetadata okResponse) (Data.ByteString.Lazy.toStrict bytes))
     Left exception ->
       case expect of

--- a/nri-http/src/Http/Internal.hs
+++ b/nri-http/src/Http/Internal.hs
@@ -5,7 +5,6 @@ module Http.Internal where
 
 import qualified Control.Exception.Safe as Exception
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString
 import qualified Data.ByteString.Lazy
 import qualified Data.Dynamic as Dynamic
 import Dict (Dict)
@@ -60,7 +59,7 @@ data Expect' x a where
   ExpectText :: Expect Text
   ExpectWhatever :: Expect ()
   ExpectTextResponse :: (Response Text -> Result x a) -> Expect' x a
-  ExpectBytesResponse :: (Response Data.ByteString.ByteString -> Result x a) -> Expect' x a
+  ExpectBytesResponse :: (Response Data.ByteString.Lazy.ByteString -> Result x a) -> Expect' x a
 
 -- | A 'Request' can fail in a couple of ways:
 --

--- a/nri-http/test/golden-results/expected-http-span
+++ b/nri-http/test/golden-results/expected-http-span
@@ -31,9 +31,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Http"
                     , srcLocFile = "src/Http.hs"
-                    , srcLocStartLine = 436
+                    , srcLocStartLine = 435
                     , srcLocStartCol = 11
-                    , srcLocEndLine = 448
+                    , srcLocEndLine = 447
                     , srcLocEndCol = 14
                     }
                 )


### PR DESCRIPTION
This PR moves a conversion of the response body to text, only to the branches interested in that result, reducing this way the required memory on some requests.

Also, this changes the type of the ByteString sent when using `expectBytesResponse` to use the lazy buffer returned by the `HTTP` library. This again avoids unnecessary duplication of buffers in memory making the evaluation of large responses more efficient. I bumped the version since this is a breaking change.
NOTE: even though the buffer is now a lazy ByteString, the response is fully evaluated by the time it comes out of the HTTP library (check [httpLBS](https://hackage.haskell.org/package/http-client-0.7.13.1/docs/Network-HTTP-Client.html#v:httpLbs)).

Closes ZEN-977