### PR TITLE
nri-http: fix timeout value in microseconds

### DIFF
--- a/nri-http/src/Http.hs
+++ b/nri-http/src/Http.hs
@@ -218,8 +218,7 @@ _request doAnythingHandler manager settings = do
                   HTTP.requestBody = HTTP.RequestBodyLBS <| Internal.bodyContents (Internal.body settings),
                   HTTP.responseTimeout =
                     Internal.timeout settings
-                      |> Maybe.withDefault (30 * 1000)
-                      |> (*) 1000
+                      |> Maybe.withDefault (30 * 1000 * 1000)
                       |> fromIntegral
                       |> HTTP.responseTimeoutMicro
                 }


### PR DESCRIPTION
According nri-http docs, the `timeout` value should be specified in microseconds. However this value is being multiplied by 1000 before passed to `http-client` library which also expects the value to be in microseconds.

Effectively we already use this value throughout our codebase as microseconds, so it makes sense to fix the code and not the docs.