### PR TITLE
nri-observability: flush reports when handler is being closed.

### DIFF
--- a/nri-observability/src/Observability.hs
+++ b/nri-observability/src/Observability.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE NumericUnderscores #-}
 
 -- | A module dedicated to observability, that is reporting information about
 -- what the program is doing in production to help us debugging it.
@@ -20,7 +21,11 @@ module Observability
 where
 
 import qualified Conduit
+import Control.Concurrent.Async (async)
+import Control.Concurrent.STM (atomically, check)
+import Control.Concurrent.STM.TVar (modifyTVar, newTVarIO, readTVar)
 import qualified Control.Exception.Safe as Exception
+import Control.Monad (void)
 import qualified Data.Aeson as Aeson
 import qualified Environment
 import qualified List
@@ -30,8 +35,10 @@ import qualified Reporter.Dev as Dev
 import qualified Reporter.File as File
 import qualified Reporter.Honeycomb as Honeycomb
 import qualified Set
+import qualified System.Mem as Mem
+import qualified System.Timeout as Timeout
 import qualified Text
-import Prelude (pure, traverse)
+import Prelude (flip, pure, traverse)
 import qualified Prelude
 
 -- | A handler for reporting to logging/monitoring/observability platforms.
@@ -52,7 +59,57 @@ handler settings = do
     firstReporter : otherReporters -> do
       firstHandler <- toHandler reportNothingHandler settings firstReporter
       otherHandlers <- traverse (toHandler firstHandler settings) otherReporters
-      Prelude.pure (Prelude.mconcat (firstHandler : otherHandlers))
+      let innerHandler = Prelude.mconcat (firstHandler : otherHandlers)
+      reportCounter <- Conduit.liftIO <| newTVarIO (0 :: Int)
+
+      Conduit.mkAcquire
+        ( Prelude.pure
+            <| Handler
+              ( \requestId span -> do
+                  atomically (modifyTVar reportCounter (+ 1))
+
+                  -- Spawning a separate thread for the reporting logic ensures the main request
+                  -- thread doesn't need to wait with responding to the user until reporting
+                  -- logic finishes. It also ensures exceptions thrown in reporting logic won't
+                  -- result in failure responses to requests.
+                  void <| async <| do
+                    -- Setting an allocation limit helps protect us from reporting logic using
+                    -- lots of CPU time and negatively affecting application performance.
+                    Mem.setAllocationCounter reportingAllocationLimitInBytes
+                    Mem.enableAllocationLimit
+
+                    report innerHandler requestId span
+                      -- This thread is spawned without anybody watching how it does. We set a
+                      -- maximum running time here to ensure it eventually completes.
+                      |> Timeout.timeout reportingTimeoutInMicroSeconds
+                      |> (flip Exception.finally) (atomically <| modifyTVar reportCounter (+ (-1)))
+              )
+        )
+        ( \_ -> do
+            -- Wait for all reporting threads to finish before cleaning up.
+            atomically <| do
+              count <- readTVar reportCounter
+              check (count == 0)
+        )
+
+-- | The maximum amount of bytes the reporting logic is allowed to allocate.
+-- Note that this is more of a limit on CPU time then maximum live memory. See
+-- the documentation on `setAllocationCounter` for more details:
+--
+-- https://hackage.haskell.org/package/base-4.14.0.0/docs/System-Mem.html#v:enableAllocationLimit
+--
+-- The current value is a somewhat arbitrary initial value, intentionally not
+-- very strict. The hope is experience will help us tighten this value a bit.
+reportingAllocationLimitInBytes :: Int
+reportingAllocationLimitInBytes = 1024 * 1024 * 1024
+
+-- | The maximum amount of time reporting logic is allowed to run for a single
+-- request.
+--
+-- The current value is a somewhat arbitrary initial value, intentionally not
+-- very strict. The hope is experience will help us tighten this value a bit.
+reportingTimeoutInMicroSeconds :: Prelude.Int
+reportingTimeoutInMicroSeconds = 5_000_000
 
 reportNothingHandler :: Handler
 reportNothingHandler = Handler (\_ _ -> Prelude.pure ())

--- a/nri-observability/tests/Spec/Observability.hs
+++ b/nri-observability/tests/Spec/Observability.hs
@@ -22,11 +22,10 @@ tests =
         let reporter2 = fakeReporter (\_ -> appendLog "reporter2" log)
         let settings = settings' {Observability.enabledReporters = [reporter1, reporter2]}
         reports <-
-          Expect.fromIO
-            ( Conduit.withAcquire (Observability.handler settings) <| \handler -> do
-                Observability.report handler "request-id-1234" emptyTracingSpan
-                IORef.readIORef log
-            )
+          Expect.fromIO <| do
+            Conduit.withAcquire (Observability.handler settings) <| \handler -> do
+              Observability.report handler "request-id-1234" emptyTracingSpan
+            IORef.readIORef log
         reports
           |> Expect.equal ["reporter1", "reporter2"],
       test "The first reporter reports sync exceptions thrown by the other reporters" <| \_ -> do
@@ -36,11 +35,10 @@ tests =
         let reporter2 = fakeReporter (\_ -> Exception.throwString "failed!")
         let settings = settings' {Observability.enabledReporters = [reporter1, reporter2]}
         reports <-
-          Expect.fromIO
-            ( Conduit.withAcquire (Observability.handler settings) <| \handler -> do
-                Observability.report handler "request-id-1234" emptyTracingSpan
-                IORef.readIORef log
-            )
+          Expect.fromIO <| do
+            Conduit.withAcquire (Observability.handler settings) <| \handler -> do
+              Observability.report handler "request-id-1234" emptyTracingSpan
+            IORef.readIORef log
         reports
           |> Expect.equal ["reporter1: example", "reporter1: Failed to report span to fake"],
       test "The first reporter reports async exceptions thrown by the other reporters" <| \_ -> do
