### PR TITLE
Fix dev reporter memory usage

### DIFF
--- a/nri-observability/src/Reporter/Dev/Internal.hs
+++ b/nri-observability/src/Reporter/Dev/Internal.hs
@@ -76,7 +76,8 @@ data Handler = Handler
     -- is empty. We have a logging thread running separately that takes logs
     -- from the MVar and prints them to stdout one at a time.
     writeLock :: MVar.MVar Builder.Builder,
-    loggingThread :: Async.Async ()
+    loggingThread :: Async.Async (),
+    advertiseLogExplorer :: Async.Async ()
   }
 
 -- | Create a 'Handler'. Do this once when your application starts and reuse
@@ -86,8 +87,9 @@ handler = do
   writeLock <- MVar.newEmptyMVar
   counter <- MVar.newMVar 0
   loggingThread <- Async.async (logLoop counter writeLock)
+  advertiseLogExplorer <- Async.async (advertiseLoop counter)
   timer <- Timer.mkTimer
-  Prelude.pure Handler {timer, writeLock, loggingThread}
+  Prelude.pure Handler {timer, writeLock, loggingThread, advertiseLogExplorer}
 
 -- | Clean up your handler after you're done with it. Call this before your
 -- application shuts down.
@@ -102,14 +104,16 @@ logLoop counter lock = do
   Builder.toLazyText line
     |> Data.Text.Lazy.toStrict
     |> putTextLn
-  ownCount <- MVar.modifyMVar counter (\n -> Prelude.pure (n + 1, n + 1))
-  Async.concurrently_
-    (logLoop counter lock)
-    ( do
-        -- After a few seconds of inactivity, advertise for log-explorer.
-        Control.Concurrent.threadDelay 3_000_000 {- 3 seconds -}
-        currentCount <- MVar.readMVar counter
-        if ownCount == currentCount
-          then putTextLn "🕵️ Need more detail? Try running the `log-explorer` command!\n"
-          else Prelude.pure ()
-    )
+  MVar.modifyMVar_ counter (\n -> Prelude.pure (n + 1))
+  logLoop counter lock
+
+advertiseLoop :: MVar.MVar Int -> Prelude.IO ()
+advertiseLoop counter = do
+  lastCount <- MVar.readMVar counter
+  Control.Concurrent.threadDelay 3_000_000 {- 3 seconds -}
+  currentCount <- MVar.readMVar counter
+  if lastCount == currentCount && currentCount > 0
+    then do
+      putTextLn "🕵️ Need more detail? Try running the `log-explorer` command!\n"
+      advertiseLoop counter
+    else advertiseLoop counter


### PR DESCRIPTION
While investigating #141, I noticed our `stdout-pretty` reporter uses ridiculous amounts of ram when logging at high thoughput.

The reason is for every iteration of `logLoop`, we launch a brand new green thread to advertise `log-explorer`.

Replacing `concurrently_` with `race_` helped, but memory usage still wasn't constant.

Changing to use a dedicated advertisement green thread fixed it.

|before|after|
|---|---|
|<img width="1226" height="884" alt="image" src="https://github.com/user-attachments/assets/534de297-9e80-47e4-9e91-81506ebc215a" />|<img width="1259" height="896" alt="image" src="https://github.com/user-attachments/assets/aa2c13b4-7f79-4361-83ca-b24ce16fc381" />|

_notice the x axis: we hit 1GB within seconds_