### PR TITLE
Make sure Http.Mock.stub works properly in multithreaded environments

### DIFF
--- a/nri-http/src/Http/Mock.hs
+++ b/nri-http/src/Http/Mock.hs
@@ -82,7 +82,7 @@ stub responders stubbedTestBody = do
         Internal.Handler
           ( \req -> do
               (log, res) <- tryRespond responders req
-              Data.IORef.modifyIORef' logRef (\prev -> log : prev)
+              Data.IORef.atomicModifyIORef' logRef (\prev -> (log : prev, ()))
                 |> map Ok
                 |> Platform.doAnything doAnything
               Prelude.pure res


### PR DESCRIPTION
The `stub` function keeps a list of the values returned by the mocks within an `IORef`, but the updates are not atomic so we get some random failures when HTTP requests are made in parallel on multiple threads.
