### PR TITLE
Allow specifying where devlogs go through NRI_DEV_LOG

### DIFF
--- a/nri-prelude/CHANGELOG.md
+++ b/nri-prelude/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Allow specifying where devlogs for log-explorer go through `NRI_DEV_LOG` environment variable.
+
 # 0.6.1.2
 
 - Support GHC 9.4.7, `aeson-2.1.x`, `lens-5.2.x`, `hedgehog-1.3`, `vector-0.13.x`

--- a/nri-prelude/src/Platform/DevLog.hs
+++ b/nri-prelude/src/Platform/DevLog.hs
@@ -12,6 +12,7 @@ import qualified Data.ByteString.Lazy
 import qualified Data.Time as Time
 import NriPrelude
 import qualified Platform.Internal
+import qualified System.Environment.Blank as Environment
 import qualified System.IO
 import qualified System.IO.Unsafe
 import qualified System.Posix.Files as Files
@@ -22,7 +23,7 @@ import qualified Prelude
 writeSpanToDevLog :: Platform.Internal.TracingSpan -> Prelude.IO ()
 writeSpanToDevLog span = do
   now <- Time.getCurrentTime
-  let logFile = "/tmp/nri-prelude-logs"
+  logFile <- Environment.getEnvDefault "NRI_DEV_LOG" "/tmp/nri-prelude-logs"
   MVar.withMVar writeLock <| \_ ->
     System.IO.withFile
       logFile

--- a/nri-prelude/src/Test/Reporter/Junit.hs
+++ b/nri-prelude/src/Test/Reporter/Junit.hs
@@ -81,7 +81,7 @@ renderFailed test maybeSrcLoc =
             Nothing -> msg
             Just (loc, src) ->
               Test.Reporter.Internal.renderSrcLoc loc src
-                |> Text.Colour.renderChunksBS Text.Colour.WithoutColours
+                |> Text.Colour.renderChunksUtf8BS Text.Colour.WithoutColours
                 |> TE.decodeUtf8
                 |> (\srcStr -> srcStr ++ "\n" ++ msg)
        in JUnit.failed (Internal.name test)

--- a/nri-prelude/src/Test/Reporter/Stdout.hs
+++ b/nri-prelude/src/Test/Reporter/Stdout.hs
@@ -28,7 +28,7 @@ report :: System.IO.Handle -> Internal.SuiteResult -> Prelude.IO ()
 report handle results = do
   terminalCapabilities <- Text.Colour.Capabilities.FromEnv.getTerminalCapabilitiesFromHandle handle
   reportChunks <- renderReport results
-  Text.Colour.hPutChunksWith terminalCapabilities handle reportChunks
+  Text.Colour.hPutChunksUtf8With terminalCapabilities handle reportChunks
   System.IO.hFlush handle
 
 renderReport :: Internal.SuiteResult -> Prelude.IO (List (Text.Colour.Chunk))

--- a/nri-prelude/src/Text.hs
+++ b/nri-prelude/src/Text.hs
@@ -48,6 +48,9 @@ module Text
     toList,
     fromList,
 
+    -- * Random stuff to Text
+    tshow,
+
     -- * Formatting
 
     -- | Cosmetic operations such as padding with extra characters or trimming whitespace.
@@ -489,5 +492,5 @@ all = Data.Text.all
 --
 -- > newtype MyType = MyType deriving (Show)
 -- > myTypeText = tshow MyType
-tshow :: (Show a) => a -> Text
+tshow :: (Prelude.Show a) => a -> Text
 tshow = Data.Text.pack << Prelude.show


### PR DESCRIPTION
Always using `/tmp/nri-prelude-logs` for devlogs can be unhelpful, especially in CI situations:

- having a single global file means there's global mutable state that cannot be made local to the system under test
- different processes may be writing spans at the same time, leading to broken output

Note that we do use an MVar based lock for the devlog, but this is local to a single GHC process. Running the testsuites of multiple programs concurrently is not compatible with this setup.

By specifying an alternate location for the dev log, we can easily work around these issues, as well as fitting better into the 12 factor pattern of application development.
