### PR TITLE
`expectBytes`: mismatches on `Http.Request' errorType` are ... awkward

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ nri-http/nri-http.cabal: nri-http/package.yaml
 ghcid-nri-http: nri-http/nri-http.cabal
 	cd nri-http && ghcid
 
+ghcid-nri-http-test: nri-http/nri-http.cabal
+	cd nri-http && ghcid --command "cabal repl nri-http:test:spec" --test Main.main
+
 nri-kafka/nri-kafka.cabal: nri-kafka/package.yaml
 	hpack nri-kafka
 

--- a/nri-http/src/Http/Mock.hs
+++ b/nri-http/src/Http/Mock.hs
@@ -161,7 +161,7 @@ tryRespond [] req =
       handleCustomResponse :: (Internal.Response s -> Result e expect) -> Task e (a, expect)
       handleCustomResponse f = case f (Internal.NetworkError_ msg) of
         Err err -> Task.fail err
-        Ok _ -> Debug.todo "Since we manually craft the Response as an Error, this case will not run."
+        Ok _ -> Debug.todo msg
    in case Internal.expect req of
         Internal.ExpectJson ->
           Task.fail (Internal.NetworkError msg)

--- a/nri-http/src/Http/Mock.hs
+++ b/nri-http/src/Http/Mock.hs
@@ -178,7 +178,7 @@ tryRespond (Stub respond : rest) req =
     |> Maybe.andThen Dynamic.fromDynamic
     |> Maybe.withDefault (tryRespond rest req)
 
-printType :: (Dynamic.Typeable expect) => proxy expect -> Text
+printType :: (Dynamic.Typeable expect) => expect -> Text
 printType expect =
-  Type.Reflection.someTypeRep expect
+  Type.Reflection.typeOf expect
     |> Debug.toString

--- a/nri-http/test/Main.hs
+++ b/nri-http/test/Main.hs
@@ -124,6 +124,32 @@ tests =
             )
         urlsAccessed
           |> Expect.equal ["example.com/one", "example.com/two"],
+      test "Http.Mock.stub binary" <| \_ -> do
+        urlsAccessed <-
+          Http.Mock.stub
+            [ Http.Mock.mkStub
+                ( \(req :: Http.Request Text) ->
+                    -- Note the error type here                    👇
+                    -- doesn't match the code under test
+                    Task.succeed (Http.url req, "dsa") :: Task Http.Error (Text, Text)
+                )
+            ]
+            ( \http ->
+                Expect.succeeds <| do
+                  _ <-
+                    Http.get
+                      http
+                      "example.com/one"
+                      ( Http.expectBytesResponse
+                          ( \_ ->
+                              -- see? a different error type 👇
+                              (Ok ("asd" :: Text)) :: Result () Text
+                          )
+                      )
+                  Task.succeed ()
+            )
+        urlsAccessed
+          |> Expect.equal ["example.com/one"],
       test "Using expectTextResponse, metadata returns the correct status" <| \() ->
         withServer
           (constant "Some text" Status.ok200)

--- a/nri-http/test/golden-results-9.8/expected-http-span
+++ b/nri-http/test/golden-results-9.8/expected-http-span
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "nri-http-0.6.0.0-inplace-spec"
             , srcLocModule = "Main"
             , srcLocFile = "test/Main.hs"
-            , srcLocStartLine = 234
+            , srcLocStartLine = 247
             , srcLocStartCol = 7
-            , srcLocEndLine = 234
+            , srcLocEndLine = 247
             , srcLocEndCol = 33
             }
         )


### PR DESCRIPTION
(see commit message comments)