### PR TITLE
Trigger CI for merge queue attempts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - "trunk"
+  merge_group:
 
   # We also provide a way to run this manually, if needed.
   workflow_dispatch:


### PR DESCRIPTION
Before enabling the merge queue, we have to make sure that CI is triggered by the merge queue.
