### PR TITLE
allow `Http.Mock` helpers to work with any error type, not just the built-in one

### DIFF
--- a/nri-http/CHANGELOG.md
+++ b/nri-http/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.0.2
+
+- Loosen types for `Http.Mock` helpers to allow for arbitrary error types
+
 # 0.5.0.1
 
 - Drop support for `aeson-1.x`

--- a/nri-http/nri-http.cabal
+++ b/nri-http/nri-http.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           nri-http
-version:        0.5.0.1
+version:        0.5.0.2
 synopsis:       Make Elm style HTTP requests
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-http#readme>.
 category:       Web

--- a/nri-http/package.yaml
+++ b/nri-http/package.yaml
@@ -2,7 +2,7 @@ name: nri-http
 synopsis: Make Elm style HTTP requests
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-http#readme>.
 author: NoRedInk
-version: 0.5.0.1
+version: 0.5.0.2
 maintainer: haskell-open-source@noredink.com
 copyright: 2024 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-http

--- a/nri-http/src/Http/Mock.hs
+++ b/nri-http/src/Http/Mock.hs
@@ -97,7 +97,7 @@ stub responders stubbedTestBody = do
 -- submitted inside a 'stub' function.
 --
 -- This will return 'Nothing' if the body cannot be parsed as UTF8 text.
-getTextBody :: Internal.Request expect -> Maybe Text
+getTextBody :: Internal.Request' e expect -> Maybe Text
 getTextBody req =
   Data.Text.Encoding.decodeUtf8' (getBytesBody req)
     |> eitherToMaybe
@@ -106,7 +106,7 @@ getTextBody req =
 -- submitted inside a 'stub' function.
 --
 -- This will return an error if parsing the JSON body fails.
-getJsonBody :: Aeson.FromJSON a => Internal.Request expect -> Result Text a
+getJsonBody :: Aeson.FromJSON a => Internal.Request' e expect -> Result Text a
 getJsonBody req =
   case Aeson.eitherDecodeStrict (getBytesBody req) of
     Prelude.Left err -> Err (Text.fromList err)
@@ -114,7 +114,7 @@ getJsonBody req =
 
 -- | Read the body of the request as bytes. Useful to check what data got
 -- submitted inside a 'stub' function.
-getBytesBody :: Internal.Request expect -> ByteString
+getBytesBody :: Internal.Request' e expect -> ByteString
 getBytesBody req =
   Internal.body req
     |> Internal.bodyContents
@@ -125,7 +125,7 @@ getBytesBody req =
 --
 -- This will return 'Nothing' if no header with that name was set on the
 -- request.
-getHeader :: Text -> Internal.Request expect -> Maybe Text
+getHeader :: Text -> Internal.Request' e expect -> Maybe Text
 getHeader name req =
   Internal.headers req
     |> List.map Internal.unHeader


### PR DESCRIPTION
see title 😎 