### PR TITLE
Patch to avoid using `IncoherentInstances`

### DIFF
--- a/nri-redis/src/Redis/Script.hs
+++ b/nri-redis/src/Redis/Script.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -62,15 +61,15 @@ data ScriptParam
 class HasScriptParam a where
   getScriptParam :: a -> ScriptParam
 
-instance HasScriptParam ScriptParam where
+-- | This instance is marked as INCOHERENT so that it will be chosen if possible in the overlapping case
+instance {-# INCOHERENT #-} HasScriptParam ScriptParam where
   getScriptParam = Prelude.id
 
 -- | This instance is used to provide a helpful error message when a user tries to use a type
 -- other than a ScriptParam in a [script|${ ... }|] quasi quote.
 --
--- It is what forces us to have IncoherentInstances and UndecidedInstances enabled.
+-- It is what forces us to hav UndecidableInstances enabled.
 instance
-  {-# OVERLAPPABLE #-}
   GHC.TypeLits.TypeError ('GHC.TypeLits.Text "[script| ${..} ] interpolation only supports Key or Literal inputs.") =>
   HasScriptParam x
   where


### PR DESCRIPTION
My editor was flagging `IncoherentInstances` in red, presumably because it is a deprecated language extension. 

<img width="300" alt="image" src="https://github.com/NoRedInk/haskell-libraries/assets/12899207/9e91945f-bf9b-446a-9cf9-e77b49b50c1b">

I did a bit of [reading on overlapping instances](https://serokell.io/blog/learn-from-errors-overlapping-instances#overlapping-instances-with-type-variables) and found that we can just specify `INCOHERENT` directly on the instance and avoid the language extension!