### PR TITLE
Add `deriving Generic` to `Result` (for aeson & elm-export)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,11 @@ jobs:
         uses: easimon/maximize-build-space@v10
         with:
           # you can try to increase this if the ubuntu runner runs out of space.
-          # prob can't push it too far above 30GB though
+          # prob can't push it too far above 30GB though.  the github actions runners
+          # have a small disk size, and if we want more we'll have to look into
+          # larger runners or self-hosted runners.  caveat - larger runners aren't
+          # included in our enterprise plan and _will_ cost extra!
+          # https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners#machine-sizes-for-larger-runners
           root-reserve-mb: 30720
           remove-dotnet: 'true'
           remove-android: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,20 @@ jobs:
           - ghc-9-8
     runs-on: ${{ matrix.runner.os }}
     steps:
+      # see write-up @ https://github.com/marketplace/actions/maximize-build-disk-space
+      - name: Reclaim space
+        if: matrix.runner.os == 'ubuntu-22.04'
+        uses: easimon/maximize-build-space@v10
+        with:
+          # you can try to increase this if the ubuntu runner runs out of space.
+          # prob can't push it too far above 30GB though
+          root-reserve-mb: 30720
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true' # we use nix to provide this anyway
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+
       - name: Install Nix
         uses: cachix/install-nix-action@v30
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
           #
           # alternately, we can think about moving the nix store off of root and onto
           # the larger `/dev/sdb1` partition.
+          #
+          # all of the above - including moving the nix store, should you choose
+          # to do that - is ultimately very hacky and unfortunately dependent
+          # on lower-level implementation that we have very little control over.
+          # nothing is stopping github from e.g. changing disk layout, software
+          # contents, os packages, etc.  this is especially true if we use newer
+          # `ubuntu-xx.yy` runners.
           root-reserve-mb: 30720
           remove-dotnet: 'true'
           remove-android: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           # larger runners or self-hosted runners.  caveat - larger runners aren't
           # included in our enterprise plan and _will_ cost extra!
           # https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners#machine-sizes-for-larger-runners
+          #
+          # alternately, we can think about moving the nix store off of root and onto
+          # the larger `/dev/sdb1` partition.
           root-reserve-mb: 30720
           remove-dotnet: 'true'
           remove-android: 'true'

--- a/nri-prelude/src/Result.hs
+++ b/nri-prelude/src/Result.hs
@@ -24,6 +24,7 @@ module Result
 where
 
 import Basics
+import GHC.Generics (Generic)
 import qualified Internal.Shortcut as Shortcut
 import Maybe (Maybe (..))
 import Prelude (fmap)
@@ -34,7 +35,7 @@ import qualified Prelude
 data Result error value
   = Ok value
   | Err error
-  deriving (Prelude.Show, Eq)
+  deriving (Prelude.Show, Eq, Generic)
 
 instance Prelude.Functor (Result error) where
   fmap func result =


### PR DESCRIPTION
Add `deriving Generic` on `Result`.
I want to generate an Elm decoder for a response that contains a `Result` but I can't! And I can't add the right instances in my app code! I am amazed we never ran into this before.

I wondered about other types but it turns out that `Result` is the only sum type that we actually _define_ in `nri-prelude`. `Maybe` and `List` are just aliases for types defined in the standard prelude, and `Dict` is an alias for `Map`. That's why all of those have `Generic` instances.

Part of QUO-1404