### PR TITLE
circumvent nix - direnv issue

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,4 @@
 use nix
+# circumvent https://github.com/direnv/direnv/issues/1345
+mkdir -p $TMPDIR
 cachix use nri


### PR DESCRIPTION
circumvents https://github.com/direnv/direnv/issues/1345 for those affected. Should be no-op otherwise