### PR TITLE
redis sorted sets

### DIFF
--- a/nri-redis/nri-redis.cabal
+++ b/nri-redis/nri-redis.cabal
@@ -36,6 +36,7 @@ library
       Redis.List
       Redis.Mock
       Redis.Set
+      Redis.SortedSet
   other-modules:
       Redis.Codec
       Redis.Internal
@@ -67,6 +68,7 @@ library
     , base >=4.12.0.0 && <4.17
     , bytestring >=0.10.8.2 && <0.12
     , conduit >=1.3.0 && <1.4
+    , containers >=0.6.0.1 && <0.7
     , hedis >=0.14.0 && <0.16
     , nri-env-parser >=0.1.0.0 && <0.2
     , nri-observability >=0.1.0 && <0.2
@@ -94,6 +96,7 @@ test-suite tests
       Redis.Real
       Redis.Set
       Redis.Settings
+      Redis.SortedSet
       Paths_nri_redis
   hs-source-dirs:
       test
@@ -121,6 +124,7 @@ test-suite tests
     , base >=4.12.0.0 && <4.17
     , bytestring >=0.10.8.2 && <0.12
     , conduit >=1.3.0 && <1.4
+    , containers >=0.6.0.1 && <0.7
     , hedis >=0.14.0 && <0.16
     , nri-env-parser >=0.1.0.0 && <0.2
     , nri-observability >=0.1.0 && <0.2

--- a/nri-redis/package.yaml
+++ b/nri-redis/package.yaml
@@ -19,6 +19,7 @@ dependencies:
   - base >= 4.12.0.0 && < 4.17
   - bytestring >= 0.10.8.2 && < 0.12
   - conduit >= 1.3.0 && < 1.4
+  - containers >= 0.6.0.1 && < 0.7
   # hedis 14 introduces redis-cluster support
   - hedis >= 0.14.0 && < 0.16
   - nri-env-parser >= 0.1.0.0 && < 0.2
@@ -39,6 +40,7 @@ library:
     - Redis.List
     - Redis.Mock
     - Redis.Set
+    - Redis.SortedSet
   source-dirs:
     - src
 default-extensions:

--- a/nri-redis/src/Redis/Real.hs
+++ b/nri-redis/src/Redis/Real.hs
@@ -306,6 +306,12 @@ doRawQuery query =
         |> Database.Redis.zadd (toB key)
         |> PreparedQuery
         |> map (Ok << Prelude.fromIntegral)
+    Internal.Zrange key start stop ->
+      Database.Redis.zrange (toB key)
+        (Prelude.fromIntegral start)
+        (Prelude.fromIntegral stop)
+        |> PreparedQuery
+        |> map Ok
     Internal.WithResult f q ->
       let PreparedQuery redisCtx = doRawQuery q
        in PreparedQuery

--- a/nri-redis/src/Redis/Real.hs
+++ b/nri-redis/src/Redis/Real.hs
@@ -307,11 +307,16 @@ doRawQuery query =
         |> PreparedQuery
         |> map (Ok << Prelude.fromIntegral)
     Internal.Zrange key start stop ->
-      Database.Redis.zrange (toB key)
+      Database.Redis.zrange
+        (toB key)
         (Prelude.fromIntegral start)
         (Prelude.fromIntegral stop)
         |> PreparedQuery
         |> map Ok
+    Internal.Zrank key member ->
+      Database.Redis.zrank (toB key) member
+        |> PreparedQuery
+        |> map (Ok << map Prelude.fromIntegral)
     Internal.WithResult f q ->
       let PreparedQuery redisCtx = doRawQuery q
        in PreparedQuery

--- a/nri-redis/src/Redis/Real.hs
+++ b/nri-redis/src/Redis/Real.hs
@@ -317,6 +317,10 @@ doRawQuery query =
       Database.Redis.zrank (toB key) member
         |> PreparedQuery
         |> map (Ok << map Prelude.fromIntegral)
+    Internal.Zrevrank key member ->
+      Database.Redis.zrevrank (toB key) member
+        |> PreparedQuery
+        |> map (Ok << map Prelude.fromIntegral)
     Internal.WithResult f q ->
       let PreparedQuery redisCtx = doRawQuery q
        in PreparedQuery

--- a/nri-redis/src/Redis/Real.hs
+++ b/nri-redis/src/Redis/Real.hs
@@ -14,6 +14,7 @@ import qualified Data.ByteString
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text.Encoding
 import qualified Database.Redis
+import qualified Dict
 import qualified GHC.Stack as Stack
 import qualified Platform
 import qualified Redis.Internal as Internal
