### PR TITLE
Add Redis.decoderWithCustomConnectionString

### DIFF
--- a/nri-redis/src/Redis.hs
+++ b/nri-redis/src/Redis.hs
@@ -16,6 +16,7 @@ module Redis
     Settings.Settings (..),
     Settings.decoder,
     Settings.decoderWithEnvVarPrefix,
+    Settings.decoderWithCustomConnectionString,
 
     -- * Creating a redis API
     jsonApi,


### PR DESCRIPTION
Add a new decoder to grab the connection string from a specific connection string. 

We keep fetching values from REDIS_CLUSTER, REDIS_DEFAULT_EXPIRY_SECONDS, REDIS_QUERY_TIMEOUT_MILLISECONDS, REDIS_MAX_KEY_SIZE for the rest of the options.