### PR TITLE
Use a lock to prevent pause/resume calls during polling

### DIFF
--- a/nri-kafka/nri-kafka.cabal
+++ b/nri-kafka/nri-kafka.cabal
@@ -27,6 +27,10 @@ source-repository head
   location: https://github.com/NoRedInk/haskell-libraries
   subdir: nri-kafka
 
+flag pause-resume-bug
+  manual: False
+  default: False
+
 library
   exposed-modules:
       Kafka
@@ -79,6 +83,104 @@ library
     , time >=1.8.0.2 && <2
     , unix >=2.7.2.2 && <2.8.0.0
     , uuid >=1.3.0 && <1.4
+  default-language: Haskell2010
+
+executable pause-resume-bug-consumer
+  main-is: Consumer.hs
+  other-modules:
+      Message
+      Producer
+      Paths_nri_kafka
+  hs-source-dirs:
+      scripts/pause-resume-bug
+  default-extensions:
+      DataKinds
+      DeriveGeneric
+      ExtendedDefaultRules
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      MultiParamTypeClasses
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      ScopedTypeVariables
+      Strict
+      TypeOperators
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fno-warn-type-defaults -fplugin=NriPrelude.Plugin -threaded -rtsopts "-with-rtsopts=-N -T" -O2 -main-is Consumer
+  build-depends:
+      aeson >=1.4.6.0 && <2.1
+    , async >=2.2.2 && <2.3
+    , base >=4.12.0.0 && <4.17
+    , bytestring >=0.10.8.2 && <0.12
+    , conduit >=1.3.0 && <1.4
+    , containers >=0.6.0.1 && <0.7
+    , hw-kafka-client >=4.0.3 && <5.0
+    , nri-env-parser >=0.1.0.0 && <0.2
+    , nri-kafka
+    , nri-observability >=0.1.1.1 && <0.2
+    , nri-prelude >=0.1.0.0 && <0.7
+    , safe-exceptions >=0.1.7.0 && <1.3
+    , stm >=2.4 && <2.6
+    , text >=1.2.3.1 && <2.1
+    , time >=1.8.0.2 && <2
+    , unix >=2.7.2.2 && <2.8.0.0
+    , uuid >=1.3.0 && <1.4
+  if flag(pause-resume-bug)
+    buildable: True
+  else
+    buildable: False
+  default-language: Haskell2010
+
+executable pause-resume-bug-producer
+  main-is: Producer.hs
+  other-modules:
+      Consumer
+      Message
+      Paths_nri_kafka
+  hs-source-dirs:
+      scripts/pause-resume-bug
+  default-extensions:
+      DataKinds
+      DeriveGeneric
+      ExtendedDefaultRules
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      MultiParamTypeClasses
+      NamedFieldPuns
+      NoImplicitPrelude
+      NumericUnderscores
+      OverloadedStrings
+      PartialTypeSignatures
+      ScopedTypeVariables
+      Strict
+      TypeOperators
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fno-warn-type-defaults -fplugin=NriPrelude.Plugin -main-is Producer
+  build-depends:
+      aeson >=1.4.6.0 && <2.1
+    , async >=2.2.2 && <2.3
+    , base >=4.12.0.0 && <4.17
+    , bytestring >=0.10.8.2 && <0.12
+    , conduit >=1.3.0 && <1.4
+    , containers >=0.6.0.1 && <0.7
+    , hw-kafka-client >=4.0.3 && <5.0
+    , nri-env-parser >=0.1.0.0 && <0.2
+    , nri-kafka
+    , nri-observability >=0.1.1.1 && <0.2
+    , nri-prelude >=0.1.0.0 && <0.7
+    , safe-exceptions >=0.1.7.0 && <1.3
+    , stm >=2.4 && <2.6
+    , text >=1.2.3.1 && <2.1
+    , time >=1.8.0.2 && <2
+    , unix >=2.7.2.2 && <2.8.0.0
+    , uuid >=1.3.0 && <1.4
+  if flag(pause-resume-bug)
+    buildable: True
+  else
+    buildable: False
   default-language: Haskell2010
 
 test-suite tests

--- a/nri-kafka/package.yaml
+++ b/nri-kafka/package.yaml
@@ -46,6 +46,33 @@ tests:
       - -threaded
       - -rtsopts "-with-rtsopts=-N -T"
       - -fno-warn-type-defaults
