### PR TITLE
Bump dependencies

### DIFF
--- a/nri-prelude/nri-prelude.cabal
+++ b/nri-prelude/nri-prelude.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           nri-prelude
-version:        0.6.1.2
+version:        0.6.1.3
 synopsis:       A Prelude inspired by the Elm programming language
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-prelude#readme>.
 category:       Web
@@ -86,7 +86,7 @@ library
       TypeOperators
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns
   build-depends:
-      aeson >=1.4.6.0 && <2.2
+      aeson >=2.0 && <2.2
     , aeson-pretty >=0.8.0 && <0.9
     , async >=2.2.2 && <2.3
     , attoparsec >=0.13.0.0 && <0.15
@@ -98,13 +98,13 @@ library
     , exceptions >=0.10.4 && <0.11
     , filepath >=1.4.2.1 && <1.5
     , ghc >=8.6.1 && <9.8
-    , hedgehog >=1.0.2 && <1.5
+    , hedgehog >=1.0.2 && <1.6
     , junit-xml >=0.1.0.0 && <0.2.0.0
-    , lens >=4.16.1 && <5.3
+    , lens >=4.16.1 && <5.4
     , pretty-diff >=0.4.0.2 && <0.5
     , pretty-show >=1.9.5 && <1.11
-    , safe-coloured-text >=0.1.0.0 && <0.3
-    , safe-coloured-text-terminfo >=0.0.0.0 && <0.2
+    , safe-coloured-text >=0.1.0.0 && <0.4
+    , safe-coloured-text-terminfo >=0.0.0.0 && <0.4
     , safe-exceptions >=0.1.7.0 && <1.3
     , terminal-size >=0.3.2.1 && <0.4
     , text >=1.2.3.1 && <2.1
@@ -184,7 +184,7 @@ test-suite tests
       ExtendedDefaultRules
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -threaded -rtsopts "-with-rtsopts=-N -T" -fno-warn-type-defaults
   build-depends:
-      aeson >=1.4.6.0 && <2.2
+      aeson >=2.0 && <2.2
     , aeson-pretty >=0.8.0 && <0.9
     , async >=2.2.2 && <2.3
     , attoparsec >=0.13.0.0 && <0.15
@@ -196,13 +196,13 @@ test-suite tests
     , exceptions >=0.10.4 && <0.11
     , filepath >=1.4.2.1 && <1.5
     , ghc >=8.6.1 && <9.8
-    , hedgehog >=1.0.2 && <1.5
+    , hedgehog >=1.0.2 && <1.6
     , junit-xml >=0.1.0.0 && <0.2.0.0
-    , lens >=4.16.1 && <5.3
+    , lens >=4.16.1 && <5.4
     , pretty-diff >=0.4.0.2 && <0.5
     , pretty-show >=1.9.5 && <1.11
-    , safe-coloured-text >=0.1.0.0 && <0.3
-    , safe-coloured-text-terminfo >=0.0.0.0 && <0.2
+    , safe-coloured-text >=0.1.0.0 && <0.4
+    , safe-coloured-text-terminfo >=0.0.0.0 && <0.4
     , safe-exceptions >=0.1.7.0 && <1.3
     , terminal-size >=0.3.2.1 && <0.4
     , text >=1.2.3.1 && <2.1

--- a/nri-prelude/package.yaml
+++ b/nri-prelude/package.yaml
@@ -3,7 +3,7 @@ synopsis: A Prelude inspired by the Elm programming language
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-prelude#readme>.
 homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-prelude#readme
 author: NoRedInk
-version: 0.6.1.2
+version: 0.6.1.3
 maintainer: haskell-open-source@noredink.com
 copyright: 2023 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-prelude
@@ -29,13 +29,13 @@ library:
     - exceptions >= 0.10.4 && < 0.11
     - filepath >= 1.4.2.1 && < 1.5
     - ghc >= 8.6.1 && < 9.8
-    - hedgehog >= 1.0.2 && < 1.5
+    - hedgehog >= 1.0.2 && < 1.6
     - junit-xml >= 0.1.0.0 && < 0.2.0.0
-    - lens >=4.16.1 && <5.3
+    - lens >=4.16.1 && <5.4
     - pretty-diff >= 0.4.0.2 && < 0.5
     - pretty-show >= 1.9.5 && < 1.11
-    - safe-coloured-text >= 0.1.0.0 && < 0.3
-    - safe-coloured-text-terminfo >= 0.0.0.0 && < 0.2
+    - safe-coloured-text >= 0.1.0.0 && < 0.4
+    - safe-coloured-text-terminfo >= 0.0.0.0 && < 0.4
     - safe-exceptions >= 0.1.7.0 && < 1.3
     - terminal-size >= 0.3.2.1 && < 0.4
     - text >= 1.2.3.1 && < 2.1


### PR DESCRIPTION
Encountered some missing dependencies upon upgrading a project to GHC 984.

```
> Error: Setup: Encountered missing or private dependencies:
> hedgehog >=1.0.2 && <1.5,
> lens >=4.16.1 && <5.3,
> safe-coloured-text >=0.1.0.0 && <0.3,
> safe-coloured-text-terminfo >=0.0.0.0 && <0.2
```

contributes to https://linear.app/noredink/issue/FXN-4014/upgrade-nixpkgs-ref-in-monorepo