### PR TITLE
Fix space leak in nri-observability

### DIFF
--- a/nix/common-haskell-overrides.nix
+++ b/nix/common-haskell-overrides.nix
@@ -36,4 +36,8 @@ self: super:
 
     # for now, pin hw-kafka-client to 4.0.3; nixpkgs@release-25.05 provides 5.3.0
     hw-kafka-client = self.callHackage "hw-kafka-client" "4.0.3" { };
+
+    # marked broken in nixpkgs
+    # current version requires io-classes >=1.5 && <1.6
+    strict-stm = pkgs.haskell.lib.doJailbreak (self.callHackage "strict-stm" "1.5.0.0" { });
   }

--- a/nix/mk-shell.nix
+++ b/nix/mk-shell.nix
@@ -49,6 +49,7 @@ in pkgs.mkShell {
         servant-auth-server
         servant-server
         stm
+        strict-stm
         terminal-size
         text
         text-zipper

--- a/nri-observability/nri-observability.cabal
+++ b/nri-observability/nri-observability.cabal
@@ -108,7 +108,7 @@ executable memory-leak-test
       ScopedTypeVariables
       Strict
       TypeOperators
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fplugin=NriPrelude.Plugin -threaded -rtsopts "-with-rtsopts=-N -T -s" -O2
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fplugin=NriPrelude.Plugin -threaded -rtsopts "-with-rtsopts=-N -T" -O2
   build-depends:
       aeson >=2.0 && <2.3
     , aeson-pretty >=0.8.0 && <0.9

--- a/nri-observability/nri-observability.cabal
+++ b/nri-observability/nri-observability.cabal
@@ -87,6 +87,51 @@ library
     , uuid >=1.3.0 && <1.4
   default-language: Haskell2010
 
+executable memory-leak-test
+  main-is: Main.hs
+  other-modules:
+      Paths_nri_observability
+  hs-source-dirs:
+      scripts/memory-leak-test
+  default-extensions:
+      DataKinds
+      DeriveGeneric
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      MultiParamTypeClasses
+      NamedFieldPuns
+      NoImplicitPrelude
+      OverloadedStrings
+      PartialTypeSignatures
+      ScopedTypeVariables
+      Strict
+      TypeOperators
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -fplugin=NriPrelude.Plugin -threaded -rtsopts "-with-rtsopts=-N -T -s" -O2
+  build-depends:
+      aeson >=2.0 && <2.3
+    , aeson-pretty >=0.8.0 && <0.9
+    , async >=2.2.2 && <2.3
+    , base >=4.18 && <4.22
+    , bugsnag-hs >=0.1.0.0 && <0.3
+    , bytestring >=0.10.8.2 && <0.13
+    , conduit >=1.3.0 && <1.4
+    , directory >=1.3.3.0 && <1.4
+    , hostname ==1.0.*
+    , http-client >=0.6.0 && <0.8
+    , http-client-tls >=0.3.0 && <0.4
+    , nri-env-parser >=0.1.0.0 && <0.5
+    , nri-observability
+    , nri-prelude >=0.1.0.0 && <0.7
+    , random >=1.1 && <1.3
+    , safe-exceptions >=0.1.7.0 && <1.3
+    , stm >=2.4 && <2.6
+    , text >=1.2.3.1 && <2.2
+    , time >=1.8.0.2 && <2
+    , unordered-containers >=0.2.0.0 && <0.3
+    , uuid >=1.3.0 && <1.4
+  default-language: Haskell2010
+
 test-suite tests
   type: exitcode-stdio-1.0
   main-is: Main.hs

--- a/nri-observability/nri-observability.cabal
+++ b/nri-observability/nri-observability.cabal
@@ -81,6 +81,7 @@ library
     , random >=1.1 && <1.3
     , safe-exceptions >=0.1.7.0 && <1.3
     , stm >=2.4 && <2.6
+    , strict-stm >=1.5.0.0 && <1.6
     , text >=1.2.3.1 && <2.2
     , time >=1.8.0.2 && <2
     , unordered-containers >=0.2.0.0 && <0.3
@@ -126,6 +127,7 @@ executable memory-leak-test
     , random >=1.1 && <1.3
     , safe-exceptions >=0.1.7.0 && <1.3
     , stm >=2.4 && <2.6
+    , strict-stm >=1.5.0.0 && <1.6
     , text >=1.2.3.1 && <2.2
     , time >=1.8.0.2 && <2
     , unordered-containers >=0.2.0.0 && <0.3
@@ -196,6 +198,7 @@ test-suite tests
     , random >=1.1 && <1.3
     , safe-exceptions >=0.1.7.0 && <1.3
     , stm >=2.4 && <2.6
+    , strict-stm >=1.5.0.0 && <1.6
     , text >=1.2.3.1 && <2.2
     , time >=1.8.0.2 && <2
     , unordered-containers >=0.2.0.0 && <0.3

--- a/nri-observability/package.yaml
+++ b/nri-observability/package.yaml
@@ -81,3 +81,13 @@ tests:
       - -fno-warn-type-defaults
     default-extensions:
       - ExtendedDefaultRules
+executables:
+  memory-leak-test:
+    source-dirs: scripts/memory-leak-test
+    main: Main.hs
+    dependencies:
+      - nri-observability
+    ghc-options:
+      - -threaded
+      - -rtsopts "-with-rtsopts=-N -T -s"
+      - -O2

--- a/nri-observability/package.yaml
+++ b/nri-observability/package.yaml
@@ -30,6 +30,7 @@ dependencies:
   - random >= 1.1 && < 1.3
   - unordered-containers >= 0.2.0.0 && < 0.3
   - safe-exceptions >= 0.1.7.0 && < 1.3
+  - strict-stm >= 1.5.0.0 && < 1.6
   - stm >= 2.4 && < 2.6
   - text >= 1.2.3.1 && < 2.2
   - time >= 1.8.0.2 && < 2

--- a/nri-observability/package.yaml
+++ b/nri-observability/package.yaml
@@ -90,5 +90,5 @@ executables:
       - nri-observability
     ghc-options:
       - -threaded
-      - -rtsopts "-with-rtsopts=-N -T -s"
+      - -rtsopts "-with-rtsopts=-N -T"
       - -O2

--- a/nri-observability/scripts/memory-leak-test/.env
+++ b/nri-observability/scripts/memory-leak-test/.env
@@ -1,0 +1,2 @@
+LOG_ENABLED_LOGGERS="stdout"
+LOG_ROOT_NAMESPACE="memory-leak-test"

--- a/nri-observability/scripts/memory-leak-test/Main.hs
+++ b/nri-observability/scripts/memory-leak-test/Main.hs
@@ -14,7 +14,11 @@ import qualified Observability
 import qualified Process
 import qualified Platform
 import Data.List (splitAt)
-import Prelude (IO, show, putStrLn, fromIntegral, pure, mapM_)
+import Prelude (IO, show, putStrLn, fromIntegral, pure, mapM_, div)
+import GHC.Conc (numCapabilities)
+
+threads :: Int
+threads = fromIntegral numCapabilities
 
 main :: IO ()
 main = do
@@ -22,7 +26,7 @@ main = do
   putStrLn (show settings'.enabledReporters)
   let ids = [1..12] |> List.map Text.fromInt
   Conduit.withAcquire (Observability.handler settings') <| \handler -> do
-    forM_ [1..(floor (1_000_000/12))] <| \n -> do
+    forM_ [1..(floor (1_000_000 / fromIntegral threads))] <| \n -> do
       runRequests handler ids
   -- give async threads 5s to finish
   -- threadDelay 5_000_000
@@ -30,9 +34,9 @@ main = do
 runTest :: Int -> Observability.Handler -> IO ()
 runTest n handler = do
   if n >= 50_000 then pure () else do
-    let ids = [n..n+12] |> List.map Text.fromInt
+    let ids = [n..n+threads] |> List.map Text.fromInt
     runRequests handler ids
-    runTest (n + 12) handler
+    runTest (n + threads) handler
 
 runRequests :: Observability.Handler -> [Text] -> IO ()
 runRequests handler =

--- a/nri-observability/scripts/memory-leak-test/Main.hs
+++ b/nri-observability/scripts/memory-leak-test/Main.hs
@@ -5,34 +5,51 @@
 module Main where
 
 
-import Control.Monad (void)
-import Control.Concurrent.Async (mapConcurrently)
+import Control.Monad (void, sequence, forM_)
+import Control.Concurrent.Async (mapConcurrently_)
 import Control.Concurrent (threadDelay)
 import qualified Conduit
 import qualified Environment
 import qualified Observability
 import qualified Process
 import qualified Platform
-import Prelude (IO, show, putStrLn)
+import Data.List (splitAt)
+import Prelude (IO, show, putStrLn, fromIntegral, pure, mapM_)
 
 main :: IO ()
 main = do
   settings' <- Environment.decode Observability.decoder
   putStrLn (show settings'.enabledReporters)
+  let ids = [1..12] |> List.map Text.fromInt
   Conduit.withAcquire (Observability.handler settings') <| \handler -> do
-    [0..300_000]
-      |> List.map Text.fromInt
-      |> mapConcurrently (\requestId -> do
-          Platform.rootTracingSpanIO
-              requestId
-              (Observability.report handler requestId)
-              ("Running task" ++ requestId)
-              ( \log -> do
-                  Task.perform log (do
-                    Process.sleep 5
-                    Task.succeed ())
-              )
-      )
-      |> void
-  -- give async threads 1s to finish
+    forM_ [1..(floor (1_000_000/12))] <| \n -> do
+      runRequests handler ids
+  -- give async threads 5s to finish
   -- threadDelay 5_000_000
+
+runTest :: Int -> Observability.Handler -> IO ()
+runTest n handler = do
+  if n >= 50_000 then pure () else do
+    let ids = [n..n+12] |> List.map Text.fromInt
+    runRequests handler ids
+    runTest (n + 12) handler
+
+runRequests :: Observability.Handler -> [Text] -> IO ()
+runRequests handler =
+  mapConcurrently_ (\requestId -> do
+            Platform.rootTracingSpanIO
+                requestId
+                (handler.report requestId)
+                ("Running task" ++ requestId)
+                ( \log -> do
+                    Task.perform log (do
+                      Process.sleep 5
+                      Task.succeed ())
+                )
+          )
+
+chunks :: Int -> [a] -> [[a]]
+chunks _ [] = []
+chunks n xs =
+    let (ys, zs) = splitAt (fromIntegral n) xs
+    in  ys : chunks n zs

--- a/nri-observability/scripts/memory-leak-test/Main.hs
+++ b/nri-observability/scripts/memory-leak-test/Main.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedRecordDot, OverloadedRecordUpdate #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NumericUnderscores #-}
+
+module Main where
+
+
+import Control.Monad (void)
+import Control.Concurrent.Async (mapConcurrently)
+import Control.Concurrent (threadDelay)
+import qualified Conduit
+import qualified Environment
+import qualified Observability
+import qualified Process
+import qualified Platform
+import Prelude (IO, show, putStrLn)
+
+main :: IO ()
+main = do
+  settings' <- Environment.decode Observability.decoder
+  putStrLn (show settings'.enabledReporters)
+  -- [0 .. 1000]
+  [0..10000]
+    |> List.map Text.fromInt
+    |> mapConcurrently (\requestId -> do
+      Conduit.withAcquire (Observability.handler settings') <| \handler -> do
+        Platform.rootTracingSpanIO
+            requestId
+            (Observability.report handler requestId)
+            ("Running task" ++ requestId)
+            ( \log -> do
+                Task.perform log (do
+                  Process.sleep 5
+                  Task.succeed ())
+            )
+    )
+    |> void
+  -- give async threads 1s to finish
+  threadDelay 1_000_000

--- a/nri-observability/scripts/memory-leak-test/Main.hs
+++ b/nri-observability/scripts/memory-leak-test/Main.hs
@@ -19,21 +19,20 @@ main :: IO ()
 main = do
   settings' <- Environment.decode Observability.decoder
   putStrLn (show settings'.enabledReporters)
-  -- [0 .. 1000]
-  [0..10000]
-    |> List.map Text.fromInt
-    |> mapConcurrently (\requestId -> do
-      Conduit.withAcquire (Observability.handler settings') <| \handler -> do
-        Platform.rootTracingSpanIO
-            requestId
-            (Observability.report handler requestId)
-            ("Running task" ++ requestId)
-            ( \log -> do
-                Task.perform log (do
-                  Process.sleep 5
-                  Task.succeed ())
-            )
-    )
-    |> void
+  Conduit.withAcquire (Observability.handler settings') <| \handler -> do
+    [0..300_000]
+      |> List.map Text.fromInt
+      |> mapConcurrently (\requestId -> do
+          Platform.rootTracingSpanIO
+              requestId
+              (Observability.report handler requestId)
+              ("Running task" ++ requestId)
+              ( \log -> do
+                  Task.perform log (do
+                    Process.sleep 5
+                    Task.succeed ())
+              )
+      )
+      |> void
   -- give async threads 1s to finish
-  threadDelay 1_000_000
+  -- threadDelay 5_000_000

--- a/nri-observability/scripts/memory-leak-test/Main.hs
+++ b/nri-observability/scripts/memory-leak-test/Main.hs
@@ -28,15 +28,6 @@ main = do
   Conduit.withAcquire (Observability.handler settings') <| \handler -> do
     forM_ [1..(floor (1_000_000 / fromIntegral threads))] <| \n -> do
       runRequests handler ids
-  -- give async threads 5s to finish
-  -- threadDelay 5_000_000
-
-runTest :: Int -> Observability.Handler -> IO ()
-runTest n handler = do
-  if n >= 50_000 then pure () else do
-    let ids = [n..n+threads] |> List.map Text.fromInt
-    runRequests handler ids
-    runTest (n + threads) handler
 
 runRequests :: Observability.Handler -> [Text] -> IO ()
 runRequests handler =

--- a/nri-observability/scripts/memory-leak-test/README.md
+++ b/nri-observability/scripts/memory-leak-test/README.md
@@ -1,0 +1,59 @@
+# Memory Leak Test
+
+Testing for memory leaks in the Observability library.
+
+A commit in this repo caused multiple NRI service to leak memory.
+
+This script is an attempt to reproduce the leak in a controlled environment.
+
+## Running
+
+```sh
+cabal run memory-leak-test
+```
+
+At the end of execution you will see a summary of memory usage.
+
+## Execution logs
+
+### w/ waj's PR
+
+#### ids: 100_000 (sequence)
+
+```
+10,450,960,160 bytes allocated in the heap
+   159,580,640 bytes copied during GC
+     5,992,320 bytes maximum residency (109 sample(s))
+     2,179,200 bytes maximum slop
+            81 MiB total memory in use (1 MiB lost due to fragmentation)
+```
+#### ids: 10_000 (sequence)
+
+```
+ 1,045,693,312 bytes allocated in the heap
+    36,096,416 bytes copied during GC
+     1,654,336 bytes maximum residency (64 sample(s))
+       885,664 bytes maximum slop
+            71 MiB total memory in use (1 MiB lost due to fragmentation)
+```
+
+### w/o waj's PR
+
+#### ids: 10_000 (sequence)
+```
+ 901,761,584 bytes allocated in the heap
+  38,123,856 bytes copied during GC
+   1,630,936 bytes maximum residency (69 sample(s))
+     810,240 bytes maximum slop
+          70 MiB total memory in use (0 MiB lost due to fragmentation)
+```
+
+#### ids: 10_000 (mapConcurrently)
+
+```
+ 1,212,006,112 bytes allocated in the heap
+   331,789,960 bytes copied during GC
+   378,212,016 bytes maximum residency (8 sample(s))
+     3,235,704 bytes maximum slop
+           706 MiB total memory in use (14 MiB lost due to fragmentation)
+```

--- a/nri-observability/scripts/memory-leak-test/README.md
+++ b/nri-observability/scripts/memory-leak-test/README.md
@@ -9,51 +9,20 @@ This script is an attempt to reproduce the leak in a controlled environment.
 ## Running
 
 ```sh
-cabal run memory-leak-test
+LOG_ENABLED_LOGGERS="stdout" cabal run --enable-profiling memory-leak-test -- +RTS -hy -l-au > /dev/null
 ```
 
-At the end of execution you will see a summary of memory usage.
+This will:
+- Run using the `stdout` logger only, so we don't write millions of events to `log-explorer`.
+- Enable GHC to copile with profiling enabled
+- Collect heap profile data grouped by data type (use `-hm` to group by module)
+- Use the new eventlog output format (`-l-au`)
+- Discard stdout
 
-## Execution logs
+After running for a good while, you can inspect the eventlog with:
 
-### w/ waj's PR
-
-#### ids: 100_000 (sequence)
-
-```
-10,450,960,160 bytes allocated in the heap
-   159,580,640 bytes copied during GC
-     5,992,320 bytes maximum residency (109 sample(s))
-     2,179,200 bytes maximum slop
-            81 MiB total memory in use (1 MiB lost due to fragmentation)
-```
-#### ids: 10_000 (sequence)
-
-```
- 1,045,693,312 bytes allocated in the heap
-    36,096,416 bytes copied during GC
-     1,654,336 bytes maximum residency (64 sample(s))
-       885,664 bytes maximum slop
-            71 MiB total memory in use (1 MiB lost due to fragmentation)
+```sh
+nix-shell -p haskellPackages.eventlog2html --run "eventlog2html memory-leak-test.eventlog"
 ```
 
-### w/o waj's PR
-
-#### ids: 10_000 (sequence)
-```
- 901,761,584 bytes allocated in the heap
-  38,123,856 bytes copied during GC
-   1,630,936 bytes maximum residency (69 sample(s))
-     810,240 bytes maximum slop
-          70 MiB total memory in use (0 MiB lost due to fragmentation)
-```
-
-#### ids: 10_000 (mapConcurrently)
-
-```
- 1,212,006,112 bytes allocated in the heap
-   331,789,960 bytes copied during GC
-   378,212,016 bytes maximum residency (8 sample(s))
-     3,235,704 bytes maximum slop
-           706 MiB total memory in use (14 MiB lost due to fragmentation)
-```
+Then open `memory-leak-test.eventlog.html` in your browser.

--- a/nri-observability/src/Observability.hs
+++ b/nri-observability/src/Observability.hs
@@ -22,8 +22,8 @@ where
 
 import qualified Conduit
 import Control.Concurrent.Async (async)
-import Control.Concurrent.STM (atomically, check)
-import Control.Concurrent.STM.TVar (modifyTVar, newTVarIO, readTVar)
+import Control.Concurrent.Class.MonadSTM.Strict (atomically, check)
+import Control.Concurrent.Class.MonadSTM.Strict.TVar (modifyTVar, newTVarIO, readTVar)
 import qualified Control.Exception.Safe as Exception
 import Control.Monad (void)
 import qualified Data.Aeson as Aeson

--- a/nri-observability/src/Observability.hs
+++ b/nri-observability/src/Observability.hs
@@ -207,6 +207,9 @@ data Reporter where
     } ->
     Reporter
 
+instance Prelude.Show Reporter where
+  show reporter = "Reporter { name: " ++ Text.toList (reporterName reporter) ++ " }"
+
 -- | A list containing all the reporters we support. Reporters are ordered in
 -- increasing chance of failure, so we can pick the safest one for reporting on
 -- failures in other reporters.


### PR DESCRIPTION
Since #134 was deployed to prod, NRI's highest traffic service started slowly increasing memory usage over time, at a rate of around 5MiB/min.

This PR introduces a test app that reproduces the memory leak, and a fix.

The issue was elusive:
- Profiling with `-hm` pointed fingers at `Data.Conduit.Internal`
  - [This blogpost](https://www.well-typed.com/blog/2016/09/sharing-conduit/) made me pretty certain it was the new conduit, but I don't fully follow the blogpost, in all honesty
  - `-fno-full-laziness` didn't help
- [ndmitchell's recipe for finding space leaks](https://ndmitchell.com/downloads/slides-plugging_space_leaks_improving_performance-06_oct_2016.pdf) didn't work
  - Using `-K1K` didn't make my leaky test app blow up
- Profiling with `-hy` showed an `Int` was leaking, and Waj's PR did introduce an Int inside the `STM` in the handler

I was still suspicious of `Conduit`, so while googling for `conduit stm space leak` I landed on [the `strict-stm` library](https://hackage.haskell.org/package/strict-stm), which claimed to have helped make `cardano-node` leak-free.

The library was a drop-in replacement for `stm`, and using it made our leak go away.

|before|after|
|---|---|
|<img width="1274" height="880" alt="image" src="https://github.com/user-attachments/assets/ebbd0cfc-c00e-4c51-9cba-4d091c647c9b" />|<img width="1251" height="886" alt="image" src="https://github.com/user-attachments/assets/d4af0713-cfa1-4fc3-9648-5f6713f76a53" />|
