### PR TITLE
Fix log explorer advert

### DIFF
--- a/nri-observability/src/Reporter/Dev/Internal.hs
+++ b/nri-observability/src/Reporter/Dev/Internal.hs
@@ -87,7 +87,7 @@ handler = do
   writeLock <- MVar.newEmptyMVar
   counter <- MVar.newMVar 0
   loggingThread <- Async.async (logLoop counter writeLock)
-  advertiseLogExplorer <- Async.async (advertiseLoop counter)
+  advertiseLogExplorer <- Async.async (advertiseLoop counter Nothing)
   timer <- Timer.mkTimer
   Prelude.pure Handler {timer, writeLock, loggingThread, advertiseLogExplorer}
 
@@ -107,13 +107,17 @@ logLoop counter lock = do
   MVar.modifyMVar_ counter (\n -> Prelude.pure (n + 1))
   logLoop counter lock
 
-advertiseLoop :: MVar.MVar Int -> Prelude.IO ()
-advertiseLoop counter = do
+advertiseLoop :: MVar.MVar Int -> Maybe Int -> Prelude.IO ()
+advertiseLoop counter lastAdvertisedCount = do
   lastCount <- MVar.readMVar counter
   Control.Concurrent.threadDelay 3_000_000 {- 3 seconds -}
   currentCount <- MVar.readMVar counter
-  if lastCount == currentCount && currentCount > 0
+  -- if after 3 seconds the count hasn't changed, we've stopped logging for a bit
+  let stoppedLogging = lastCount == currentCount
+  -- we don't want to advertise multiple times while we're idle
+  let haventAdvertisedAtCurrentCount = lastAdvertisedCount /= Just currentCount
+  if stoppedLogging && haventAdvertisedAtCurrentCount
     then do
       putTextLn "🕵️ Need more detail? Try running the `log-explorer` command!\n"
-      advertiseLoop counter
-    else advertiseLoop counter
+      advertiseLoop counter (Just currentCount)
+    else advertiseLoop counter lastAdvertisedCount

--- a/nri-observability/src/Reporter/Dev/Internal.hs
+++ b/nri-observability/src/Reporter/Dev/Internal.hs
@@ -112,12 +112,19 @@ advertiseLoop counter lastAdvertisedCount = do
   lastCount <- MVar.readMVar counter
   Control.Concurrent.threadDelay 3_000_000 {- 3 seconds -}
   currentCount <- MVar.readMVar counter
-  -- if after 3 seconds the count hasn't changed, we've stopped logging for a bit
-  let stoppedLogging = lastCount == currentCount
-  -- we don't want to advertise multiple times while we're idle
-  let haventAdvertisedAtCurrentCount = lastAdvertisedCount /= Just currentCount
-  if stoppedLogging && haventAdvertisedAtCurrentCount
+  if shouldAdvertise lastCount currentCount lastAdvertisedCount
     then do
       putTextLn "🕵️ Need more detail? Try running the `log-explorer` command!\n"
       advertiseLoop counter (Just currentCount)
     else advertiseLoop counter lastAdvertisedCount
+
+shouldAdvertise :: Int -> Int -> Maybe Int -> Bool
+shouldAdvertise lastCount currentCount lastAdvertisedCount =
+  let -- we don't want to advertise on launch
+      justLaunched = lastAdvertisedCount == Nothing && currentCount == 0
+      -- if after N seconds the count hasn't changed, we've stopped logging for a bit
+      stoppedLogging = lastCount == currentCount
+      -- we don't want to advertise multiple times while we're idle
+      alreadyAdvertised =
+        lastAdvertisedCount == Just currentCount
+   in stoppedLogging && not alreadyAdvertised && not justLaunched

--- a/nri-observability/tests/Spec/Reporter/Dev.hs
+++ b/nri-observability/tests/Spec/Reporter/Dev.hs
@@ -19,30 +19,36 @@ tests :: Test.Test
 tests =
   Test.describe
     "Observability.Dev"
-    [ logTest
-        "log span without details or children"
-        emptyTracingSpan
-          { Platform.name = "root-span",
-            Platform.started = ms 5
-          },
-      logTest
-        "log span with exception"
-        emptyTracingSpan
-          { Platform.name = "root-span",
-            Platform.succeeded = Platform.FailedWith (Exception.SomeException (CustomException "toast!"))
-          },
-      logTest
-        "logs information about an incoming http request"
-        emptyTracingSpan
-          { Platform.details =
-              HttpRequest.emptyDetails
-                { HttpRequest.endpoint = Just "/hats/:hat_id"
-                }
-                |> HttpRequest.Incoming
-                |> Platform.toTracingSpanDetails
-                |> Just
-          }
+    [ Test.describe "log tests" logTests,
+      Test.describe "advertise tests" advertiseTests
     ]
+
+logTests :: [Test.Test]
+logTests =
+  [ logTest
+      "log span without details or children"
+      emptyTracingSpan
+        { Platform.name = "root-span",
+          Platform.started = ms 5
+        },
+    logTest
+      "log span with exception"
+      emptyTracingSpan
+        { Platform.name = "root-span",
+          Platform.succeeded = Platform.FailedWith (Exception.SomeException (CustomException "toast!"))
+        },
+    logTest
+      "logs information about an incoming http request"
+      emptyTracingSpan
+        { Platform.details =
+            HttpRequest.emptyDetails
+              { HttpRequest.endpoint = Just "/hats/:hat_id"
+              }
+              |> HttpRequest.Incoming
+              |> Platform.toTracingSpanDetails
+              |> Just
+        }
+  ]
 
 logTest :: Text -> Platform.TracingSpan -> Test.Test
 logTest name span =
@@ -77,3 +83,21 @@ emptyTracingSpan =
       Platform.allocated = 0,
       Platform.children = []
     }
+
+advertiseTests :: [Test.Test]
+advertiseTests =
+  [ Test.test "does not advertises on launch" <| \_ -> do
+      Dev.shouldAdvertise 0 0 Nothing |> Expect.equal False,
+    Test.test "does not advertise if still logging (on launch)" <| \_ -> do
+      Dev.shouldAdvertise 0 10 Nothing |> Expect.equal False,
+    Test.test "does not advertise if still logging" <| \_ -> do
+      Dev.shouldAdvertise 0 10 (Just 0) |> Expect.equal False,
+    Test.test "does not readvertise" <| \_ -> do
+      Dev.shouldAdvertise 1 1 (Just 1) |> Expect.equal False,
+    Test.test "does not advertise if still logging (on launch)" <| \_ -> do
+      Dev.shouldAdvertise 0 10 Nothing |> Expect.equal False,
+    Test.test "does not advertise if still logging" <| \_ -> do
+      Dev.shouldAdvertise 0 10 (Just 0) |> Expect.equal False,
+    Test.test "only advertises if counter hasn't changed and we haven't advertised it yet" <| \_ -> do
+      Dev.shouldAdvertise 10 10 (Just 0) |> Expect.equal True
+  ]


### PR DESCRIPTION
On #142 I broke the logic for the `log-explorer` advertiser.

This fixes it and adds tests.