### PR TITLE
Fix delay calculation

### DIFF
--- a/nri-kafka/src/Kafka/Worker/Partition.hs
+++ b/nri-kafka/src/Kafka/Worker/Partition.hs
@@ -277,9 +277,8 @@ processMsgLoop skipOrNot messageFormat commitOffsets observabilityHandler state 
 
 microSecondsDelayForAttempt :: Int -> Int
 microSecondsDelayForAttempt attempts =
-  min
-    3_600_000_000 {- 1 hour in microseconds -}
-    ((10 Prelude.^ attempts) * 1000_000 {- 1 second in microseconds -})
+  -- Maximum delay is 2^10 seconds = 17 minutes
+  2 Prelude.^ (min attempts 10) * 1_000_000
 
 handleFailures ::
   Show e =>

--- a/nri-kafka/test/Spec/Kafka/Worker/Partition.hs
+++ b/nri-kafka/test/Spec/Kafka/Worker/Partition.hs
@@ -12,15 +12,18 @@ tests =
         "microSecondsDelayForAttempt"
         [ Test.test "1 attempt" <| \() ->
             Partition.microSecondsDelayForAttempt 1
-              |> Expect.equal 10_000_000,
+              |> Expect.equal 2_000_000,
           Test.test "2 attempts" <| \() ->
             Partition.microSecondsDelayForAttempt 2
-              |> Expect.equal 100_000_000,
+              |> Expect.equal 4_000_000,
           Test.test "3 attempts" <| \() ->
             Partition.microSecondsDelayForAttempt 3
-              |> Expect.equal 1000_000_000,
+              |> Expect.equal 8_000_000,
           Test.test "4 attempts" <| \() ->
             Partition.microSecondsDelayForAttempt 4
-              |> Expect.equal 3_600_000_000
+              |> Expect.equal 16_000_000,
+          Test.test "100 attempts" <| \() ->
+            Partition.microSecondsDelayForAttempt 100
+              |> Expect.equal 1_024_000_000
         ]
     ]


### PR DESCRIPTION
This PR fixes an issue with the calculation of delay between Kafka message retries.
Before this, it was using the minimum between 1h and `10^attempts` seconds. But this later value (in microseconds) quickly exceeded the maximum value for an `Int64` and it was being truncated, resulting often either negative numbers or very small values, making the Kafka workers retrying extremely often and flooding BugSnag and Honeycomb with errors and traces.

The new formula caps directly the number of attempts before calculation and sets a maximum of `2^10` seconds (~17 minutes). I also changed the formula to use powers of 2 seconds to make a slower growth until the maximum.

Closes ZEN-991