### PR TITLE
nri-observability: async reports

### DIFF
--- a/nri-observability/src/Observability.hs
+++ b/nri-observability/src/Observability.hs
@@ -20,7 +20,10 @@ module Observability
 where
 
 import qualified Conduit
+import Control.Concurrent.Async (async, wait)
+import Control.Concurrent.STM.TQueue (newTQueueIO, readTQueue, writeTQueue)
 import qualified Control.Exception.Safe as Exception
+import Control.Monad.STM (atomically)
 import qualified Data.Aeson as Aeson
 import qualified Environment
 import qualified List
@@ -43,6 +46,10 @@ newtype Handler = Handler
   }
   deriving (Prelude.Semigroup, Prelude.Monoid)
 
+data Msg
+  = Report Text Platform.TracingSpan
+  | Close
+
 -- | Function for creating an observability handler. The settings we pass in
 -- determine which platforms we'll report information to.
 handler :: Settings -> Conduit.Acquire Handler
@@ -52,7 +59,29 @@ handler settings = do
     firstReporter : otherReporters -> do
       firstHandler <- toHandler reportNothingHandler settings firstReporter
       otherHandlers <- traverse (toHandler firstHandler settings) otherReporters
-      Prelude.pure (Prelude.mconcat (firstHandler : otherHandlers))
+      let innerHandler = Prelude.mconcat (firstHandler : otherHandlers)
+
+      queue <- Conduit.liftIO newTQueueIO
+      let loop = do
+            msg <- atomically (readTQueue queue)
+            case msg of
+              Close -> Prelude.pure ()
+              Report requestId span -> do
+                report innerHandler requestId span
+                loop
+      loopId <- Conduit.liftIO <| async loop
+
+      Conduit.mkAcquire
+        ( Prelude.pure
+            <| Handler
+              ( \requestId span ->
+                  atomically (writeTQueue queue (Report requestId span))
+              )
+        )
+        ( \_ -> do
+            atomically (writeTQueue queue Close)
+            wait loopId
+        )
 
 reportNothingHandler :: Handler
 reportNothingHandler = Handler (\_ _ -> Prelude.pure ())

--- a/nri-observability/tests/Spec/Observability.hs
+++ b/nri-observability/tests/Spec/Observability.hs
@@ -22,11 +22,10 @@ tests =
         let reporter2 = fakeReporter (\_ -> appendLog "reporter2" log)
         let settings = settings' {Observability.enabledReporters = [reporter1, reporter2]}
         reports <-
-          Expect.fromIO
-            ( Conduit.withAcquire (Observability.handler settings) <| \handler -> do
-                Observability.report handler "request-id-1234" emptyTracingSpan
-                IORef.readIORef log
-            )
+          Expect.fromIO <| do
+            Conduit.withAcquire (Observability.handler settings) <| \handler -> do
+              Observability.report handler "request-id-1234" emptyTracingSpan
+            IORef.readIORef log
         reports
           |> Expect.equal ["reporter1", "reporter2"],
       test "The first reporter reports sync exceptions thrown by the other reporters" <| \_ -> do
@@ -36,11 +35,10 @@ tests =
         let reporter2 = fakeReporter (\_ -> Exception.throwString "failed!")
         let settings = settings' {Observability.enabledReporters = [reporter1, reporter2]}
         reports <-
-          Expect.fromIO
-            ( Conduit.withAcquire (Observability.handler settings) <| \handler -> do
-                Observability.report handler "request-id-1234" emptyTracingSpan
-                IORef.readIORef log
-            )
+          Expect.fromIO <| do
+            Conduit.withAcquire (Observability.handler settings) <| \handler -> do
+              Observability.report handler "request-id-1234" emptyTracingSpan
+            IORef.readIORef log
         reports
           |> Expect.equal ["reporter1: example", "reporter1: Failed to report span to fake"],
       test "The first reporter reports async exceptions thrown by the other reporters" <| \_ -> do
@@ -55,8 +53,10 @@ tests =
                 )
         let settings = settings' {Observability.enabledReporters = [reporter1, reporter2]}
         reports <-
-          Expect.fromIO <| Conduit.withAcquire (Observability.handler settings) <| \handler -> do
-            Observability.report handler "request-id-1234" emptyTracingSpan
+          Expect.fromIO <| do
+            ( Conduit.withAcquire (Observability.handler settings) <| \handler -> do
+                Observability.report handler "request-id-1234" emptyTracingSpan
+              )
               |> Exception.handleAsync (\(Exception.AsyncExceptionWrapper _) -> Prelude.pure ())
             IORef.readIORef log
         reports
@@ -69,11 +69,10 @@ tests =
         let reporter3 = fakeReporter (\span -> appendLog ("reporter3: " ++ Platform.name span) log)
         let settings = settings' {Observability.enabledReporters = [reporter1, reporter2, reporter3]}
         reports <-
-          Expect.fromIO
-            ( Conduit.withAcquire (Observability.handler settings) <| \handler -> do
-                Observability.report handler "request-id-1234" emptyTracingSpan
-                IORef.readIORef log
-            )
+          Expect.fromIO <| do
+            Conduit.withAcquire (Observability.handler settings) <| \handler -> do
+              Observability.report handler "request-id-1234" emptyTracingSpan
+            IORef.readIORef log
         reports
           |> Expect.equal ["reporter1: example", "reporter1: Failed to report span to fake", "reporter3: example"]
     ]

--- a/nri-prelude/src/Platform/Internal.hs
+++ b/nri-prelude/src/Platform/Internal.hs
@@ -834,7 +834,7 @@ rootTracingSpanIO :: (Stack.HasCallStack) => Text -> (TracingSpan -> IO ()) -> T
 rootTracingSpanIO requestId onFinish name runIO = do
   clock' <- mkClock
   Exception.bracketWithError
-    (Stack.withFrozenCallStack mkHandler requestId clock' (onFinish >> reportSafely) Nothing name)
+    (Stack.withFrozenCallStack mkHandler requestId clock' onFinish Nothing name)
     (Prelude.flip finishTracingSpan)
     runIO
 


### PR DESCRIPTION
Reports are queued and executed on a separate thread. Wait for the queue to be empty when the handler is released.

This is useful for short lived processes like cron jobs, where a single trace is reported. Currently the report is executed using `async` without waiting it to finish, so the traces are lost.

Part of ZEN-2516