### PR TITLE
Kafka fire repro

### DIFF
--- a/nri-kafka/scripts/pause-resume-bug/Consumer.hs
+++ b/nri-kafka/scripts/pause-resume-bug/Consumer.hs
@@ -20,8 +20,8 @@ main = do
   setEnv "KAFKA_MAX_MSGS_PER_PARTITION_BUFFERED_LOCALLY" "20"
   setEnv "KAFKA_POLL_BATCH_SIZE" "5"
 
-  fireDelay <- readIntEnvVar "FIRE_DELAY"
-  fireModulo <- readIntEnvVar "FIRE_MODULO"
+  fireDelay <- readIntEnvVar "FIRE_DELAY" 31  -- seconds
+  fireModulo <- readIntEnvVar "FIRE_MODULO" 5 -- sleep on every Nth message
 
   settings <- Environment.decode Kafka.decoder
   doAnythingHandler <- Platform.doAnythingHandler
@@ -54,11 +54,11 @@ printAtomic lock handle msg = do
     |> forkIO
     |> void
 
-readIntEnvVar :: String -> IO Int
-readIntEnvVar name = do
+readIntEnvVar :: String -> Int -> IO Int
+readIntEnvVar name defaultVal = do
   valueStr <- getEnv name
   valueStr 
     |> Text.fromList 
     |> Text.toInt 
-    |> Maybe.withDefault (Debug.todo (Text.fromList name ++ " must be a number"))
+    |> Maybe.withDefault defaultVal
     |> pure

--- a/nri-kafka/scripts/pause-resume-bug/Consumer.hs
+++ b/nri-kafka/scripts/pause-resume-bug/Consumer.hs
@@ -1,14 +1,14 @@
 module Consumer where
 
 import Control.Concurrent (forkIO, threadDelay)
-import Control.Concurrent.MVar (MVar, newEmptyMVar, newMVar, putMVar, tryTakeMVar, withMVar)
-import Control.Monad (void)
+import Control.Concurrent.MVar (MVar, newMVar, withMVar)
+import Control.Monad (void, when)
 import qualified Environment
 import qualified Kafka.Worker as Kafka
 import Message
-import System.Environment (setEnv)
-import System.IO (Handle, hPutStrLn, stderr, stdout)
-import Prelude (IO, String, show)
+import System.Environment (getEnv, setEnv)
+import System.IO (Handle, hPutStrLn, stdout)
+import Prelude (IO, String, mod, show, fromIntegral, pure)
 
 main :: IO ()
 main = do
@@ -20,39 +20,26 @@ main = do
   setEnv "KAFKA_MAX_MSGS_PER_PARTITION_BUFFERED_LOCALLY" "20"
   setEnv "KAFKA_POLL_BATCH_SIZE" "5"
 
+  fireDelay <- readIntEnvVar "FIRE_DELAY"
+  fireModulo <- readIntEnvVar "FIRE_MODULO"
+
   settings <- Environment.decode Kafka.decoder
   doAnythingHandler <- Platform.doAnythingHandler
-  lastId <- newEmptyMVar
 
   lock <- newMVar ()
 
   let processMsg (msg :: Message) =
         ( do
-            let msgId = ("ID(" ++ show (id msg) ++ ")")
-            prevId <- tryTakeMVar lastId
-
-            case (prevId, id msg) of
-              (Nothing, _) ->
-                printAtomic lock stdout (msgId ++ " First message has been received")
-              (_, 1) ->
-                printAtomic lock stdout (msgId ++ " Producer has been restarted")
-              (Just prev, curr)
-                | prev + 1 == curr ->
-                    -- This is the expected behavior
-                    printAtomic lock stdout (msgId ++ " OK")
-              (Just prev, curr) ->
-                -- This is the bug
-                printAtomic
-                  lock
-                  stderr
-                  ( "ERROR: Expected ID "
-                      ++ show (prev + 1)
-                      ++ " but got "
-                      ++ show curr
-                  )
-
-            putMVar lastId (id msg)
-            threadDelay 200000
+            let msgId = id msg
+            let msgIdStr = "ID(" ++ show msgId ++ ")"
+            when
+              (msgId `mod` fireModulo == 0)
+              ( do
+                  printAtomic lock stdout (msgIdStr ++ " Pausing consumer (simulating stuck MySQL)")
+                  threadDelay (fromIntegral fireDelay * 1000000)
+              )
+            printAtomic lock stdout (msgIdStr ++ " Done")
+            threadDelay 2000
         )
           |> fmap Ok
           |> Platform.doAnything doAnythingHandler
@@ -66,3 +53,12 @@ printAtomic lock handle msg = do
     |> withMVar lock
     |> forkIO
     |> void
+
+readIntEnvVar :: String -> IO Int
+readIntEnvVar name = do
+  valueStr <- getEnv name
+  valueStr 
+    |> Text.fromList 
+    |> Text.toInt 
+    |> Maybe.withDefault (Debug.todo (Text.fromList name ++ " must be a number"))
+    |> pure


### PR DESCRIPTION
Trying to reproduce [this fire](https://paper.dropbox.com/doc/2023-11-02-HQE-Kafka-workers-stopped--CDSUonsyZoX4tx8zHAYbBeILAg-6qsaoJnRLUxl15UOBD2iu)
I do not see librdkafka complaining about not polling
The polling thread seems to happily print out that it is polling, while the consumer is paused.
When I insert a long delay into the consumer, it gets behind on its work. Meanwhile, the polling thread continues enqueueing all of the records it can get. But the consumer is stuck so it can't process them.
I thought this might cause it to run out of memory but that's not what we observed in the fire.