@@ -299,6 +300,12 @@ doRawQuery query =
       Database.Redis.smembers (toB key)
         |> PreparedQuery
         |> map Ok
+    Internal.Zadd key vals ->
+      Dict.toList vals
+        |> List.map (\(a, b) -> (b, a))
+        |> Database.Redis.zadd (toB key)
+        |> PreparedQuery
+        |> map (Ok << Prelude.fromIntegral)
     Internal.WithResult f q ->
       let PreparedQuery redisCtx = doRawQuery q
        in PreparedQuery

--- a/nri-redis/src/Redis/SortedSet.hs
+++ b/nri-redis/src/Redis/SortedSet.hs
@@ -1,0 +1,119 @@
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+
+-- | A simple Redis library providing high level access to Redis features we
+-- use here at NoRedInk
+--
+-- As with our Ruby Redis access, we enforce working within a "namespace".
+module Redis.SortedSet
+  ( -- * Creating a Redis handler
+    Real.handler,
+    Real.handlerAutoExtendExpire,
+    Internal.Handler,
+    Internal.HandlerAutoExtendExpire,
+    Settings.Settings (..),
+    Settings.decoder,
+
+    -- * Creating a Redis API
+    jsonApi,
+    textApi,
+    byteStringApi,
+    Api,
+
+    -- * Creating Redis queries
+    del,
+    exists,
+    expire,
+    ping,
+    zadd,
+
+    -- * Running Redis queries
+    Internal.query,
+    Internal.transaction,
+    Internal.Query,
+    Internal.Error (..),
+    Internal.map,
+    Internal.map2,
+    Internal.map3,
+    Internal.sequence,
+  )
+where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as ByteString
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
+-- import qualified Dict
+-- import qualified Prelude
+import qualified Data.Map.Strict
+import qualified NonEmptyDict
+import qualified Redis.Codec as Codec
+import qualified Redis.Internal as Internal
+import qualified Redis.Real as Real
+import qualified Redis.Settings as Settings
+
+data Api key a = Api
+  { -- | Removes the specified keys. A key is ignored if it does not exist.
+    --
+    -- https://redis.io/commands/del
+    del :: NonEmpty key -> Internal.Query Int,
+    -- | Returns if key exists.
+    --
+    -- https://redis.io/commands/exists
+    exists :: key -> Internal.Query Bool,
+    -- | Set a timeout on key. After the timeout has expired, the key will
+    -- automatically be deleted. A key with an associated timeout is often said to
+    -- be volatile in Redis terminology.
+    --
+    -- https://redis.io/commands/expire
+    expire :: key -> Int -> Internal.Query (),
+    -- | Returns PONG if no argument is provided, otherwise return a copy of the
+    -- argument as a bulk. This command is often used to test if a connection is
+    -- still alive, or to measure latency.
+    --
+    -- https://redis.io/commands/ping
+    ping :: Internal.Query (),
+    -- | Adds all the specified members with the specified scores to the sorted
+    -- set. If a specified member is already a member of the sorted set, the
+    -- score is updated and the element reinserted at the right position to
+    -- ensure the correct ordering.
+    --
+    -- https://redis.io/commands/zadd
+    zadd :: key -> NonEmptyDict.NonEmptyDict a Float -> Internal.Query Int
+  }
+
+-- | Creates a json API mapping a 'key' to a json-encodable-decodable type
+--
+-- > data Key = Key { fieldA: Text, fieldB: Text }
+-- > data Val = Val { ... }
+-- >
+-- > myJsonApi :: Redis.Api Key Val
+-- > myJsonApi = Redis.jsonApi (\Key {fieldA,
+jsonApi ::
+  forall a key.
+  (Aeson.ToJSON a, Aeson.FromJSON a, Ord a) =>
+  (key -> Text) ->
+  Api key a
+jsonApi = makeApi Codec.jsonCodec
+
+-- | Creates a Redis API mapping a 'key' to Text
+textApi :: (key -> Text) -> Api key Text
+textApi = makeApi Codec.textCodec
+
+-- | Creates a Redis API mapping a 'key' to a ByteString
+byteStringApi :: (key -> Text) -> Api key ByteString.ByteString
+byteStringApi = makeApi Codec.byteStringCodec
+
+makeApi ::
+  Ord a =>
+  Codec.Codec a ->
+  (key -> Text) ->
+  Api key a
+makeApi Codec.Codec {Codec.codecEncoder} toKey =
+  Api
+    { del = Internal.Del << NonEmpty.map toKey,
+      exists = Internal.Exists << toKey,
+      expire = \key secs -> Internal.Expire (toKey key) secs,
+      ping = Internal.Ping |> map (\_ -> ()),
+      zadd = \key vals ->
+        Internal.Zadd (toKey key) (Data.Map.Strict.mapKeys codecEncoder (NonEmptyDict.toDict vals))
+    }

--- a/nri-redis/src/Redis/SortedSet.hs
+++ b/nri-redis/src/Redis/SortedSet.hs
@@ -27,6 +27,7 @@ module Redis.SortedSet
     zadd,
     zrange,
     zrank,
+    zrevrank,
 
     -- * Running Redis queries
     Internal.query,
@@ -101,7 +102,13 @@ data Api key a = Api
     -- means that the member with the lowest score has rank 0.
     --
     -- https://redis.io/commands/zrank
-    zrank :: key -> a -> Internal.Query (Maybe Int)
+    zrank :: key -> a -> Internal.Query (Maybe Int),
+    -- | Returns the rank of member in the sorted set stored at key, with the
+    -- scores ordered from high to low. The rank (or index) is 0-based, which
+    -- means that the member with the highest score has rank 0.
+    --
+    -- https://redis.io/commands/zrevrank
+    zrevrank :: key -> a -> Internal.Query (Maybe Int)
   }
 
 -- | Creates a json API mapping a 'key' to a json-encodable-decodable type
@@ -142,5 +149,6 @@ makeApi Codec.Codec {Codec.codecEncoder, Codec.codecDecoder} toKey =
       zrange = \key start stop ->
         Internal.Zrange (toKey key) start stop
           |> Internal.WithResult (Prelude.traverse codecDecoder),
-      zrank = \key member -> Internal.Zrank (toKey key) (codecEncoder member)
+      zrank = \key member -> Internal.Zrank (toKey key) (codecEncoder member),
+      zrevrank = \key member -> Internal.Zrevrank (toKey key) (codecEncoder member)
     }

