### PR TITLE
add tshow

### DIFF
--- a/nri-prelude/src/Text.hs
+++ b/nri-prelude/src/Text.hs
@@ -484,3 +484,10 @@ any = Data.Text.any
 -- > all isDigit "heart" == False
 all :: (Char -> Bool) -> Text -> Bool
 all = Data.Text.all
+
+-- | Get a Text representation of something Show-able.
+--
+-- > newtype MyType = MyType deriving (Show)
+-- > myTypeText = tshow MyType
+tshow :: (Show a) => a -> Text
+tshow = Data.Text.pack << Prelude.show


### PR DESCRIPTION
We often end up using `Debug.toString` in places where we want to like... not actually debug something but just get a `Text`. It finally bugged me enough that I ran off to [Hoogle](https://hoogle.haskell.org/?hoogle=Show%20a%20%3D%3E%20a%20-%3E%20Text). From there I carefully ~stole~ ~borrowed~ literally copy pasted from the definition in RIO.Prelude.