### PR TITLE
Redis error can have eq

### DIFF
--- a/nix/mk-shell.nix
+++ b/nix/mk-shell.nix
@@ -6,11 +6,6 @@ let
     with pkgs.haskell.lib;
     overrideCabal hpkg (drv: { enableSeparateBinOutput = false; });
   # It is still necessary to run `hpack --force` into packages home dirs
-  haskell-language-server = pkgs.haskellPackages.haskell-language-server.override {
-    hls-ormolu-plugin = pkgs.haskellPackages.hls-ormolu-plugin.override {
-      ormolu = (workaround140774 pkgs.haskellPackages.ormolu);
-    };
-  };
 
 in pkgs.mkShell {
   buildInputs = [
@@ -72,7 +67,6 @@ in pkgs.mkShell {
     pkgs.cabal-install
     pkgs.cachix
     pkgs.gnumake
-    haskell-language-server
     pkgs.haskellPackages.hpack
     pkgs.pcre
     pkgs.postgresql # for nri-postgres

--- a/nri-redis/nri-redis.cabal
+++ b/nri-redis/nri-redis.cabal
@@ -60,7 +60,7 @@ library
       ScopedTypeVariables
       Strict
       TypeOperators
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fno-warn-type-defaults -fplugin=NriPrelude.Plugin
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fno-warn-type-defaults
   build-depends:
       aeson >=1.4.6.0 && <2.2
     , async >=2.2.2 && <2.3
@@ -119,7 +119,7 @@ test-suite tests
       ScopedTypeVariables
       Strict
       TypeOperators
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fno-warn-type-defaults -fplugin=NriPrelude.Plugin -threaded -rtsopts "-with-rtsopts=-N -T" -fno-warn-type-defaults
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fno-warn-type-defaults -threaded -rtsopts "-with-rtsopts=-N -T" -fno-warn-type-defaults
   build-depends:
       aeson >=1.4.6.0 && <2.2
     , async >=2.2.2 && <2.3

--- a/nri-redis/package.yaml
+++ b/nri-redis/package.yaml
@@ -68,7 +68,6 @@ ghc-options:
   - -Wredundant-constraints
   - -Wincomplete-uni-patterns
   - -fno-warn-type-defaults
-  - -fplugin=NriPrelude.Plugin
 tests:
   tests:
     main: Spec.hs

--- a/nri-redis/src/NonEmptyDict.hs
+++ b/nri-redis/src/NonEmptyDict.hs
@@ -12,6 +12,7 @@ where
 
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Dict
+import NriPrelude
 
 -- | A Dict with at least one entry. For use in writing to redis, where it's an
 -- error when writing nothing
@@ -20,14 +21,14 @@ data NonEmptyDict k v
   deriving (Show)
 
 -- | tries to create a 'NonEmptyDict' from a 'Dict'
-fromDict :: Ord k => Dict.Dict k v -> Maybe (NonEmptyDict k v)
+fromDict :: (Ord k) => Dict.Dict k v -> Maybe (NonEmptyDict k v)
 fromDict dict =
   case Dict.toList dict of
     [] -> Nothing
     (k, v) : _ -> Just <| init k v dict
 
 -- | creates a 'Dict' from a 'NonEmptyDict'
-toDict :: Ord k => NonEmptyDict k v -> Dict k v
+toDict :: (Ord k) => NonEmptyDict k v -> Dict k v
 toDict (NonEmptyDict (k, v) dict) =
   Dict.insert k v dict
 
@@ -37,6 +38,6 @@ toNonEmptyList (NonEmptyDict kv dict) =
   kv :| Dict.toList dict
 
 -- | creates a `NonEmptyDict` from a key, value, and dict
-init :: Ord k => k -> v -> Dict.Dict k v -> NonEmptyDict k v
+init :: (Ord k) => k -> v -> Dict.Dict k v -> NonEmptyDict k v
 init key val dict =
   NonEmptyDict (key, val) (Dict.remove key dict)

--- a/nri-redis/src/Redis.hs
+++ b/nri-redis/src/Redis.hs
@@ -57,6 +57,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Dict
 import qualified NonEmptyDict
+import NriPrelude
 import qualified Redis.Codec as Codec
 import qualified Redis.Handler as Handler
 import qualified Redis.Internal as Internal
@@ -102,7 +103,7 @@ data Api key a = Api
     -- operation never fails.
     --
     -- https://redis.io/commands/mget
-    mget :: Ord key => NonEmpty key -> Internal.Query (Dict.Dict key a),
+    mget :: (Ord key) => NonEmpty key -> Internal.Query (Dict.Dict key a),
     -- | Sets the given keys to their respective values. MSET replaces existing
     -- values with new values, just as regular SET. See MSETNX if you don't want to
     -- overwrite existing values.

--- a/nri-redis/src/Redis/Codec.hs
+++ b/nri-redis/src/Redis/Codec.hs
@@ -6,7 +6,9 @@ import qualified Data.Aeson as Aeson
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy
 import qualified Data.Text.Encoding
+import NriPrelude
 import qualified Redis.Internal as Internal
+import qualified Text
 import qualified Prelude
 
 data Codec a = Codec
@@ -21,10 +23,10 @@ type Decoder a = ByteString -> Result Internal.Error a
 jsonCodec :: (Aeson.FromJSON a, Aeson.ToJSON a) => Codec a
 jsonCodec = Codec jsonEncoder jsonDecoder
 
-jsonEncoder :: Aeson.ToJSON a => Encoder a
+jsonEncoder :: (Aeson.ToJSON a) => Encoder a
 jsonEncoder = Aeson.encode >> Data.ByteString.Lazy.toStrict
 
-jsonDecoder :: Aeson.FromJSON a => Decoder a
+jsonDecoder :: (Aeson.FromJSON a) => Decoder a
 jsonDecoder byteString =
   case Aeson.eitherDecodeStrict' byteString of
     Prelude.Right decoded -> Ok decoded

--- a/nri-redis/src/Redis/Counter.hs
+++ b/nri-redis/src/Redis/Counter.hs
@@ -42,6 +42,7 @@ where
 
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
+import NriPrelude
 import qualified Redis.Codec as Codec
 import qualified Redis.Handler as Handler
 import qualified Redis.Internal as Internal

--- a/nri-redis/src/Redis/Handler.hs
+++ b/nri-redis/src/Redis/Handler.hs
@@ -16,10 +16,13 @@ import qualified Data.Text.Encoding
 import qualified Database.Redis
 import qualified Dict
 import qualified GHC.Stack as Stack
+import qualified List
+import NriPrelude
 import qualified Platform
 import qualified Redis.Internal as Internal
 import qualified Redis.Settings as Settings
 import qualified Set
+import qualified Task
 import qualified Text
 import Prelude (Either (Left, Right), IO, fromIntegral, pure)
 import qualified Prelude
@@ -342,7 +345,7 @@ data Connection = Connection
   }
 
 platformRedis ::
-  Stack.HasCallStack =>
+  (Stack.HasCallStack) =>
   [Text] ->
   Connection ->
   Platform.DoAnythingHandler ->

--- a/nri-redis/src/Redis/Hash.hs
+++ b/nri-redis/src/Redis/Hash.hs
@@ -54,6 +54,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Dict
 import qualified NonEmptyDict
+import NriPrelude
 import qualified Redis.Codec as Codec
 import qualified Redis.Handler as Handler
 import qualified Redis.Internal as Internal
@@ -153,7 +154,7 @@ jsonApi = makeApi Codec.jsonCodec
 
 -- | Creates a Redis API mapping a 'key' to Text
 textApi ::
-  Ord field =>
+  (Ord field) =>
   (key -> Text) ->
   (field -> Text) ->
   (Text -> Maybe field) ->
@@ -162,7 +163,7 @@ textApi = makeApi Codec.textCodec
 
 -- | Creates a Redis API mapping a 'key' to a ByteString
 byteStringApi ::
-  Ord field =>
+  (Ord field) =>
   (key -> Text) ->
   (field -> Text) ->
   (Text -> Maybe field) ->
@@ -170,7 +171,7 @@ byteStringApi ::
 byteStringApi = makeApi Codec.byteStringCodec
 
 makeApi ::
-  Ord field =>
+  (Ord field) =>
   Codec.Codec a ->
   (key -> Text) ->
   (field -> Text) ->
@@ -211,7 +212,7 @@ makeApi Codec.Codec {Codec.codecEncoder, Codec.codecDecoder} toKey toField fromF
         Internal.Hsetnx (toKey key) (toField field) (codecEncoder val)
     }
 
-toDict :: Ord field => (Text -> Maybe field) -> Codec.Decoder a -> List (Text, ByteString) -> Result Internal.Error (Dict.Dict field a)
+toDict :: (Ord field) => (Text -> Maybe field) -> Codec.Decoder a -> List (Text, ByteString) -> Result Internal.Error (Dict.Dict field a)
 toDict fromField decode =
   Result.map Dict.fromList
     << Prelude.traverse

--- a/nri-redis/src/Redis/Internal.hs
+++ b/nri-redis/src/Redis/Internal.hs
@@ -54,6 +54,7 @@ data Error
   | TransactionAborted
   | TimeoutError
   | KeyExceedsMaxSize Text Int
+  deriving (Eq)
 
 instance Aeson.ToJSON Error where
   toJSON err = Aeson.toJSON (errorForHumans err)

--- a/nri-redis/src/Redis/List.hs
+++ b/nri-redis/src/Redis/List.hs
@@ -45,6 +45,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as ByteString
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
+import NriPrelude
 import qualified Redis.Codec as Codec
 import qualified Redis.Handler as Handler
 import qualified Redis.Internal as Internal

--- a/nri-redis/src/Redis/Set.hs
+++ b/nri-redis/src/Redis/Set.hs
@@ -47,6 +47,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as ByteString
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
+import NriPrelude
 import qualified Redis.Codec as Codec
 import qualified Redis.Handler as Handler
 import qualified Redis.Internal as Internal
@@ -129,7 +130,7 @@ byteStringApi :: (key -> Text) -> Api key ByteString.ByteString
 byteStringApi = makeApi Codec.byteStringCodec
 
 makeApi ::
-  Ord a =>
+  (Ord a) =>
   Codec.Codec a ->
   (key -> Text) ->
   Api key a

--- a/nri-redis/src/Redis/Settings.hs
+++ b/nri-redis/src/Redis/Settings.hs
@@ -14,6 +14,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import Data.Text.Encoding (encodeUtf8)
 import Database.Redis hiding (Ok)
 import qualified Environment
+import NriPrelude
 import qualified Text
 import qualified Text.URI as URI
 import Prelude (Either (Left, Right), foldr, fromIntegral, id, pure)
@@ -122,13 +123,13 @@ decoderConnectInfo envVarName =
         )
     )
 