@@ -55,8 +53,10 @@ tests =
                 )
         let settings = settings' {Observability.enabledReporters = [reporter1, reporter2]}
         reports <-
-          Expect.fromIO <| Conduit.withAcquire (Observability.handler settings) <| \handler -> do
-            Observability.report handler "request-id-1234" emptyTracingSpan
+          Expect.fromIO <| do
+            ( Conduit.withAcquire (Observability.handler settings) <| \handler -> do
+                Observability.report handler "request-id-1234" emptyTracingSpan
+              )
               |> Exception.handleAsync (\(Exception.AsyncExceptionWrapper _) -> Prelude.pure ())
             IORef.readIORef log
         reports
@@ -69,11 +69,10 @@ tests =
         let reporter3 = fakeReporter (\span -> appendLog ("reporter3: " ++ Platform.name span) log)
         let settings = settings' {Observability.enabledReporters = [reporter1, reporter2, reporter3]}
         reports <-
-          Expect.fromIO
-            ( Conduit.withAcquire (Observability.handler settings) <| \handler -> do
-                Observability.report handler "request-id-1234" emptyTracingSpan
-                IORef.readIORef log
-            )
+          Expect.fromIO <| do
+            Conduit.withAcquire (Observability.handler settings) <| \handler -> do
+              Observability.report handler "request-id-1234" emptyTracingSpan
+            IORef.readIORef log
         reports
           |> Expect.equal ["reporter1: example", "reporter1: Failed to report span to fake", "reporter3: example"]
     ]

--- a/nri-prelude/src/Platform/Internal.hs
+++ b/nri-prelude/src/Platform/Internal.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Platform.Internal where
@@ -8,7 +7,6 @@ module Platform.Internal where
 import Basics
 import Control.Applicative ((<|>))
 import qualified Control.AutoUpdate as AutoUpdate
-import qualified Control.Concurrent.Async as Async
 import qualified Control.Exception.Safe as Exception
 import qualified Control.Monad
 import Data.Aeson ((.:), (.:?), (.=))
@@ -28,8 +26,6 @@ import Maybe (Maybe (..))
 import qualified Maybe
 import Result (Result (Err, Ok))
 import qualified System.Mem
-import qualified System.Mem as Mem
-import qualified System.Timeout as Timeout
 import Text (Text)
 import qualified Tuple
 import Prelude
@@ -834,56 +830,9 @@ rootTracingSpanIO :: (Stack.HasCallStack) => Text -> (TracingSpan -> IO ()) -> T
 rootTracingSpanIO requestId onFinish name runIO = do
   clock' <- mkClock
   Exception.bracketWithError
-    (Stack.withFrozenCallStack mkHandler requestId clock' (onFinish >> reportSafely) Nothing name)
+    (Stack.withFrozenCallStack mkHandler requestId clock' onFinish Nothing name)
     (Prelude.flip finishTracingSpan)
     runIO
-
--- After a root action (HTTP request, perform a job from a queue, etc) is done
--- we run our reporting logic, which sends debugging information to platforms
--- like Bugsnag and NewRelic.
---
--- This information is important when helping us debug our applications, but it
--- shouldn't be able to cause problems for the non-reporting logic, i.e. the
--- parts responsible for sending a response back to the user.
---
--- This function might kill the reporting thread if it thinks it's misbehaving.
--- It's up to the reporting logic to implement cleanup logic or notifications
--- of failed reporting using functions like `bracket`.
-reportSafely :: IO () -> IO ()
-reportSafely report = do
-  -- Spawning a separate thread for the reporting logic ensures the main request
-  -- thread doesn't need to wait with responding to the user until reporting
-  -- logic finishes. It also ensures exceptions thrown in reporting logic won't
-  -- result in failure responses to requests.
-  _ <-
-    Async.async <| do
-      -- Setting an allocation limit helps protect us from reporting logic using
-      -- lots of CPU time and negatively affecting application performance.
-      Mem.setAllocationCounter reportingAllocationLimitInBytes
-      Mem.enableAllocationLimit
-      -- This thread is spawned without anybody watching how it does. We set a
-      -- maximum running time here to ensure it eventually completes.
-      Timeout.timeout reportingTimeoutInMicroSeconds report
-  Prelude.pure ()
-
--- | The maximum amount of bytes the reporting logic is allowed to allocate.
--- Note that this is more of a limit on CPU time then maximum live memory. See
--- the documentation on `setAllocationCounter` for more details:
---
--- https://hackage.haskell.org/package/base-4.14.0.0/docs/System-Mem.html#v:enableAllocationLimit
---
--- The current value is a somewhat arbitrary initial value, intentionally not
--- very strict. The hope is experience will help us tighten this value a bit.
-reportingAllocationLimitInBytes :: Int
-reportingAllocationLimitInBytes = 1024 * 1024 * 1024
-
--- | The maximum amount of time reporting logic is allowed to run for a single
--- request.
---
--- The current value is a somewhat arbitrary initial value, intentionally not
--- very strict. The hope is experience will help us tighten this value a bit.
-reportingTimeoutInMicroSeconds :: Prelude.Int
-reportingTimeoutInMicroSeconds = 5_000_000
 
 --
 -- CLOCK


### PR DESCRIPTION
- Move asynchronicity from `Platform.rootTracingSpanIO` to `Handler.report`.
- Observability handler waits for pending reports while releasing.

This is useful for short lived processes like cron jobs, where a single trace is reported. Currently the report is executed using async without waiting it to finish, so the traces are lost.

Part of ZEN-2516