### PR TITLE
get CI working & misc cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
           - os: ubuntu-22.04 # linux x86_64; 4 vcpu, 16 GB memory
             base-nixpkgs-channel: nixos-24.05
         ghc:
-          - ghc-9-2
-          - ghc-9-4
           - ghc-9-6
     runs-on: ${{ matrix.runner.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         runner:
           - os: macos-14 # macos sonoma on m1; 3 vcpu, 7 GB memory
-            base-nixpkgs-channel: nixpkgs-23.11-darwin
+            base-nixpkgs-channel: nixpkgs-24.05-darwin
           - os: ubuntu-22.04 # linux x86_64; 4 vcpu, 16 GB memory
-            base-nixpkgs-channel: nixos-23.11
+            base-nixpkgs-channel: nixos-24.05
         ghc:
           - ghc-9-2
           - ghc-9-4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.runner.os }}
     steps:
       - name: Install Nix
-        uses: cachix/install-nix-action@v26
+        uses: cachix/install-nix-action@v30
         with:
           nix_path: nixpkgs=channel:${{ matrix.runner.base-nixpkgs-channel }}
           extra_nix_config: |
@@ -37,7 +37,7 @@ jobs:
         run: nix-env -f '<nixpkgs>' -iA cachix
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Documentation comments use the [Haddock][haddock] format to ensure they are rend
 
 ### Testing compilation
 
-Our default `shell.nix` sets up an environment around the most recent version of GHC that we support. CI also runs tests against a couple of older versions of GHC. To test using any of these versions locally:
+Our default `shell.nix` sets up an environment around the most recent version of GHC that we support. CI used to supporst running tests against a different versions of GHC. To test using any of these versions locally:
 
 ```sh
 cachix use nri              # set up cache so the next step goes faster

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Documentation comments use the [Haddock][haddock] format to ensure they are rend
 
 ### Testing compilation
 
-Our default `shell.nix` sets up an environment around the most recent version of GHC that we support. CI used to supporst running tests against a different versions of GHC. To test using any of these versions locally:
+Our default `shell.nix` sets up an environment around the most recent version of GHC that we support. CI used to support running tests against a different versions of GHC. To test using any of these versions locally:
 
 ```sh
 cachix use nri              # set up cache so the next step goes faster

--- a/nri-postgresql/cleanup-postgres.sh
+++ b/nri-postgresql/cleanup-postgres.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+PGDATA="$(realpath ../_build/postgres/data)"
+export PGDATA
+export PGUSER=$USER
+pg_ctl stop || true
+rm -rf "$PGDATA"

--- a/nri-postgresql/setup-postgres.sh
+++ b/nri-postgresql/setup-postgres.sh
@@ -5,8 +5,7 @@ mkdir -p "../_build/postgres/data"
 PGDATA="$(realpath ../_build/postgres/data)"
 export PGDATA
 export PGUSER=$USER
-pg_ctl stop || true
-rm -rf "$PGDATA"
+source cleanup-postgres.sh
 initdb --no-locale --encoding=UTF8
 pg_ctl start -o '-k . -p 5432'
 

--- a/nri-postgresql/src/Postgres/Connection.hs
+++ b/nri-postgresql/src/Postgres/Connection.hs
@@ -53,12 +53,15 @@ connectionIO settings = do
   doAnything <- Platform.doAnythingHandler
   pool <-
     map Pool
-      <| Data.Pool.createPool
-        (pgConnect database `Exception.catch` handleError (toConnectionString database))
-        pgDisconnect
-        stripes
-        maxIdleTime
-        size
+      <| Data.Pool.newPool
+        ( Data.Pool.defaultPoolConfig
+            (pgConnect database `Exception.catch` handleError (toConnectionString database))
+            pgDisconnect
+            (Prelude.realToFrac maxIdleTime)
+            (stripes * size)
+            |> Data.Pool.setNumStripes (Just stripes)
+        )
+
   Prelude.pure
     ( Connection
         doAnything

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -10,22 +10,21 @@ popd
 ## block us, if it happens to be enabled. This is an instance for testing only.
 mkdir -p ./_build/redis/data
 redis-server --daemonize yes \
-  --dir ./_build/redis/data \
-  --save '' \
-  --stop-writes-on-bgsave-error no
+    --dir ./_build/redis/data \
+    --save '' \
+    --stop-writes-on-bgsave-error no
 
-## start zookeeper (for kafka) 
+## start zookeeper (for kafka)
 mkdir -p /tmp/zookeeper /tmp/zookeeper-logs
-ZOOPIDFILE=/tmp/zookeeper-logs/pid ZOO_LOG_DIR=/tmp/zookeeper-logs  zkServer.sh stop zoo_sample.cfg
+ZOOPIDFILE=/tmp/zookeeper-logs/pid ZOO_LOG_DIR=/tmp/zookeeper-logs zkServer.sh stop zoo_sample.cfg
 rm -rf /tmp/zookeeper/* /tmp/zookeeper-logs/*
 ZOOPIDFILE=/tmp/zookeeper-logs/pid ZOO_LOG_DIR=/tmp/zookeeper-logs zkServer.sh start zoo_sample.cfg
 
 ## wait for zookeeper
 echo "waiting for zookeeper to start"
-until nc -vz localhost 2181
-do
-  sleep 1
-done 
+until nc -vz localhost 2181; do
+    sleep 1
+done
 echo "zookeeper available"
 
 ## start kafka
@@ -36,16 +35,17 @@ kafka-server-start.sh -daemon "$server_properties_path" --override num.partition
 
 ## wait for kafka
 echo "waiting for kafka to start"
-until  nc -vz localhost 9092
-do
-  sleep 1
+until nc -vz localhost 9092; do
+    sleep 1
 done
 echo "kafka available"
-
 
 cabal build --offline all
 cabal test --offline all
 
 # cleanup
 kafka-server-stop.sh
-ZOOPIDFILE=/tmp/zookeeper-logs/pid ZOO_LOG_DIR=/tmp/zookeeper-logs  zkServer.sh stop zoo_sample.cfg
+ZOOPIDFILE=/tmp/zookeeper-logs/pid ZOO_LOG_DIR=/tmp/zookeeper-logs zkServer.sh stop zoo_sample.cfg
+pushd nri-postgresql
+source cleanup-postgres.sh
+popd


### PR DESCRIPTION
- drops testing of old GHC versions because they were breaking CI / not building
- drop deprecated github actions (and upgrade nix installer while we're at it)
- upgrade CI nixpkgs to match what's in niv
- drop deprecated `Data.Pool.createPool`
- run tests script stops postgres (but not redis)