-parseRedisSchemeURI :: URI.URI -> Result Text ConnectInfo
+parseRedisSchemeURI :: URI.URI -> NriPrelude.Result Text ConnectInfo
 parseRedisSchemeURI uri =
   case parseConnectInfo (URI.renderStr uri) of
     Left parseError -> Err ("Invalid Redis connection string: " ++ Text.fromList parseError)
     Right info' -> Ok info'
 
-parseRedisSocketSchemeURI :: URI.URI -> Result Text ConnectInfo
+parseRedisSocketSchemeURI :: URI.URI -> NriPrelude.Result Text ConnectInfo
 parseRedisSocketSchemeURI uri =
   let uriPathTextFromURI =
         case URI.uriPath uri of

--- a/nri-redis/src/Redis/SortedSet.hs
+++ b/nri-redis/src/Redis/SortedSet.hs
@@ -47,6 +47,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map.Strict
 import qualified NonEmptyDict
+import NriPrelude
 import qualified Redis.Codec as Codec
 import qualified Redis.Handler as Handler
 import qualified Redis.Internal as Internal
@@ -134,7 +135,7 @@ byteStringApi :: (key -> Text) -> Api key ByteString.ByteString
 byteStringApi = makeApi Codec.byteStringCodec
 
 makeApi ::
-  Ord a =>
+  (Ord a) =>
   Codec.Codec a ->
   (key -> Text) ->
   Api key a


### PR DESCRIPTION
While working through a refactor I found that existing tests that expected equality based on a Webserver Error would have be to modified to assert against a different Error type. That type I started to create had a variant that wrapped the `Redis.Error`. I found that `Redis.Error` did not have an `Eq` instance. And I thought to myself hmmm, why not?

This also removes the Haskell LS from nix. The version coming from nix was old, and did not work with ghc 9.4.7. I found that using ghcup to get the LS on version 2.5.0 built with 9.4.7 worked out great!

Lastly I also removed fplugin from `nri-redis` as we have in other places, and sorted out the imports as needed.

If this is cool, I am not sure what I need to do to go about bumping versions of things. Please let me know :).