--- a/nri-redis/test/Main.hs
+++ b/nri-redis/test/Main.hs
@@ -16,6 +16,7 @@ import qualified Redis.List
 import qualified Redis.Mock as Mock
 import qualified Redis.Real as Real
 import qualified Redis.Settings as Settings
+import qualified Redis.SortedSet
 import qualified Set
 import qualified Task
 import qualified Test
@@ -264,6 +265,15 @@ queryTests redisHandler =
           |> Expect.succeeds
       field2
         |> Expect.equal (Just "val2"),
+    Test.test "zadd returns count of stored values" <| \() -> do
+      _ <-
+        Redis.SortedSet.del sortedSetApi ("zadd-returns-count-of-stored-values" :| [])
+          |> Redis.query redisHandler
+          |> Expect.succeeds
+      NonEmptyDict.init "foo" 1 Dict.empty
+        |> Redis.SortedSet.zadd sortedSetApi "zadd-returns-count-of-stored-values"
+        |> Redis.query redisHandler
+        |> Expect.andCheck (Expect.equal 1),
     Test.test "scan iterates over all matching keys in batches" <| \() -> do
       let firstKey = "scanTest::key1"
       let firstValue = "value 1"
@@ -353,6 +363,9 @@ listApi = Redis.List.textApi identity
 
 counterApi :: Redis.Counter.Api Text
 counterApi = Redis.Counter.makeApi identity
+
+sortedSetApi :: Redis.SortedSet.Api Text Text
+sortedSetApi = Redis.SortedSet.textApi identity
 
 jsonApi' :: Redis.Api Text [Int]
 jsonApi' = Redis.jsonApi identity

--- a/nri-redis/test/Main.hs
+++ b/nri-redis/test/Main.hs
@@ -274,6 +274,23 @@ queryTests redisHandler =
         |> Redis.SortedSet.zadd sortedSetApi "zadd-returns-count-of-stored-values"
         |> Redis.query redisHandler
         |> Expect.andCheck (Expect.equal 1),
