### PR TITLE
Add message offset to trace details for Kafka workers

### DIFF
--- a/nri-kafka/src/Kafka/Worker/Partition.hs
+++ b/nri-kafka/src/Kafka/Worker/Partition.hs
@@ -358,6 +358,7 @@ getTracingDetails analytics (ProcessAttemptsCount processAttempt) record = do
                       Prelude.Left _ -> Nothing
                       Prelude.Right keyText -> Just keyText
                 ),
+          Log.Kafka.offset = Just (Consumer.unOffset (Consumer.crOffset record)),
           Log.Kafka.contents = Just contents,
           Log.Kafka.processAttempt = Just processAttempt,
           Log.Kafka.createTime,

--- a/nri-observability/src/Log/Kafka.hs
+++ b/nri-observability/src/Log/Kafka.hs
@@ -7,6 +7,7 @@ module Log.Kafka
     topic,
     partitionId,
     key,
+    offset,
     contents,
     createTime,
     logAppendTime,
@@ -41,6 +42,8 @@ data Details = Details
     -- that messages with the same key are guaranteed to end up in the same
     -- partition.
     key :: Maybe Text,
+    -- | The message offset into the partition
+    offset :: Maybe Int,
     -- | The contents of the message.
     contents :: Maybe Contents,
     -- | The time at which this message was created by a producer.
@@ -77,6 +80,7 @@ emptyDetails =
     { topic = Nothing,
       partitionId = Nothing,
       key = Nothing,
+      offset = Nothing,
       contents = Nothing,
       createTime = Nothing,
       logAppendTime = Nothing,

--- a/nri-observability/test/golden-results/honeycomb-failure-processing-kafka-message.json
+++ b/nri-observability/test/golden-results/honeycomb-failure-processing-kafka-message.json
@@ -21,6 +21,7 @@
             "contains_failures": true,
             "kafka.contents": [],
             "service_name": "some service",
+            "kafka.offset": 1,
             "endpoint": "GET /hats/:hat_id",
             "kafka.request_id": "requestId",
             "revision": "gitref",

--- a/nri-observability/tests/Spec/Reporter/Honeycomb.hs
+++ b/nri-observability/tests/Spec/Reporter/Honeycomb.hs
@@ -83,6 +83,7 @@ tests =
                 { Kafka.topic = Just "topic",
                   Kafka.partitionId = Just 12,
                   Kafka.key = Just "key",
+                  Kafka.offset = Just 1,
                   Kafka.contents = Just (Kafka.mkContents ()),
                   Kafka.createTime = Just (Clock.POSIX.posixSecondsToUTCTime 0),
                   Kafka.logAppendTime = Just (Clock.POSIX.posixSecondsToUTCTime 0),


### PR DESCRIPTION
When we log+trace kafka messages being assigned to workers, we don't log their offsets.

This makes it harder to inspect messages around it.

Inspecting preceding messages could have helped us root-cause Redis data loss in [PHX-1249](https://linear.app/noredink/issue/PHX-1249/finish-root-causing-hqe-redis-data-loss).