+executables:
+  pause-resume-bug-producer:
+    source-dirs: scripts/pause-resume-bug
+    main: Producer
+    dependencies:
+      - nri-kafka
+    when:
+      - condition: flag(pause-resume-bug)
+        then:
+          buildable: true
+        else:
+          buildable: false
+  pause-resume-bug-consumer:
+    source-dirs: scripts/pause-resume-bug
+    main: Consumer
+    dependencies:
+      - nri-kafka
+    ghc-options:
+      - -threaded
+      - -rtsopts "-with-rtsopts=-N -T"
+      - -O2
+    when:
+      - condition: flag(pause-resume-bug)
+        then:
+          buildable: true
+        else:
+          buildable: false
 default-extensions:
   - DataKinds
   - DeriveGeneric
@@ -72,3 +99,7 @@ ghc-options:
   - -Wincomplete-uni-patterns
   - -fno-warn-type-defaults
   - -fplugin=NriPrelude.Plugin
+flags:
+  pause-resume-bug:
+    default: false
+    manual: false

--- a/nri-kafka/scripts/pause-resume-bug/Consumer.hs
+++ b/nri-kafka/scripts/pause-resume-bug/Consumer.hs
@@ -6,7 +6,8 @@ import qualified Environment
 import qualified Kafka.Worker as Kafka
 import Message
 import System.Environment (setEnv)
-import Prelude (IO, pure, putStrLn, show)
+import System.IO (hPutStrLn, stderr)
+import Prelude (IO, putStrLn, show)
 
 main :: IO ()
 main = do
@@ -29,18 +30,17 @@ main = do
 
             case (prevId, id msg) of
               (Nothing, _) ->
-                -- First message has been received
-                pure ()
+                putStrLn "First message has been received"
               (_, 1) ->
-                -- Producer has been restarted
-                pure ()
+                putStrLn "Producer has been restarted"
               (Just prev, curr)
                 | prev + 1 == curr ->
                   -- This is the expected behavior
-                  pure ()
+                  putStrLn "OK"
               (Just prev, curr) ->
                 -- This is the bug
-                putStrLn
+                hPutStrLn
+                  stderr
                   ( "ERROR: Expected ID "
                       ++ show (prev + 1)
                       ++ " but got "

--- a/nri-kafka/scripts/pause-resume-bug/Consumer.hs
+++ b/nri-kafka/scripts/pause-resume-bug/Consumer.hs
@@ -1,0 +1,57 @@
+module Consumer where
+
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.MVar
+import qualified Environment
+import qualified Kafka.Worker as Kafka
+import Message
+import System.Environment (setEnv)
+import Prelude (IO, pure, putStrLn, show)
+
+main :: IO ()
+main = do
+  -- Disable console logging to make it easier to spot the bug
+  setEnv "LOG_ENABLED_LOGGERS" "file"
+  setEnv "LOG_FILE" "/dev/null"
+
+  -- Reduce buffer and batch sizes to make it fail faster
+  setEnv "KAFKA_MAX_MSGS_PER_PARTITION_BUFFERED_LOCALLY" "20"
+  setEnv "KAFKA_POLL_BATCH_SIZE" "5"
+
+  settings <- Environment.decode Kafka.decoder
+  doAnythingHandler <- Platform.doAnythingHandler
+  lastId <- newEmptyMVar
+
+  let processMsg (msg :: Message) =
+        ( do
+            putStrLn ("ID " ++ show (id msg))
+            prevId <- tryTakeMVar lastId
+
+            case (prevId, id msg) of
+              (Nothing, _) ->
+                -- First message has been received
+                pure ()
+              (_, 1) ->
+                -- Producer has been restarted
+                pure ()
+              (Just prev, curr)
+                | prev + 1 == curr ->
+                  -- This is the expected behavior
+                  pure ()
+              (Just prev, curr) ->
+                -- This is the bug
+                putStrLn
+                  ( "ERROR: Expected ID "
+                      ++ show (prev + 1)
+                      ++ " but got "
+                      ++ show curr
+                  )
+
+            putMVar lastId (id msg)
+            threadDelay 200000
+        )
+          |> fmap Ok
+          |> Platform.doAnything doAnythingHandler
+  let subscription = Kafka.subscription "pause-resume-bug" processMsg
+
+  Kafka.process settings "pause-resume-bug-consumer" subscription

--- a/nri-kafka/scripts/pause-resume-bug/Message.hs
+++ b/nri-kafka/scripts/pause-resume-bug/Message.hs
@@ -1,0 +1,12 @@
+module Message where
+
+import Data.Aeson
+
+newtype Message = Message
+  { id :: Int
+  }
+  deriving (Generic)
+
+instance FromJSON Message
+
+instance ToJSON Message

--- a/nri-kafka/scripts/pause-resume-bug/Producer.hs
+++ b/nri-kafka/scripts/pause-resume-bug/Producer.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
+
+module Producer where
+
+import Conduit
+import qualified Environment
+import qualified Kafka
+import Message
+import System.Environment (setEnv)
+import Prelude (IO, error, pure, putStrLn)
+
+main :: IO ()
+main = do
+  setEnv "KAFKA_COMPRESSION_CODEC" "Gzip"
+  settings <- Environment.decode Kafka.decoder
+  logHandler <- Platform.silentHandler
+
+  putStrLn "Sending messages..."
+
+  Conduit.withAcquire (Kafka.handler settings) <| \handler -> do
+    [1 .. 300]
+      |> List.map
+        ( \id -> do
+            let msg =
+                  Kafka.emptyMsg "pause-resume-bug"
+                    |> Kafka.addPayload Message {id}
+            Kafka.sendSync handler msg
+        )
+      |> Task.sequence
+      |> Task.attempt logHandler
+      |> andThen fromResult
+
+fromResult :: Result Text a -> IO ()
+fromResult (Ok _) = pure ()
+fromResult (Err err) = error (Text.toList err)

--- a/nri-kafka/scripts/pause-resume-bug/Producer.hs
+++ b/nri-kafka/scripts/pause-resume-bug/Producer.hs
@@ -24,6 +24,7 @@ main = do
             let msg =
                   Kafka.emptyMsg "pause-resume-bug"
                     |> Kafka.addPayload Message {id}
+                    |> Kafka.addKey "a-partition-key"
             Kafka.sendSync handler msg
         )
       |> Task.sequence