+    Test.test "zrange works as expected" <| \() -> do
+      _ <- Redis.SortedSet.del sortedSetApi ("zrange-works" :| [])
+          |> Redis.query redisHandler
+          |> Expect.succeeds
+      _ <- NonEmptyDict.init  "one" 1 (Dict.fromList [("two", 2), ("three", 3)])
+        |> Redis.SortedSet.zadd sortedSetApi "zrange-works"
+        |> Redis.query redisHandler
+        |> Expect.succeeds
+      Redis.SortedSet.zrange sortedSetApi "zrange-works" 0 (-1)
+         |> Redis.query redisHandler
+         |> Expect.andCheck (Expect.equal ["one", "two", "three"])
+      Redis.SortedSet.zrange sortedSetApi "zrange-works" 2 3
+        |> Redis.query redisHandler
+        |> Expect.andCheck (Expect.equal [ "three" ])
+      Redis.SortedSet.zrange sortedSetApi "zrange-works" (-2) (-1)
+        |> Redis.query redisHandler
+        |> Expect.andCheck (Expect.equal ["two", "three"]),
     Test.test "scan iterates over all matching keys in batches" <| \() -> do
       let firstKey = "scanTest::key1"
       let firstValue = "value 1"

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-counter-query
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-counter-query
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "main"
             , srcLocModule = "Main"
             , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 35
+            , srcLocStartLine = 36
             , srcLocStartCol = 7
-            , srcLocEndLine = 39
+            , srcLocEndLine = 40
             , srcLocEndCol = 40
             }
         )
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Main"
                     , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 110
+                    , srcLocStartLine = 111
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 110
+                    , srcLocEndLine = 111
                     , srcLocEndCol = 68
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-counter-transaction
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-counter-transaction
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "main"
             , srcLocModule = "Main"
             , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 35
+            , srcLocStartLine = 36
             , srcLocStartCol = 7
-            , srcLocEndLine = 39
+            , srcLocEndLine = 40
             , srcLocEndCol = 40
             }
         )
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Main"
                     , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 117
+                    , srcLocStartLine = 118
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 117
+                    , srcLocEndLine = 118
                     , srcLocEndCol = 74
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-hash-query
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-hash-query
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "main"
             , srcLocModule = "Main"
             , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 35
+            , srcLocStartLine = 36
             , srcLocStartCol = 7
-            , srcLocEndLine = 39
+            , srcLocEndLine = 40
             , srcLocEndCol = 40
             }
         )
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Main"
                     , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 82
+                    , srcLocStartLine = 83
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 82
+                    , srcLocEndLine = 83
                     , srcLocEndCol = 59
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-hash-transaction
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-hash-transaction
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "main"
             , srcLocModule = "Main"
             , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 35
+            , srcLocStartLine = 36
             , srcLocStartCol = 7
-            , srcLocEndLine = 39
+            , srcLocEndLine = 40
             , srcLocEndCol = 40
             }
         )
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Main"
                     , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 89
+                    , srcLocStartLine = 90
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 89
+                    , srcLocEndLine = 90
                     , srcLocEndCol = 65
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-list-query
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-list-query
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "main"
             , srcLocModule = "Main"
             , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 35
+            , srcLocStartLine = 36
             , srcLocStartCol = 7
-            , srcLocEndLine = 39
+            , srcLocEndLine = 40
             , srcLocEndCol = 40
             }
         )
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Main"
                     , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 96
+                    , srcLocStartLine = 97
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 96
+                    , srcLocEndLine = 97
                     , srcLocEndCol = 59
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-list-transaction
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-list-transaction
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "main"
             , srcLocModule = "Main"
             , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 35
+            , srcLocStartLine = 36
             , srcLocStartCol = 7
-            , srcLocEndLine = 39
+            , srcLocEndLine = 40
             , srcLocEndCol = 40
             }
         )
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Main"
                     , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 103
+                    , srcLocStartLine = 104
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 103
+                    , srcLocEndLine = 104
                     , srcLocEndCol = 65
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-query
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-query
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "main"
             , srcLocModule = "Main"
             , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 35
+            , srcLocStartLine = 36
             , srcLocStartCol = 7
-            , srcLocEndLine = 39
+            , srcLocEndLine = 40
             , srcLocEndCol = 40
             }
         )
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Main"
                     , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 68
+                    , srcLocStartLine = 69
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 68
+                    , srcLocEndLine = 69
                     , srcLocEndCol = 45
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-transaction
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-transaction
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "main"
             , srcLocModule = "Main"
             , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 35
+            , srcLocStartLine = 36
             , srcLocStartCol = 7
-            , srcLocEndLine = 39
+            , srcLocEndLine = 40
             , srcLocEndCol = 40
             }
         )
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "main"
                     , srcLocModule = "Main"
                     , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 75
+                    , srcLocStartLine = 76
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 75
+                    , srcLocEndLine = 76
                     , srcLocEndCol = 51
                     }
                 )


### PR DESCRIPTION
Add support for the [basic sorted sets commands](https://redis.io/docs/data-types/sorted-sets/#basic-commands). Further commands can be added later; hedis has pretty broad coverage!