### PR TITLE
add unix socket config support to nri-redis

### DIFF
--- a/nri-redis/CHANGELOG.md
+++ b/nri-redis/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1.0
+
+- Add Unix socket config support.
+
 # 0.1.0.4
 
 - Relax version bounds to encompass `text-2.0.x`, `base-4.16.x` and `template-haskell-2.18.x`

--- a/nri-redis/README.md
+++ b/nri-redis/README.md
@@ -26,6 +26,9 @@ these are the defaults:
 
 ```sh
 REDIS_CONNECTION_STRING=redis://localhost:6379
+# we also support unix sockets via a scheme we provide:
+# REDIS_CONNECTION_STRING=redis+unix:///path/to/redis.sock[?db=DB_NUM]
+
 REDIS_CLUSTER=0 # 1 is on
 REDIS_DEFAULT_EXPIRY_SECONDS=0 # 0 is no expiration
 REDIS_QUERY_TIMEOUT_MILLISECONDS=1000 # 0 is no timeout

--- a/nri-redis/nri-redis.cabal
+++ b/nri-redis/nri-redis.cabal
@@ -87,6 +87,7 @@ test-suite tests
   other-modules:
       Helpers
       Spec.Redis
+      Spec.Settings
       NonEmptyDict
       Redis
       Redis.Codec

--- a/nri-redis/nri-redis.cabal
+++ b/nri-redis/nri-redis.cabal
@@ -83,8 +83,10 @@ library
 
 test-suite tests
   type: exitcode-stdio-1.0
-  main-is: Main.hs
+  main-is: Spec.hs
   other-modules:
+      Helpers
+      Spec.Redis
       NonEmptyDict
       Redis
       Redis.Codec

--- a/nri-redis/nri-redis.cabal
+++ b/nri-redis/nri-redis.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           nri-redis
-version:        0.1.0.4
+version:        0.1.1.0
 synopsis:       An intuitive hedis wrapper library.
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-redis#readme>.
 category:       Web
@@ -70,6 +70,7 @@ library
     , conduit >=1.3.0 && <1.4
     , containers >=0.6.0.1 && <0.7
     , hedis >=0.14.0 && <0.16
+    , modern-uri >=0.3.1.0 && <0.4
     , nri-env-parser >=0.1.0.0 && <0.2
     , nri-observability >=0.1.0 && <0.2
     , nri-prelude >=0.1.0.0 && <0.7
@@ -129,6 +130,7 @@ test-suite tests
     , conduit >=1.3.0 && <1.4
     , containers >=0.6.0.1 && <0.7
     , hedis >=0.14.0 && <0.16
+    , modern-uri >=0.3.1.0 && <0.4
     , nri-env-parser >=0.1.0.0 && <0.2
     , nri-observability >=0.1.0 && <0.2
     , nri-prelude >=0.1.0.0 && <0.7

--- a/nri-redis/package.yaml
+++ b/nri-redis/package.yaml
@@ -3,7 +3,7 @@ synopsis: An intuitive hedis wrapper library.
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-redis#readme>.
 homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-redis#readme
 author: NoRedInk
-version: 0.1.0.4
+version: 0.1.1.0
 maintainer: haskell-open-source@noredink.com
 copyright: 2022 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-redis
@@ -22,6 +22,7 @@ dependencies:
   - containers >= 0.6.0.1 && < 0.7
   # hedis 14 introduces redis-cluster support
   - hedis >= 0.14.0 && < 0.16
+  - modern-uri >= 0.3.1.0 && < 0.4
   - nri-env-parser >= 0.1.0.0 && < 0.2
   - nri-observability >= 0.1.0 && < 0.2
   - nri-prelude >= 0.1.0.0 && < 0.7

--- a/nri-redis/package.yaml
+++ b/nri-redis/package.yaml
@@ -71,7 +71,7 @@ ghc-options:
   - -fplugin=NriPrelude.Plugin
 tests:
   tests:
-    main: Main.hs
+    main: Spec.hs
     source-dirs:
       - test
       - src

--- a/nri-redis/src/Redis/Settings.hs
+++ b/nri-redis/src/Redis/Settings.hs
@@ -16,6 +16,7 @@ import qualified Text
 import Prelude (Either (Left, Right))
 
 data ClusterMode = Cluster | NotCluster
+  deriving (Show)
 
 -- | Settings required to initiate a redis connection.
 data Settings = Settings
@@ -43,13 +44,16 @@ data Settings = Settings
     queryTimeout :: QueryTimeout,
     maxKeySize :: MaxKeySize
   }
+  deriving (Show)
 
 data MaxKeySize = NoMaxKeySize | MaxKeySize Int
+  deriving (Show)
 
 data DefaultExpiry = NoDefaultExpiry | ExpireKeysAfterSeconds Int
   deriving (Show)
 
 data QueryTimeout = NoQueryTimeout | TimeoutQueryAfterMilliseconds Int
+  deriving (Show)
 
 -- | decodes Settings from environmental variables
 decoder :: Environment.Decoder Settings

--- a/nri-redis/test/Helpers.hs
+++ b/nri-redis/test/Helpers.hs
@@ -1,0 +1,23 @@
+module Helpers where
+
+import qualified Conduit
+import qualified Environment
+import qualified Redis
+import qualified Redis.Mock as Mock
+import qualified Redis.Real as Real
+import qualified Redis.Settings as Settings
+import qualified Prelude
+
+data TestHandlers = TestHandlers
+  { mockHandler :: Redis.Handler,
+    autoExtendExpireHandler :: Redis.HandlerAutoExtendExpire,
+    realHandler :: Redis.Handler
+  }
+
+getHandlers :: Conduit.Acquire TestHandlers
+getHandlers = do
+  settings <- Conduit.liftIO (Environment.decode Settings.decoder)
+  autoExtendExpireHandler <- Real.handlerAutoExtendExpire "tests-auto-extend-expire" settings {Settings.defaultExpiry = Settings.ExpireKeysAfterSeconds 1}
+  realHandler <- Real.handler "tests" settings {Settings.defaultExpiry = Settings.NoDefaultExpiry}
+  mockHandler <- Conduit.liftIO <| Mock.handlerIO
+  Prelude.pure TestHandlers {autoExtendExpireHandler, realHandler, mockHandler}

--- a/nri-redis/test/Spec.hs
+++ b/nri-redis/test/Spec.hs
@@ -1,0 +1,8 @@
+import qualified Conduit
+import Helpers
+import qualified Spec.Redis
+import qualified Test
+import qualified Prelude
+
+main :: Prelude.IO ()
+main = Conduit.withAcquire Helpers.getHandlers (Test.run << Spec.Redis.tests)

--- a/nri-redis/test/Spec.hs
+++ b/nri-redis/test/Spec.hs
@@ -1,8 +1,14 @@
 import qualified Conduit
 import Helpers
 import qualified Spec.Redis
+import qualified Spec.Settings
 import qualified Test
 import qualified Prelude
 
 main :: Prelude.IO ()
-main = Conduit.withAcquire Helpers.getHandlers (Test.run << Spec.Redis.tests)
+main =
+  Conduit.withAcquire Helpers.getHandlers <| \testHandlers -> Test.run <|
+    Test.describe "nri-redis"
+      [ Spec.Redis.tests testHandlers,
+        Spec.Settings.tests
+      ]

--- a/nri-redis/test/Spec/Settings.hs
+++ b/nri-redis/test/Spec/Settings.hs
@@ -16,8 +16,12 @@ tests =
       decoderWithCustomConnectionStringTests
     ]
 
--- we lean on `show` for equality since `Database.Redis.ConnectInfo` doesn't have
+-- | Compare equality based on `String` representation.
+--
+-- We lean on `show` for equality since `Database.Redis.ConnectInfo` doesn't have
 -- an `Eq` instance (but does have a `Show` instance)
+expectEqualShow :: Show a => a -> a -> Expect.Expectation
+expectEqualShow x y = Expect.equal (show x) (show y)
 
 decoderTests :: Test.Test
 decoderTests =
@@ -243,6 +247,3 @@ decoderWithCustomConnectionStringTests =
          in Environment.decodePairs (Settings.decoderWithCustomConnectionString "COOL_CONNECTION_STRING") env
             |> expectEqualShow (Ok expected)
     ]
-
-expectEqualShow :: Show a => a -> a -> Expect.Expectation
-expectEqualShow x y = Expect.equal (show x) (show y)

--- a/nri-redis/test/Spec/Settings.hs
+++ b/nri-redis/test/Spec/Settings.hs
@@ -1,0 +1,149 @@
+module Spec.Settings (tests) where
+
+import Database.Redis hiding (Ok)
+import qualified Dict
+import qualified Environment
+import qualified Expect
+import qualified Redis.Settings as Settings
+import qualified Test
+import Prelude (Either (..), Show (..))
+
+tests :: Test.Test
+tests =
+  Test.describe "parsing settings from environment"
+    [ decoderTests,
+      decoderWithEnvVarPrefixTests,
+      decoderWithCustomConnectionStringTests
+    ]
+
+-- we lean on `show` for equality since `Database.Redis.ConnectInfo` doesn't have
+-- an `Eq` instance (but does have a `Show` instance)
+
+decoderTests :: Test.Test
+decoderTests =
+  Test.describe "decoder tests"
+    [ Test.test "returns expected defaults when no env vars set" <| \_ ->
+        case parseConnectInfo "redis://localhost:6379" of
+          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
+          Right connectInfo ->
+            let expected =
+                  Settings.Settings
+                    { Settings.connectionInfo = connectInfo,
+                      Settings.clusterMode = Settings.NotCluster,
+                      Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                      Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                      Settings.maxKeySize = Settings.NoMaxKeySize
+                    }
+             in Environment.decodePairs Settings.decoder (Dict.fromList [])
+                  |> expectEqualShow (Ok expected),
+      Test.test "returns parsed values from env when env vars set" <| \_ ->
+        case parseConnectInfo "redis://egg:bug@my-cool-host:36379/2" of
+          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
+          Right connectInfo ->
+            let env =
+                  Dict.fromList
+                    [ ("REDIS_CONNECTION_STRING", "redis://egg:bug@my-cool-host:36379/2"),
+                      ("REDIS_CLUSTER", "1"),
+                      ("REDIS_DEFAULT_EXPIRY_SECONDS", "10"),
+                      ("REDIS_QUERY_TIMEOUT_MILLISECONDS", "0"),
+                      ("REDIS_MAX_KEY_SIZE", "500")
+                    ]
+
+                expected =
+                  Settings.Settings
+                    { Settings.connectionInfo = connectInfo,
+                      Settings.clusterMode = Settings.Cluster,
+                      Settings.defaultExpiry = Settings.ExpireKeysAfterSeconds 10,
+                      Settings.queryTimeout = Settings.NoQueryTimeout,
+                      Settings.maxKeySize = Settings.MaxKeySize 500
+                    }
+             in Environment.decodePairs Settings.decoder env
+                  |> expectEqualShow (Ok expected)
+    ]
+
+decoderWithEnvVarPrefixTests :: Test.Test
+decoderWithEnvVarPrefixTests =
+  Test.describe "decoderWithEnvVarPrefix tests"
+    [ Test.test "returns expected defaults when no env vars set" <| \_ ->
+        case parseConnectInfo "redis://localhost:6379" of
+          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
+          Right connectInfo ->
+            let expected =
+                  Settings.Settings
+                    { Settings.connectionInfo = connectInfo,
+                      Settings.clusterMode = Settings.NotCluster,
+                      Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                      Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                      Settings.maxKeySize = Settings.NoMaxKeySize
+                    }
+             in Environment.decodePairs (Settings.decoderWithEnvVarPrefix "TEST_") (Dict.fromList [])
+                  |> expectEqualShow (Ok expected),
+      Test.test "returns parsed values from env when env vars set" <| \_ ->
+        case parseConnectInfo "redis://egg:bug@my-cool-host:36379/2" of
+          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
+          Right connectInfo ->
+            let env =
+                  Dict.fromList
+                    [ ("TEST_REDIS_CONNECTION_STRING", "redis://egg:bug@my-cool-host:36379/2"),
+                      ("TEST_REDIS_CLUSTER", "1"),
+                      ("TEST_REDIS_DEFAULT_EXPIRY_SECONDS", "10"),
+                      ("TEST_REDIS_QUERY_TIMEOUT_MILLISECONDS", "0"),
+                      ("TEST_REDIS_MAX_KEY_SIZE", "500")
+                    ]
+
+                expected =
+                  Settings.Settings
+                    { Settings.connectionInfo = connectInfo,
+                      Settings.clusterMode = Settings.Cluster,
+                      Settings.defaultExpiry = Settings.ExpireKeysAfterSeconds 10,
+                      Settings.queryTimeout = Settings.NoQueryTimeout,
+                      Settings.maxKeySize = Settings.MaxKeySize 500
+                    }
+             in Environment.decodePairs (Settings.decoderWithEnvVarPrefix "TEST_") env
+                  |> expectEqualShow (Ok expected)
+    ]
+
+decoderWithCustomConnectionStringTests :: Test.Test
+decoderWithCustomConnectionStringTests =
+  Test.describe "decoderWithCustomConnectionString tests"
+    [ Test.test "returns expected defaults when no env vars set" <| \_ ->
+        case parseConnectInfo "redis://localhost:6379" of
+          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
+          Right connectInfo ->
+            let expected =
+                  Settings.Settings
+                    { Settings.connectionInfo = connectInfo,
+                      Settings.clusterMode = Settings.NotCluster,
+                      Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                      Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                      Settings.maxKeySize = Settings.NoMaxKeySize
+                    }
+             in Environment.decodePairs (Settings.decoderWithCustomConnectionString "COOL_CONNECTION_STRING") (Dict.fromList [])
+                  |> expectEqualShow (Ok expected),
+      Test.test "returns parsed values from env when env vars set" <| \_ ->
+        case parseConnectInfo "redis://egg:bug@my-cool-host:36379/2" of
+          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
+          Right connectInfo ->
+            let env =
+                  Dict.fromList
+                    [ ("COOL_CONNECTION_STRING", "redis://egg:bug@my-cool-host:36379/2"),
+                      ("REDIS_CLUSTER", "1"),
+                      ("REDIS_DEFAULT_EXPIRY_SECONDS", "10"),
+                      ("REDIS_QUERY_TIMEOUT_MILLISECONDS", "0"),
+                      ("REDIS_MAX_KEY_SIZE", "500")
+                    ]
+
+                expected =
+                  Settings.Settings
+                    { Settings.connectionInfo = connectInfo,
+                      Settings.clusterMode = Settings.Cluster,
+                      Settings.defaultExpiry = Settings.ExpireKeysAfterSeconds 10,
+                      Settings.queryTimeout = Settings.NoQueryTimeout,
+                      Settings.maxKeySize = Settings.MaxKeySize 500
+                    }
+             in Environment.decodePairs (Settings.decoderWithCustomConnectionString "COOL_CONNECTION_STRING") env
+                  |> expectEqualShow (Ok expected)
+    ]
+
+expectEqualShow :: Show a => a -> a -> Expect.Expectation
+expectEqualShow x y = Expect.equal (show x) (show y)

--- a/nri-redis/test/Spec/Settings.hs
+++ b/nri-redis/test/Spec/Settings.hs
@@ -58,7 +58,40 @@ decoderTests =
                       Settings.maxKeySize = Settings.MaxKeySize 500
                     }
              in Environment.decodePairs Settings.decoder env
-                  |> expectEqualShow (Ok expected)
+                  |> expectEqualShow (Ok expected),
+      Test.test "handles unix socket scheme with default db" <| \_ ->
+        let env = Dict.fromList [("REDIS_CONNECTION_STRING", "redis+unix:///path/to/redis.sock")]
+            expected =
+              Settings.Settings
+                { Settings.connectionInfo =
+                    defaultConnectInfo
+                      { connectPort = UnixSocket "/path/to/redis.sock",
+                        connectDatabase = 0
+                      },
+                  Settings.clusterMode = Settings.NotCluster,
+                  Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                  Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                  Settings.maxKeySize = Settings.NoMaxKeySize
+                }
+         in Environment.decodePairs Settings.decoder env
+            |> expectEqualShow (Ok expected),
+      Test.test "handles unix socket scheme with specified db" <| \_ ->
+        let env = Dict.fromList [("REDIS_CONNECTION_STRING", "redis+unix://some:dude@/other/redis.sock?db=5")]
+            expected =
+              Settings.Settings
+                { Settings.connectionInfo =
+                    defaultConnectInfo
+                      { connectPort = UnixSocket "/other/redis.sock",
+                        connectAuth = Just "dude",
+                        connectDatabase = 5
+                      },
+                  Settings.clusterMode = Settings.NotCluster,
+                  Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                  Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                  Settings.maxKeySize = Settings.NoMaxKeySize
+                }
+         in Environment.decodePairs Settings.decoder env
+            |> expectEqualShow (Ok expected)
     ]
 
 decoderWithEnvVarPrefixTests :: Test.Test
@@ -100,7 +133,40 @@ decoderWithEnvVarPrefixTests =
                       Settings.maxKeySize = Settings.MaxKeySize 500
                     }
              in Environment.decodePairs (Settings.decoderWithEnvVarPrefix "TEST_") env
-                  |> expectEqualShow (Ok expected)
+                  |> expectEqualShow (Ok expected),
+      Test.test "handles unix socket scheme with default db" <| \_ ->
+        let env = Dict.fromList [("TEST_REDIS_CONNECTION_STRING", "redis+unix:///path/to/redis.sock")]
+            expected =
+              Settings.Settings
+                { Settings.connectionInfo =
+                    defaultConnectInfo
+                      { connectPort = UnixSocket "/path/to/redis.sock",
+                        connectDatabase = 0
+                      },
+                  Settings.clusterMode = Settings.NotCluster,
+                  Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                  Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                  Settings.maxKeySize = Settings.NoMaxKeySize
+                }
+         in Environment.decodePairs (Settings.decoderWithEnvVarPrefix "TEST_") env
+            |> expectEqualShow (Ok expected),
+      Test.test "handles unix socket scheme with specified db" <| \_ ->
+        let env = Dict.fromList [("TEST_REDIS_CONNECTION_STRING", "redis+unix://some:dude@/other/redis.sock?db=5")]
+            expected =
+              Settings.Settings
+                { Settings.connectionInfo =
+                    defaultConnectInfo
+                      { connectPort = UnixSocket "/other/redis.sock",
+                        connectAuth = Just "dude",
+                        connectDatabase = 5
+                      },
+                  Settings.clusterMode = Settings.NotCluster,
+                  Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                  Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                  Settings.maxKeySize = Settings.NoMaxKeySize
+                }
+         in Environment.decodePairs (Settings.decoderWithEnvVarPrefix "TEST_") env
+            |> expectEqualShow (Ok expected)
     ]
 
 decoderWithCustomConnectionStringTests :: Test.Test
@@ -142,7 +208,40 @@ decoderWithCustomConnectionStringTests =
                       Settings.maxKeySize = Settings.MaxKeySize 500
                     }
              in Environment.decodePairs (Settings.decoderWithCustomConnectionString "COOL_CONNECTION_STRING") env
-                  |> expectEqualShow (Ok expected)
+                  |> expectEqualShow (Ok expected),
+      Test.test "handles unix socket scheme with default db" <| \_ ->
+        let env = Dict.fromList [("COOL_CONNECTION_STRING", "redis+unix:///path/to/redis.sock")]
+            expected =
+              Settings.Settings
+                { Settings.connectionInfo =
+                    defaultConnectInfo
+                      { connectPort = UnixSocket "/path/to/redis.sock",
+                        connectDatabase = 0
+                      },
+                  Settings.clusterMode = Settings.NotCluster,
+                  Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                  Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                  Settings.maxKeySize = Settings.NoMaxKeySize
+                }
+         in Environment.decodePairs (Settings.decoderWithCustomConnectionString "COOL_CONNECTION_STRING") env
+            |> expectEqualShow (Ok expected),
+      Test.test "handles unix socket scheme with specified db" <| \_ ->
+        let env = Dict.fromList [("COOL_CONNECTION_STRING", "redis+unix://some:dude@/other/redis.sock?db=5")]
+            expected =
+              Settings.Settings
+                { Settings.connectionInfo =
+                    defaultConnectInfo
+                      { connectPort = UnixSocket "/other/redis.sock",
+                        connectAuth = Just "dude",
+                        connectDatabase = 5
+                      },
+                  Settings.clusterMode = Settings.NotCluster,
+                  Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                  Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                  Settings.maxKeySize = Settings.NoMaxKeySize
+                }
+         in Environment.decodePairs (Settings.decoderWithCustomConnectionString "COOL_CONNECTION_STRING") env
+            |> expectEqualShow (Ok expected)
     ]
 
 expectEqualShow :: Show a => a -> a -> Expect.Expectation

--- a/nri-redis/test/Spec/Settings.hs
+++ b/nri-redis/test/Spec/Settings.hs
@@ -1,12 +1,12 @@
 module Spec.Settings (tests) where
 
-import Database.Redis hiding (Ok)
+import Database.Redis hiding (String, Ok)
 import qualified Dict
 import qualified Environment
 import qualified Expect
 import qualified Redis.Settings as Settings
 import qualified Test
-import Prelude (Either (..), Show (..))
+import Prelude (Either (..), Show (..), String, pure)
 
 tests :: Test.Test
 tests =
@@ -26,43 +26,39 @@ expectEqualShow x y = Expect.equal (show x) (show y)
 decoderTests :: Test.Test
 decoderTests =
   Test.describe "decoder tests"
-    [ Test.test "returns expected defaults when no env vars set" <| \_ ->
-        case parseConnectInfo "redis://localhost:6379" of
-          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
-          Right connectInfo ->
-            let expected =
-                  Settings.Settings
-                    { Settings.connectionInfo = connectInfo,
-                      Settings.clusterMode = Settings.NotCluster,
-                      Settings.defaultExpiry = Settings.NoDefaultExpiry,
-                      Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
-                      Settings.maxKeySize = Settings.NoMaxKeySize
-                    }
-             in Environment.decodePairs Settings.decoder (Dict.fromList [])
-                  |> expectEqualShow (Ok expected),
-      Test.test "returns parsed values from env when env vars set" <| \_ ->
-        case parseConnectInfo "redis://egg:bug@my-cool-host:36379/2" of
-          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
-          Right connectInfo ->
-            let env =
-                  Dict.fromList
-                    [ ("REDIS_CONNECTION_STRING", "redis://egg:bug@my-cool-host:36379/2"),
-                      ("REDIS_CLUSTER", "1"),
-                      ("REDIS_DEFAULT_EXPIRY_SECONDS", "10"),
-                      ("REDIS_QUERY_TIMEOUT_MILLISECONDS", "0"),
-                      ("REDIS_MAX_KEY_SIZE", "500")
-                    ]
+    [ Test.test "returns expected defaults when no env vars set" <| \_ -> do
+        connectInfo <- parseConnectInfoElseFailTest "redis://localhost:6379"
+        let expected =
+              Settings.Settings
+                { Settings.connectionInfo = connectInfo,
+                  Settings.clusterMode = Settings.NotCluster,
+                  Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                  Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                  Settings.maxKeySize = Settings.NoMaxKeySize
+                }
+        Environment.decodePairs Settings.decoder (Dict.fromList [])
+          |> expectEqualShow (Ok expected),
+      Test.test "returns parsed values from env when env vars set" <| \_ -> do
+        connectInfo <- parseConnectInfoElseFailTest "redis://egg:bug@my-cool-host:36379/2"
+        let env =
+              Dict.fromList
+                [ ("REDIS_CONNECTION_STRING", "redis://egg:bug@my-cool-host:36379/2"),
+                  ("REDIS_CLUSTER", "1"),
+                  ("REDIS_DEFAULT_EXPIRY_SECONDS", "10"),
+                  ("REDIS_QUERY_TIMEOUT_MILLISECONDS", "0"),
+                  ("REDIS_MAX_KEY_SIZE", "500")
+                ]
 
-                expected =
-                  Settings.Settings
-                    { Settings.connectionInfo = connectInfo,
-                      Settings.clusterMode = Settings.Cluster,
-                      Settings.defaultExpiry = Settings.ExpireKeysAfterSeconds 10,
-                      Settings.queryTimeout = Settings.NoQueryTimeout,
-                      Settings.maxKeySize = Settings.MaxKeySize 500
-                    }
-             in Environment.decodePairs Settings.decoder env
-                  |> expectEqualShow (Ok expected),
+            expected =
+              Settings.Settings
+                { Settings.connectionInfo = connectInfo,
+                  Settings.clusterMode = Settings.Cluster,
+                  Settings.defaultExpiry = Settings.ExpireKeysAfterSeconds 10,
+                  Settings.queryTimeout = Settings.NoQueryTimeout,
+                  Settings.maxKeySize = Settings.MaxKeySize 500
+                }
+        Environment.decodePairs Settings.decoder env
+          |> expectEqualShow (Ok expected),
       Test.test "handles unix socket scheme with default db" <| \_ ->
         let env = Dict.fromList [("REDIS_CONNECTION_STRING", "redis+unix:///path/to/redis.sock")]
             expected =
@@ -101,43 +97,39 @@ decoderTests =
 decoderWithEnvVarPrefixTests :: Test.Test
 decoderWithEnvVarPrefixTests =
   Test.describe "decoderWithEnvVarPrefix tests"
-    [ Test.test "returns expected defaults when no env vars set" <| \_ ->
-        case parseConnectInfo "redis://localhost:6379" of
-          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
-          Right connectInfo ->
-            let expected =
-                  Settings.Settings
-                    { Settings.connectionInfo = connectInfo,
-                      Settings.clusterMode = Settings.NotCluster,
-                      Settings.defaultExpiry = Settings.NoDefaultExpiry,
-                      Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
-                      Settings.maxKeySize = Settings.NoMaxKeySize
-                    }
-             in Environment.decodePairs (Settings.decoderWithEnvVarPrefix "TEST_") (Dict.fromList [])
-                  |> expectEqualShow (Ok expected),
-      Test.test "returns parsed values from env when env vars set" <| \_ ->
-        case parseConnectInfo "redis://egg:bug@my-cool-host:36379/2" of
-          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
-          Right connectInfo ->
-            let env =
-                  Dict.fromList
-                    [ ("TEST_REDIS_CONNECTION_STRING", "redis://egg:bug@my-cool-host:36379/2"),
-                      ("TEST_REDIS_CLUSTER", "1"),
-                      ("TEST_REDIS_DEFAULT_EXPIRY_SECONDS", "10"),
-                      ("TEST_REDIS_QUERY_TIMEOUT_MILLISECONDS", "0"),
-                      ("TEST_REDIS_MAX_KEY_SIZE", "500")
-                    ]
+    [ Test.test "returns expected defaults when no env vars set" <| \_ -> do
+        connectInfo <- parseConnectInfoElseFailTest "redis://localhost:6379"
+        let expected =
+              Settings.Settings
+                { Settings.connectionInfo = connectInfo,
+                  Settings.clusterMode = Settings.NotCluster,
+                  Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                  Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                  Settings.maxKeySize = Settings.NoMaxKeySize
+                }
+        Environment.decodePairs (Settings.decoderWithEnvVarPrefix "TEST_") (Dict.fromList [])
+          |> expectEqualShow (Ok expected),
+      Test.test "returns parsed values from env when env vars set" <| \_ -> do
+        connectInfo <- parseConnectInfoElseFailTest "redis://egg:bug@my-cool-host:36379/2"
+        let env =
+              Dict.fromList
+                [ ("TEST_REDIS_CONNECTION_STRING", "redis://egg:bug@my-cool-host:36379/2"),
+                  ("TEST_REDIS_CLUSTER", "1"),
+                  ("TEST_REDIS_DEFAULT_EXPIRY_SECONDS", "10"),
+                  ("TEST_REDIS_QUERY_TIMEOUT_MILLISECONDS", "0"),
+                  ("TEST_REDIS_MAX_KEY_SIZE", "500")
+                ]
 
-                expected =
-                  Settings.Settings
-                    { Settings.connectionInfo = connectInfo,
-                      Settings.clusterMode = Settings.Cluster,
-                      Settings.defaultExpiry = Settings.ExpireKeysAfterSeconds 10,
-                      Settings.queryTimeout = Settings.NoQueryTimeout,
-                      Settings.maxKeySize = Settings.MaxKeySize 500
-                    }
-             in Environment.decodePairs (Settings.decoderWithEnvVarPrefix "TEST_") env
-                  |> expectEqualShow (Ok expected),
+            expected =
+              Settings.Settings
+                { Settings.connectionInfo = connectInfo,
+                  Settings.clusterMode = Settings.Cluster,
+                  Settings.defaultExpiry = Settings.ExpireKeysAfterSeconds 10,
+                  Settings.queryTimeout = Settings.NoQueryTimeout,
+                  Settings.maxKeySize = Settings.MaxKeySize 500
+                }
+        Environment.decodePairs (Settings.decoderWithEnvVarPrefix "TEST_") env
+          |> expectEqualShow (Ok expected),
       Test.test "handles unix socket scheme with default db" <| \_ ->
         let env = Dict.fromList [("TEST_REDIS_CONNECTION_STRING", "redis+unix:///path/to/redis.sock")]
             expected =
@@ -176,43 +168,39 @@ decoderWithEnvVarPrefixTests =
 decoderWithCustomConnectionStringTests :: Test.Test
 decoderWithCustomConnectionStringTests =
   Test.describe "decoderWithCustomConnectionString tests"
-    [ Test.test "returns expected defaults when no env vars set" <| \_ ->
-        case parseConnectInfo "redis://localhost:6379" of
-          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
-          Right connectInfo ->
-            let expected =
-                  Settings.Settings
-                    { Settings.connectionInfo = connectInfo,
-                      Settings.clusterMode = Settings.NotCluster,
-                      Settings.defaultExpiry = Settings.NoDefaultExpiry,
-                      Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
-                      Settings.maxKeySize = Settings.NoMaxKeySize
-                    }
-             in Environment.decodePairs (Settings.decoderWithCustomConnectionString "COOL_CONNECTION_STRING") (Dict.fromList [])
-                  |> expectEqualShow (Ok expected),
-      Test.test "returns parsed values from env when env vars set" <| \_ ->
-        case parseConnectInfo "redis://egg:bug@my-cool-host:36379/2" of
-          Left err -> Expect.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
-          Right connectInfo ->
-            let env =
-                  Dict.fromList
-                    [ ("COOL_CONNECTION_STRING", "redis://egg:bug@my-cool-host:36379/2"),
-                      ("REDIS_CLUSTER", "1"),
-                      ("REDIS_DEFAULT_EXPIRY_SECONDS", "10"),
-                      ("REDIS_QUERY_TIMEOUT_MILLISECONDS", "0"),
-                      ("REDIS_MAX_KEY_SIZE", "500")
-                    ]
+    [ Test.test "returns expected defaults when no env vars set" <| \_ -> do
+        connectInfo <- parseConnectInfoElseFailTest "redis://localhost:6379"
+        let expected =
+              Settings.Settings
+                { Settings.connectionInfo = connectInfo,
+                  Settings.clusterMode = Settings.NotCluster,
+                  Settings.defaultExpiry = Settings.NoDefaultExpiry,
+                  Settings.queryTimeout = Settings.TimeoutQueryAfterMilliseconds 1000,
+                  Settings.maxKeySize = Settings.NoMaxKeySize
+                }
+        Environment.decodePairs (Settings.decoderWithCustomConnectionString "COOL_CONNECTION_STRING") (Dict.fromList [])
+          |> expectEqualShow (Ok expected),
+      Test.test "returns parsed values from env when env vars set" <| \_ -> do
+        connectInfo <- parseConnectInfoElseFailTest "redis://egg:bug@my-cool-host:36379/2"
+        let env =
+              Dict.fromList
+                [ ("COOL_CONNECTION_STRING", "redis://egg:bug@my-cool-host:36379/2"),
+                  ("REDIS_CLUSTER", "1"),
+                  ("REDIS_DEFAULT_EXPIRY_SECONDS", "10"),
+                  ("REDIS_QUERY_TIMEOUT_MILLISECONDS", "0"),
+                  ("REDIS_MAX_KEY_SIZE", "500")
+                ]
 
-                expected =
-                  Settings.Settings
-                    { Settings.connectionInfo = connectInfo,
-                      Settings.clusterMode = Settings.Cluster,
-                      Settings.defaultExpiry = Settings.ExpireKeysAfterSeconds 10,
-                      Settings.queryTimeout = Settings.NoQueryTimeout,
-                      Settings.maxKeySize = Settings.MaxKeySize 500
-                    }
-             in Environment.decodePairs (Settings.decoderWithCustomConnectionString "COOL_CONNECTION_STRING") env
-                  |> expectEqualShow (Ok expected),
+            expected =
+              Settings.Settings
+                { Settings.connectionInfo = connectInfo,
+                  Settings.clusterMode = Settings.Cluster,
+                  Settings.defaultExpiry = Settings.ExpireKeysAfterSeconds 10,
+                  Settings.queryTimeout = Settings.NoQueryTimeout,
+                  Settings.maxKeySize = Settings.MaxKeySize 500
+                }
+        Environment.decodePairs (Settings.decoderWithCustomConnectionString "COOL_CONNECTION_STRING") env
+          |> expectEqualShow (Ok expected),
       Test.test "handles unix socket scheme with default db" <| \_ ->
         let env = Dict.fromList [("COOL_CONNECTION_STRING", "redis+unix:///path/to/redis.sock")]
             expected =
@@ -247,3 +235,10 @@ decoderWithCustomConnectionStringTests =
          in Environment.decodePairs (Settings.decoderWithCustomConnectionString "COOL_CONNECTION_STRING") env
             |> expectEqualShow (Ok expected)
     ]
+
+parseConnectInfoElseFailTest :: String -> Expect.Expectation' ConnectInfo
+parseConnectInfoElseFailTest uri = do
+  Expect.succeeds <|
+    case parseConnectInfo uri of
+      Left err -> Task.fail <| "you wrote this test wrong, got err: " ++ Text.fromList err
+      Right connectInfo -> pure connectInfo

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-counter-query
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-counter-query
@@ -7,11 +7,11 @@ TracingSpan
         ( "rootTracingSpanIO"
         , SrcLoc
             { srcLocPackage = "main"
-            , srcLocModule = "Main"
-            , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 36
+            , srcLocModule = "Spec.Redis"
+            , srcLocFile = "test/Spec/Redis.hs"
+            , srcLocStartLine = 29
             , srcLocStartCol = 7
-            , srcLocEndLine = 40
+            , srcLocEndLine = 33
             , srcLocEndCol = 40
             }
         )
@@ -30,11 +30,11 @@ TracingSpan
                 ( "query"
                 , SrcLoc
                     { srcLocPackage = "main"
-                    , srcLocModule = "Main"
-                    , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 111
+                    , srcLocModule = "Spec.Redis"
+                    , srcLocFile = "test/Spec/Redis.hs"
+                    , srcLocStartLine = 104
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 111
+                    , srcLocEndLine = 104
                     , srcLocEndCol = 68
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-counter-transaction
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-counter-transaction
@@ -7,11 +7,11 @@ TracingSpan
         ( "rootTracingSpanIO"
         , SrcLoc
             { srcLocPackage = "main"
-            , srcLocModule = "Main"
-            , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 36
+            , srcLocModule = "Spec.Redis"
+            , srcLocFile = "test/Spec/Redis.hs"
+            , srcLocStartLine = 29
             , srcLocStartCol = 7
-            , srcLocEndLine = 40
+            , srcLocEndLine = 33
             , srcLocEndCol = 40
             }
         )
@@ -30,11 +30,11 @@ TracingSpan
                 ( "transaction"
                 , SrcLoc
                     { srcLocPackage = "main"
-                    , srcLocModule = "Main"
-                    , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 118
+                    , srcLocModule = "Spec.Redis"
+                    , srcLocFile = "test/Spec/Redis.hs"
+                    , srcLocStartLine = 111
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 118
+                    , srcLocEndLine = 111
                     , srcLocEndCol = 74
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-hash-query
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-hash-query
@@ -7,11 +7,11 @@ TracingSpan
         ( "rootTracingSpanIO"
         , SrcLoc
             { srcLocPackage = "main"
-            , srcLocModule = "Main"
-            , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 36
+            , srcLocModule = "Spec.Redis"
+            , srcLocFile = "test/Spec/Redis.hs"
+            , srcLocStartLine = 29
             , srcLocStartCol = 7
-            , srcLocEndLine = 40
+            , srcLocEndLine = 33
             , srcLocEndCol = 40
             }
         )
@@ -30,11 +30,11 @@ TracingSpan
                 ( "query"
                 , SrcLoc
                     { srcLocPackage = "main"
-                    , srcLocModule = "Main"
-                    , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 83
+                    , srcLocModule = "Spec.Redis"
+                    , srcLocFile = "test/Spec/Redis.hs"
+                    , srcLocStartLine = 76
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 83
+                    , srcLocEndLine = 76
                     , srcLocEndCol = 59
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-hash-transaction
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-hash-transaction
@@ -7,11 +7,11 @@ TracingSpan
         ( "rootTracingSpanIO"
         , SrcLoc
             { srcLocPackage = "main"
-            , srcLocModule = "Main"
-            , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 36
+            , srcLocModule = "Spec.Redis"
+            , srcLocFile = "test/Spec/Redis.hs"
+            , srcLocStartLine = 29
             , srcLocStartCol = 7
-            , srcLocEndLine = 40
+            , srcLocEndLine = 33
             , srcLocEndCol = 40
             }
         )
@@ -30,11 +30,11 @@ TracingSpan
                 ( "transaction"
                 , SrcLoc
                     { srcLocPackage = "main"
-                    , srcLocModule = "Main"
-                    , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 90
+                    , srcLocModule = "Spec.Redis"
+                    , srcLocFile = "test/Spec/Redis.hs"
+                    , srcLocStartLine = 83
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 90
+                    , srcLocEndLine = 83
                     , srcLocEndCol = 65
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-list-query
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-list-query
@@ -7,11 +7,11 @@ TracingSpan
         ( "rootTracingSpanIO"
         , SrcLoc
             { srcLocPackage = "main"
-            , srcLocModule = "Main"
-            , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 36
+            , srcLocModule = "Spec.Redis"
+            , srcLocFile = "test/Spec/Redis.hs"
+            , srcLocStartLine = 29
             , srcLocStartCol = 7
-            , srcLocEndLine = 40
+            , srcLocEndLine = 33
             , srcLocEndCol = 40
             }
         )
@@ -30,11 +30,11 @@ TracingSpan
                 ( "query"
                 , SrcLoc
                     { srcLocPackage = "main"
-                    , srcLocModule = "Main"
-                    , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 97
+                    , srcLocModule = "Spec.Redis"
+                    , srcLocFile = "test/Spec/Redis.hs"
+                    , srcLocStartLine = 90
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 97
+                    , srcLocEndLine = 90
                     , srcLocEndCol = 59
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-list-transaction
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-list-transaction
@@ -7,11 +7,11 @@ TracingSpan
         ( "rootTracingSpanIO"
         , SrcLoc
             { srcLocPackage = "main"
-            , srcLocModule = "Main"
-            , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 36
+            , srcLocModule = "Spec.Redis"
+            , srcLocFile = "test/Spec/Redis.hs"
+            , srcLocStartLine = 29
             , srcLocStartCol = 7
-            , srcLocEndLine = 40
+            , srcLocEndLine = 33
             , srcLocEndCol = 40
             }
         )
@@ -30,11 +30,11 @@ TracingSpan
                 ( "transaction"
                 , SrcLoc
                     { srcLocPackage = "main"
-                    , srcLocModule = "Main"
-                    , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 104
+                    , srcLocModule = "Spec.Redis"
+                    , srcLocFile = "test/Spec/Redis.hs"
+                    , srcLocStartLine = 97
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 104
+                    , srcLocEndLine = 97
                     , srcLocEndCol = 65
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-query
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-query
@@ -7,11 +7,11 @@ TracingSpan
         ( "rootTracingSpanIO"
         , SrcLoc
             { srcLocPackage = "main"
-            , srcLocModule = "Main"
-            , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 36
+            , srcLocModule = "Spec.Redis"
+            , srcLocFile = "test/Spec/Redis.hs"
+            , srcLocStartLine = 29
             , srcLocStartCol = 7
-            , srcLocEndLine = 40
+            , srcLocEndLine = 33
             , srcLocEndCol = 40
             }
         )
@@ -30,11 +30,11 @@ TracingSpan
                 ( "query"
                 , SrcLoc
                     { srcLocPackage = "main"
-                    , srcLocModule = "Main"
-                    , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 69
+                    , srcLocModule = "Spec.Redis"
+                    , srcLocFile = "test/Spec/Redis.hs"
+                    , srcLocStartLine = 62
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 69
+                    , srcLocEndLine = 62
                     , srcLocEndCol = 45
                     }
                 )

--- a/nri-redis/test/golden-results/observability-spec-reporting-redis-transaction
+++ b/nri-redis/test/golden-results/observability-spec-reporting-redis-transaction
@@ -7,11 +7,11 @@ TracingSpan
         ( "rootTracingSpanIO"
         , SrcLoc
             { srcLocPackage = "main"
-            , srcLocModule = "Main"
-            , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 36
+            , srcLocModule = "Spec.Redis"
+            , srcLocFile = "test/Spec/Redis.hs"
+            , srcLocStartLine = 29
             , srcLocStartCol = 7
-            , srcLocEndLine = 40
+            , srcLocEndLine = 33
             , srcLocEndCol = 40
             }
         )
@@ -30,11 +30,11 @@ TracingSpan
                 ( "transaction"
                 , SrcLoc
                     { srcLocPackage = "main"
-                    , srcLocModule = "Main"
-                    , srcLocFile = "test/Main.hs"
-                    , srcLocStartLine = 76
+                    , srcLocModule = "Spec.Redis"
+                    , srcLocFile = "test/Spec/Redis.hs"
+                    , srcLocStartLine = 69
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 76
+                    , srcLocEndLine = 69
                     , srcLocEndCol = 51
                     }
                 )


### PR DESCRIPTION
see title + diff in readme

tested with redis hosted on a unix socket by doing the following:
1. delete golden test results
2. `REDIS_CONNECTION_STRING=redis+unix://<absolute_path_to_redis_socket>?db=10 cabal test nri-redis` (`10` was chosen at random)

tests still work with redis hosted on a tcp socket 😎 