--- a/nri-kafka/scripts/pause-resume-bug/README.md
+++ b/nri-kafka/scripts/pause-resume-bug/README.md
@@ -1,0 +1,23 @@
+# pause-resume-bug
+
+There's a bug in librdkafka, fixed in 2.1.0, while hw-kafka is on 1.6.
+The symptom is messages being skipped every once in a while in a slow consumer that has its
+buffer filled up and has to pause/resume all the time.
+
+See https://github.com/confluentinc/librdkafka/blob/c282ba2423b2694052393c8edb0399a5ef471b3f/CHANGELOG.md?plain=1#L90-L95
+
+This directory contains sample code to check wether this bug is fixed in our library.
+
+To use it run in a console:
+
+```
+cabal run pause-resume-bug-consumer -fpause-resume-bug
+```
+
+At the same time, run this in another terminal:
+
+```
+cabal run pause-resume-bug-producer -fpause-resume-bug
+```
+
+If all works well, no "ERROR" should be printed out.

--- a/nri-kafka/scripts/pause-resume-bug/README.md
+++ b/nri-kafka/scripts/pause-resume-bug/README.md
@@ -20,4 +20,4 @@ At the same time, run this in another terminal:
 cabal run pause-resume-bug-producer -fpause-resume-bug
 ```
 
-If all works well, no "ERROR" should be printed out.
+If all works well, no "ERROR" should be printed out. If the bug is present, you should see the error infrequently e.g. 3 times for 300 messages.

--- a/nri-kafka/src/Kafka/Worker/Fetcher.hs
+++ b/nri-kafka/src/Kafka/Worker/Fetcher.hs
@@ -74,6 +74,8 @@ pollingLoop'
       -- buffer filled up and had to pause/resume all the time.
       --
       -- See https://github.com/confluentinc/librdkafka/blob/c282ba2423b2694052393c8edb0399a5ef471b3f/CHANGELOG.md?plain=1#L90-L95
+      --
+      -- We have a small app to reproduce the bug. Check out scripts/pause-resume-bug/README.md
       MVar.withMVar consumerLock
         <| \_ -> Consumer.pollMessageBatch consumer pollingTimeout pollBatchSize
     msgs <- Prelude.traverse handleKafkaError eitherMsgs

--- a/nri-kafka/src/Kafka/Worker/Internal.hs
+++ b/nri-kafka/src/Kafka/Worker/Internal.hs
@@ -598,6 +598,8 @@ pauseAndAnalyticsLoop maxBufferSize consumer consumerLock state pausedPartitions
   -- buffer filled up and has to pause/resume all the time.
   --
   -- See https://github.com/confluentinc/librdkafka/blob/c282ba2423b2694052393c8edb0399a5ef471b3f/CHANGELOG.md?plain=1#L90-L95
+  --
+  -- We have a small app to reproduce the bug. Check out scripts/pause-resume-bug/README.md
   MVar.withMVar consumerLock <| \_ -> do
     let newlyPaused = Set.diff desiredPausedPartitions pausedPartitions
     _ <- Consumer.pausePartitions consumer (Set.toList newlyPaused)

--- a/nri-kafka/src/Kafka/Worker/Internal.hs
+++ b/nri-kafka/src/Kafka/Worker/Internal.hs
@@ -5,6 +5,7 @@ module Kafka.Worker.Internal where
 import qualified Conduit
 import qualified Control.Concurrent
 import qualified Control.Concurrent.Async as Async
+import qualified Control.Concurrent.MVar as MVar
 import qualified Control.Concurrent.STM as STM
 import qualified Control.Concurrent.STM.TVar as TVar
 import qualified Control.Exception.Safe as Exception
@@ -547,12 +548,13 @@ runThreads ::
   Consumer.KafkaConsumer ->
   Prelude.IO ()
 runThreads settings state consumer = do
+  consumerLock <- MVar.newMVar ()
   Stopping.runUnlessStopping
     (stopping state)
     ()
     ( Async.race
-        (pauseAndAnalyticsLoop (Settings.maxMsgsPerPartitionBufferedLocally settings) consumer state Set.empty)
-        (Fetcher.pollingLoop settings (enqueueRecord (partitions state)) (analytics state) consumer)
+        (pauseAndAnalyticsLoop (Settings.maxMsgsPerPartitionBufferedLocally settings) consumer consumerLock state Set.empty)
+        (Fetcher.pollingLoop settings (enqueueRecord (partitions state)) (analytics state) consumer consumerLock)
         |> map (\_ -> ())
     )
 
@@ -581,18 +583,21 @@ enqueueRecord partitions record =
 pauseAndAnalyticsLoop ::
   Settings.MaxMsgsPerPartitionBufferedLocally ->
   Consumer.KafkaConsumer ->
+  MVar.MVar () ->
   State ->
   Set.Set PartitionKey ->
   Prelude.IO ()
-pauseAndAnalyticsLoop maxBufferSize consumer state pausedPartitions = do
+pauseAndAnalyticsLoop maxBufferSize consumer consumerLock state pausedPartitions = do
   desiredPausedPartitions <- pausedPartitionKeys maxBufferSize (partitions state)
   Analytics.updatePaused (Set.size desiredPausedPartitions) (analytics state)
-  let newlyPaused = Set.diff desiredPausedPartitions pausedPartitions
-  _ <- Consumer.pausePartitions consumer (Set.toList newlyPaused)
-  let newlyResumed = Set.diff pausedPartitions desiredPausedPartitions
-  _ <- Consumer.resumePartitions consumer (Set.toList newlyResumed)
+  MVar.withMVar consumerLock <| \_ -> do
+    let newlyPaused = Set.diff desiredPausedPartitions pausedPartitions
+    _ <- Consumer.pausePartitions consumer (Set.toList newlyPaused)
+    let newlyResumed = Set.diff pausedPartitions desiredPausedPartitions
+    _ <- Consumer.resumePartitions consumer (Set.toList newlyResumed)
+    Prelude.pure ()
   Control.Concurrent.threadDelay 1_000_000 {- 1 second -}
-  pauseAndAnalyticsLoop maxBufferSize consumer state desiredPausedPartitions
+  pauseAndAnalyticsLoop maxBufferSize consumer consumerLock state desiredPausedPartitions
 
 pausedPartitionKeys :: Settings.MaxMsgsPerPartitionBufferedLocally -> AllPartitions -> Prelude.IO (Set.Set PartitionKey)
 pausedPartitionKeys (Settings.MaxMsgsPerPartitionBufferedLocally maxBufferSize) partitions = do


### PR DESCRIPTION
This adds a lock to prevent calls to pause/resume the consumer concurrently with the polling. There's a [bug](https://github.com/confluentinc/librdkafka/blob/c282ba2423b2694052393c8edb0399a5ef471b3f/CHANGELOG.md?plain=1#L90-L95) in the librdkafka library that corrupts the current offset stored in memory making it miss or process messages out of order.

Initially I thought about using an `MVar KafkaConsumer` but it's actually not required to enforce the serialization with other calls like `seek` and `assignment`.

It would be nice to add specs but I couldn't find an easy and fast enough way to reproduce the issue. To test this I was using a process that enqueues 300 messages and a process that just sleeps for 200ms on each message. That consistently made it skip messages once the buffer gets full.

Closes ZEN-984