### PR TITLE
Add `Expect.runExpectation`

### DIFF
--- a/nri-prelude/src/Expect.hs
+++ b/nri-prelude/src/Expect.hs
@@ -59,6 +59,7 @@ module Expect
     Internal.runExpectation,
     Internal.fromIOResult,
     Internal.Expectation',
+    Internal.Failure,
     around,
   )
 where

--- a/nri-prelude/src/Expect.hs
+++ b/nri-prelude/src/Expect.hs
@@ -57,6 +57,7 @@ module Expect
     -- * Fancy Expectations
     Internal.fromIO,
     Internal.runExpectation,
+    Internal.fromIOResult,
     Internal.Expectation',
     around,
   )

--- a/nri-prelude/src/Expect.hs
+++ b/nri-prelude/src/Expect.hs
@@ -56,6 +56,7 @@ module Expect
 
     -- * Fancy Expectations
     Internal.fromIO,
+    Internal.runExpectation,
     Internal.Expectation',
     around,
   )

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -405,9 +405,8 @@ runExpectation log expectation = do
 -- Useful in combination with 'runExpectation'.
 fromIOResult :: Prelude.IO (Result Failure a) -> Expectation' a
 fromIOResult io =
-    Platform.Internal.Task (\_ -> io)
+  Platform.Internal.Task (\_ -> io)
     |> Expectation
-
 
 run :: Request -> Test -> Task e SuiteResult
 run request (Test all) = do

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -396,14 +396,18 @@ fromIO io =
 
 -- | Run an expectation directly in IO.
 -- On success, returns the result. On failure, throws the Failure as an exception.
-runExpectation :: Platform.LogHandler -> Expectation' a -> Prelude.IO a
+runExpectation :: Platform.LogHandler -> Expectation' a -> Prelude.IO (Result Failure a)
 runExpectation log expectation = do
-  result <-
-    unExpectation expectation
-      |> Task.attempt log
-  case result of
-    Ok a -> Prelude.pure a
-    Err failure -> Exception.throwIO failure
+  unExpectation expectation
+    |> Task.attempt log
+
+-- | Convert an IO action that returns a Result into an expectation.
+-- Useful in combination with 'runExpectation'.
+fromIOResult :: Prelude.IO (Result Failure a) -> Expectation' a
+fromIOResult io =
+    Platform.Internal.Task (\_ -> io)
+    |> Expectation
+
 
 run :: Request -> Test -> Task e SuiteResult
 run request (Test all) = do

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -396,9 +396,8 @@ fromIO io =
 
 -- | Run an expectation directly in IO.
 -- On success, returns the result. On failure, throws the Failure as an exception.
-runExpectation :: Expectation' a -> Prelude.IO a
-runExpectation expectation = do
-  log <- Platform.silentHandler
+runExpectation :: Platform.LogHandler -> Expectation' a -> Prelude.IO a
+runExpectation log expectation = do
   result <-
     unExpectation expectation
       |> Task.map Ok

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -400,9 +400,7 @@ runExpectation :: Platform.LogHandler -> Expectation' a -> Prelude.IO a
 runExpectation log expectation = do
   result <-
     unExpectation expectation
-      |> Task.map Ok
-      |> Task.onError (Task.succeed << Err)
-      |> Task.perform log
+      |> Task.attempt log
   case result of
     Ok a -> Prelude.pure a
     Err failure -> Exception.throwIO failure

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -395,7 +395,11 @@ fromIO io =
     |> Expectation
 
 -- | Run an expectation directly in IO.
--- On success, returns the result. On failure, throws the Failure as an exception.
+-- Some external testing libraries required using a resource in an IO continution like `(\resource -> IO a) -> IO a`.
+-- For example see warp's `testWithApplication`.
+--
+-- This function allows you to convert an expectation to IO inside of such a continuation.  You will likely want to
+-- transform the result back to an expectation with `fromIOResult`.
 runExpectation :: Platform.LogHandler -> Expectation' a -> Prelude.IO (Result Failure a)
 runExpectation log expectation = do
   unExpectation expectation

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -394,6 +394,20 @@ fromIO io =
   Platform.Internal.Task (\_ -> map Ok io)
     |> Expectation
 
+-- | Run an expectation directly in IO.
+-- On success, returns the result. On failure, throws the Failure as an exception.
+runExpectation :: Expectation' a -> Prelude.IO a
+runExpectation expectation = do
+  log <- Platform.silentHandler
+  result <-
+    unExpectation expectation
+      |> Task.map Ok
+      |> Task.onError (Task.succeed << Err)
+      |> Task.perform log
+  case result of
+    Ok a -> Prelude.pure a
+    Err failure -> Exception.throwIO failure
+
 run :: Request -> Test -> Task e SuiteResult
 run request (Test all) = do
   let grouped = groupBy label all

--- a/nri-prelude/tests/TestSpec.hs
+++ b/nri-prelude/tests/TestSpec.hs
@@ -36,7 +36,8 @@ tests =
       stdoutReporter,
       logfileReporter,
       cliParser,
-      deadlockPrevention
+      deadlockPrevention,
+      runExpectationTests
     ]
 
 api :: Test
@@ -666,3 +667,27 @@ withoutDurationLine text =
     |> Text.lines
     |> List.filter (\line -> line |> Text.startsWith "Duration: " |> not)
     |> Text.join "\n"
+
+runExpectationTests :: Test
+runExpectationTests =
+  describe
+    "runExpectation"
+    [ test "returns the value on success" <| \_ -> do
+        result <-
+          Expect.fromIO
+            ( Internal.runExpectation (Expect.succeeds (Task.succeed 42))
+            )
+        Expect.equal 42 result,
+      test "throws Failure exception on assertion failure" <| \_ -> do
+        result <-
+                Expect.fromIO
+                ( Exception.try (Internal.runExpectation (Expect.fail "test failure"))
+                )
+        case result of
+            Prelude.Left (Internal.FailedAssertion msg _) ->
+                Expect.true (Text.contains "test failure" msg)
+            Prelude.Left _ ->
+                Expect.fail "Expected FailedAssertion but got different Failure"
+            Prelude.Right () ->
+                Expect.fail "Expected exception but runExpectation succeeded"
+    ]

--- a/nri-prelude/tests/TestSpec.hs
+++ b/nri-prelude/tests/TestSpec.hs
@@ -673,15 +673,17 @@ runExpectationTests =
   describe
     "runExpectation"
     [ test "returns the value on success" <| \_ -> do
+        log <- Expect.fromIO Platform.silentHandler
         result <-
           Expect.fromIO
-            ( Internal.runExpectation (Expect.succeeds (Task.succeed 42))
+            ( Internal.runExpectation log (Expect.succeeds (Task.succeed 42))
             )
         Expect.equal 42 result,
       test "throws Failure exception on assertion failure" <| \_ -> do
+        log <- Expect.fromIO Platform.silentHandler
         result <-
           Expect.fromIO
-            ( Exception.try (Internal.runExpectation (Expect.fail "test failure"))
+            ( Exception.try (Internal.runExpectation log (Expect.fail "test failure"))
             )
         case result of
           Prelude.Left (Internal.FailedAssertion msg _) ->

--- a/nri-prelude/tests/TestSpec.hs
+++ b/nri-prelude/tests/TestSpec.hs
@@ -680,14 +680,14 @@ runExpectationTests =
         Expect.equal 42 result,
       test "throws Failure exception on assertion failure" <| \_ -> do
         result <-
-                Expect.fromIO
-                ( Exception.try (Internal.runExpectation (Expect.fail "test failure"))
-                )
+          Expect.fromIO
+            ( Exception.try (Internal.runExpectation (Expect.fail "test failure"))
+            )
         case result of
-            Prelude.Left (Internal.FailedAssertion msg _) ->
-                Expect.true (Text.contains "test failure" msg)
-            Prelude.Left _ ->
-                Expect.fail "Expected FailedAssertion but got different Failure"
-            Prelude.Right () ->
-                Expect.fail "Expected exception but runExpectation succeeded"
+          Prelude.Left (Internal.FailedAssertion msg _) ->
+            Expect.true (Text.contains "test failure" msg)
+          Prelude.Left _ ->
+            Expect.fail "Expected FailedAssertion but got different Failure"
+          Prelude.Right () ->
+            Expect.fail "Expected exception but runExpectation succeeded"
     ]

--- a/nri-prelude/tests/TestSpec.hs
+++ b/nri-prelude/tests/TestSpec.hs
@@ -678,18 +678,12 @@ runExpectationTests =
           Expect.fromIO
             ( Internal.runExpectation log (Expect.succeeds (Task.succeed 42))
             )
-        Expect.equal 42 result,
+        Expect.ok result,
       test "throws Failure exception on assertion failure" <| \_ -> do
         log <- Expect.fromIO Platform.silentHandler
         result <-
           Expect.fromIO
-            ( Exception.try (Internal.runExpectation log (Expect.fail "test failure"))
+            ( Internal.runExpectation log (Expect.fail "test failure")
             )
-        case result of
-          Prelude.Left (Internal.FailedAssertion msg _) ->
-            Expect.true (Text.contains "test failure" msg)
-          Prelude.Left _ ->
-            Expect.fail "Expected FailedAssertion but got different Failure"
-          Prelude.Right () ->
-            Expect.fail "Expected exception but runExpectation succeeded"
+        Expect.err result
     ]

--- a/nri-prelude/tests/golden-results-9.10/test-report-logfile-all-passed
+++ b/nri-prelude/tests/golden-results-9.10/test-report-logfile-all-passed
@@ -57,13 +57,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 429,
+        "endLine": 430,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 429
+        "startLine": 430
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.10/test-report-logfile-no-tests-in-suite
+++ b/nri-prelude/tests/golden-results-9.10/test-report-logfile-no-tests-in-suite
@@ -6,13 +6,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 468,
+        "endLine": 469,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 468
+        "startLine": 469
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.10/test-report-logfile-onlys-passed
+++ b/nri-prelude/tests/golden-results-9.10/test-report-logfile-onlys-passed
@@ -57,13 +57,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 444,
+        "endLine": 445,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 444
+        "startLine": 445
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.10/test-report-logfile-passed-with-skipped
+++ b/nri-prelude/tests/golden-results-9.10/test-report-logfile-passed-with-skipped
@@ -57,13 +57,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 459,
+        "endLine": 460,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 459
+        "startLine": 460
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.10/test-report-logfile-tests-failed
+++ b/nri-prelude/tests/golden-results-9.10/test-report-logfile-tests-failed
@@ -105,13 +105,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 488,
+        "endLine": 489,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 488
+        "startLine": 489
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.10/test-report-stdout-tests-failed-loc
+++ b/nri-prelude/tests/golden-results-9.10/test-report-stdout-tests-failed-loc
@@ -1,26 +1,26 @@
-↓ tests/TestSpec.hs:324
+↓ tests/TestSpec.hs:325
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:324
-  322:               describe
-  323:                 "suite loc"
-✗ 324:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  325:                   test "test equal" (\_ -> Expect.equal True False),
-  326:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+Expectation failed at tests/TestSpec.hs:325
+  323:               describe
+  324:                 "suite loc"
+✗ 325:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  326:                   test "test equal" (\_ -> Expect.equal True False),
+  327:                   test "test notEqual" (\_ -> Expect.notEqual True True),
 
 fail
 
-↓ tests/TestSpec.hs:325
+↓ tests/TestSpec.hs:326
 ↓ suite loc
 ✗ test equal
 
-Expectation failed at tests/TestSpec.hs:325
-  323:                 "suite loc"
-  324:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-✗ 325:                   test "test equal" (\_ -> Expect.equal True False),
-  326:                   test "test notEqual" (\_ -> Expect.notEqual True True),
-  327:                   test
+Expectation failed at tests/TestSpec.hs:326
+  324:                 "suite loc"
+  325:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+✗ 326:                   test "test equal" (\_ -> Expect.equal True False),
+  327:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+  328:                   test
 
 ▼▼▼▼
 False
@@ -30,16 +30,16 @@ False
 True
 ▲▲▲
 
-↓ tests/TestSpec.hs:326
+↓ tests/TestSpec.hs:327
 ↓ suite loc
 ✗ test notEqual
 
-Expectation failed at tests/TestSpec.hs:326
-  324:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  325:                   test "test equal" (\_ -> Expect.equal True False),
-✗ 326:                   test "test notEqual" (\_ -> Expect.notEqual True True),
-  327:                   test
-  328:                     "test all"
+Expectation failed at tests/TestSpec.hs:327
+  325:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  326:                   test "test equal" (\_ -> Expect.equal True False),
+✗ 327:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+  328:                   test
+  329:                     "test all"
 
 True
 ╷
@@ -47,16 +47,16 @@ True
 ╵
 True
 
-↓ tests/TestSpec.hs:327
+↓ tests/TestSpec.hs:328
 ↓ suite loc
 ✗ test all
 
-Expectation failed at tests/TestSpec.hs:332
-  330:                         True
-  331:                           |> Expect.all
-✗ 332:                             [ Expect.equal False
-  333:                             ]
-  334:                     ),
+Expectation failed at tests/TestSpec.hs:333
+  331:                         True
+  332:                           |> Expect.all
+✗ 333:                             [ Expect.equal False
+  334:                             ]
+  335:                     ),
 
 ▼▼▼
 True
@@ -66,16 +66,16 @@ True
 False
 ▲▲▲▲
 
-↓ tests/TestSpec.hs:335
+↓ tests/TestSpec.hs:336
 ↓ suite loc
 ✗ test lessThan
 
-Expectation failed at tests/TestSpec.hs:335
-  333:                             ]
-  334:                     ),
-✗ 335:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-  336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+Expectation failed at tests/TestSpec.hs:336
+  334:                             ]
+  335:                     ),
+✗ 336:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+  337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
 
 ▼
 2
@@ -85,16 +85,16 @@ Expectation failed at tests/TestSpec.hs:335
 1
 ▲
 
-↓ tests/TestSpec.hs:336
+↓ tests/TestSpec.hs:337
 ↓ suite loc
 ✗ test astMost
 
-Expectation failed at tests/TestSpec.hs:336
-  334:                     ),
-  335:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-✗ 336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+Expectation failed at tests/TestSpec.hs:337
+  335:                     ),
+  336:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+✗ 337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
 
 ▼
 2
@@ -104,16 +104,16 @@ Expectation failed at tests/TestSpec.hs:336
 1
 ▲
 
-↓ tests/TestSpec.hs:337
+↓ tests/TestSpec.hs:338
 ↓ suite loc
 ✗ test greatherThan
 
-Expectation failed at tests/TestSpec.hs:337
-  335:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-  336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-✗ 337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+Expectation failed at tests/TestSpec.hs:338
+  336:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+  337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+✗ 338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
 
 ▼
 1
@@ -123,16 +123,16 @@ Expectation failed at tests/TestSpec.hs:337
 2
 ▲
 
-↓ tests/TestSpec.hs:338
+↓ tests/TestSpec.hs:339
 ↓ suite loc
 ✗ test atLeast
 
-Expectation failed at tests/TestSpec.hs:338
-  336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-✗ 338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+Expectation failed at tests/TestSpec.hs:339
+  337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+✗ 339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
 
 ▼
 1
@@ -142,16 +142,16 @@ Expectation failed at tests/TestSpec.hs:338
 2
 ▲
 
-↓ tests/TestSpec.hs:339
+↓ tests/TestSpec.hs:340
 ↓ suite loc
 ✗ test within
 
-Expectation failed at tests/TestSpec.hs:339
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-✗ 339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  341:                   test "test true" (\_ -> Expect.true False),
+Expectation failed at tests/TestSpec.hs:340
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+✗ 340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  342:                   test "test true" (\_ -> Expect.true False),
 
 ▼
 2.0
@@ -161,16 +161,16 @@ Expectation failed at tests/TestSpec.hs:339
 1.0
 ▲
 
-↓ tests/TestSpec.hs:340
+↓ tests/TestSpec.hs:341
 ↓ suite loc
 ✗ test notWithin
 
-Expectation failed at tests/TestSpec.hs:340
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-✗ 340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  341:                   test "test true" (\_ -> Expect.true False),
-  342:                   test "test false" (\_ -> Expect.false True),
+Expectation failed at tests/TestSpec.hs:341
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+✗ 341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  342:                   test "test true" (\_ -> Expect.true False),
+  343:                   test "test false" (\_ -> Expect.false True),
 
 1.0
 ╷
@@ -178,94 +178,94 @@ Expectation failed at tests/TestSpec.hs:340
 ╵
 1.0
 
-↓ tests/TestSpec.hs:341
+↓ tests/TestSpec.hs:342
 ↓ suite loc
 ✗ test true
 
-Expectation failed at tests/TestSpec.hs:341
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-✗ 341:                   test "test true" (\_ -> Expect.true False),
-  342:                   test "test false" (\_ -> Expect.false True),
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
+Expectation failed at tests/TestSpec.hs:342
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+✗ 342:                   test "test true" (\_ -> Expect.true False),
+  343:                   test "test false" (\_ -> Expect.false True),
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
 
 I expected a True but got False
 
-↓ tests/TestSpec.hs:342
+↓ tests/TestSpec.hs:343
 ↓ suite loc
 ✗ test false
 
-Expectation failed at tests/TestSpec.hs:342
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  341:                   test "test true" (\_ -> Expect.true False),
-✗ 342:                   test "test false" (\_ -> Expect.false True),
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
+Expectation failed at tests/TestSpec.hs:343
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  342:                   test "test true" (\_ -> Expect.true False),
+✗ 343:                   test "test false" (\_ -> Expect.false True),
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
 
 I expected a False but got True
 
-↓ tests/TestSpec.hs:343
+↓ tests/TestSpec.hs:344
 ↓ suite loc
 ✗ test ok
 
-Expectation failed at tests/TestSpec.hs:343
-  341:                   test "test true" (\_ -> Expect.true False),
-  342:                   test "test false" (\_ -> Expect.false True),
-✗ 343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+Expectation failed at tests/TestSpec.hs:344
+  342:                   test "test true" (\_ -> Expect.true False),
+  343:                   test "test false" (\_ -> Expect.false True),
+✗ 344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
 
 I expected a Ok but got Err (())
 
-↓ tests/TestSpec.hs:344
+↓ tests/TestSpec.hs:345
 ↓ suite loc
 ✗ test err
 
-Expectation failed at tests/TestSpec.hs:344
-  342:                   test "test false" (\_ -> Expect.false True),
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-✗ 344:                   test "test err" (\_ -> Expect.err (Ok ())),
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+Expectation failed at tests/TestSpec.hs:345
+  343:                   test "test false" (\_ -> Expect.false True),
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+✗ 345:                   test "test err" (\_ -> Expect.err (Ok ())),
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
 
 I expected a Err but got Ok (())
 
-↓ tests/TestSpec.hs:345
+↓ tests/TestSpec.hs:346
 ↓ suite loc
 ✗ test succeeds
 
-Expectation failed at tests/TestSpec.hs:345
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
-✗ 345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  347:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+Expectation failed at tests/TestSpec.hs:346
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
+✗ 346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+  348:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
 
 "oops"
 
-↓ tests/TestSpec.hs:346
+↓ tests/TestSpec.hs:347
 ↓ suite loc
 ✗ test fails
 
-Expectation failed at tests/TestSpec.hs:346
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-✗ 346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  347:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  348:                 ]
+Expectation failed at tests/TestSpec.hs:347
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+✗ 347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+  348:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+  349:                 ]
 
 "Expected failure but succeeded with \"oops\""
 
-↓ tests/TestSpec.hs:347
+↓ tests/TestSpec.hs:348
 ↓ suite loc
 ✗ test andCheck
 
-Expectation failed at tests/TestSpec.hs:347
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-✗ 347:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  348:                 ]
-  349:         contents <-
+Expectation failed at tests/TestSpec.hs:348
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+✗ 348:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+  349:                 ]
+  350:         contents <-
 
 ▼
 1

--- a/nri-prelude/tests/golden-results-9.10/test-report-stdout-tests-failed-loc-one-file
+++ b/nri-prelude/tests/golden-results-9.10/test-report-stdout-tests-failed-loc-one-file
@@ -1,13 +1,13 @@
-↓ tests/TestSpec.hs:397
+↓ tests/TestSpec.hs:398
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:397
-  395:               describe
-  396:                 "suite loc"
-✗ 397:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  398:                   test "test equal" (\_ -> Expect.equal True True),
-  399:                   test "test notEqual" (\_ -> Expect.notEqual True False)
+Expectation failed at tests/TestSpec.hs:398
+  396:               describe
+  397:                 "suite loc"
+✗ 398:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  399:                   test "test equal" (\_ -> Expect.equal True True),
+  400:                   test "test notEqual" (\_ -> Expect.notEqual True False)
 
 fail
 

--- a/nri-prelude/tests/golden-results-9.10/test-report-stdout-tests-failed-loc-subset
+++ b/nri-prelude/tests/golden-results-9.10/test-report-stdout-tests-failed-loc-subset
@@ -1,13 +1,13 @@
-↓ tests/TestSpec.hs:369
+↓ tests/TestSpec.hs:370
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:369
-  367:               describe
-  368:                 "suite loc"
-✗ 369:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  370:                   test "test equal" (\_ -> Expect.equal True True),
-  371:                   test "test notEqual" (\_ -> Expect.notEqual True False)
+Expectation failed at tests/TestSpec.hs:370
+  368:               describe
+  369:                 "suite loc"
+✗ 370:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  371:                   test "test equal" (\_ -> Expect.equal True True),
+  372:                   test "test notEqual" (\_ -> Expect.notEqual True False)
 
 fail
 

--- a/nri-prelude/tests/golden-results-9.12/test-report-logfile-all-passed
+++ b/nri-prelude/tests/golden-results-9.12/test-report-logfile-all-passed
@@ -57,13 +57,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 429,
+        "endLine": 430,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 429
+        "startLine": 430
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.12/test-report-logfile-no-tests-in-suite
+++ b/nri-prelude/tests/golden-results-9.12/test-report-logfile-no-tests-in-suite
@@ -6,13 +6,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 468,
+        "endLine": 469,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 468
+        "startLine": 469
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.12/test-report-logfile-onlys-passed
+++ b/nri-prelude/tests/golden-results-9.12/test-report-logfile-onlys-passed
@@ -57,13 +57,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 444,
+        "endLine": 445,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 444
+        "startLine": 445
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.12/test-report-logfile-passed-with-skipped
+++ b/nri-prelude/tests/golden-results-9.12/test-report-logfile-passed-with-skipped
@@ -57,13 +57,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 459,
+        "endLine": 460,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 459
+        "startLine": 460
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.12/test-report-logfile-tests-failed
+++ b/nri-prelude/tests/golden-results-9.12/test-report-logfile-tests-failed
@@ -105,13 +105,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 488,
+        "endLine": 489,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 488
+        "startLine": 489
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.12/test-report-stdout-tests-failed-loc
+++ b/nri-prelude/tests/golden-results-9.12/test-report-stdout-tests-failed-loc
@@ -1,26 +1,26 @@
-↓ tests/TestSpec.hs:324
+↓ tests/TestSpec.hs:325
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:324
-  322:               describe
-  323:                 "suite loc"
-✗ 324:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  325:                   test "test equal" (\_ -> Expect.equal True False),
-  326:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+Expectation failed at tests/TestSpec.hs:325
+  323:               describe
+  324:                 "suite loc"
+✗ 325:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  326:                   test "test equal" (\_ -> Expect.equal True False),
+  327:                   test "test notEqual" (\_ -> Expect.notEqual True True),
 
 fail
 
-↓ tests/TestSpec.hs:325
+↓ tests/TestSpec.hs:326
 ↓ suite loc
 ✗ test equal
 
-Expectation failed at tests/TestSpec.hs:325
-  323:                 "suite loc"
-  324:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-✗ 325:                   test "test equal" (\_ -> Expect.equal True False),
-  326:                   test "test notEqual" (\_ -> Expect.notEqual True True),
-  327:                   test
+Expectation failed at tests/TestSpec.hs:326
+  324:                 "suite loc"
+  325:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+✗ 326:                   test "test equal" (\_ -> Expect.equal True False),
+  327:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+  328:                   test
 
 ▼▼▼▼
 False
@@ -30,16 +30,16 @@ False
 True
 ▲▲▲
 
-↓ tests/TestSpec.hs:326
+↓ tests/TestSpec.hs:327
 ↓ suite loc
 ✗ test notEqual
 
-Expectation failed at tests/TestSpec.hs:326
-  324:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  325:                   test "test equal" (\_ -> Expect.equal True False),
-✗ 326:                   test "test notEqual" (\_ -> Expect.notEqual True True),
-  327:                   test
-  328:                     "test all"
+Expectation failed at tests/TestSpec.hs:327
+  325:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  326:                   test "test equal" (\_ -> Expect.equal True False),
+✗ 327:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+  328:                   test
+  329:                     "test all"
 
 True
 ╷
@@ -47,16 +47,16 @@ True
 ╵
 True
 
-↓ tests/TestSpec.hs:327
+↓ tests/TestSpec.hs:328
 ↓ suite loc
 ✗ test all
 
-Expectation failed at tests/TestSpec.hs:332
-  330:                         True
-  331:                           |> Expect.all
-✗ 332:                             [ Expect.equal False
-  333:                             ]
-  334:                     ),
+Expectation failed at tests/TestSpec.hs:333
+  331:                         True
+  332:                           |> Expect.all
+✗ 333:                             [ Expect.equal False
+  334:                             ]
+  335:                     ),
 
 ▼▼▼
 True
@@ -66,16 +66,16 @@ True
 False
 ▲▲▲▲
 
-↓ tests/TestSpec.hs:335
+↓ tests/TestSpec.hs:336
 ↓ suite loc
 ✗ test lessThan
 
-Expectation failed at tests/TestSpec.hs:335
-  333:                             ]
-  334:                     ),
-✗ 335:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-  336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+Expectation failed at tests/TestSpec.hs:336
+  334:                             ]
+  335:                     ),
+✗ 336:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+  337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
 
 ▼
 2
@@ -85,16 +85,16 @@ Expectation failed at tests/TestSpec.hs:335
 1
 ▲
 
-↓ tests/TestSpec.hs:336
+↓ tests/TestSpec.hs:337
 ↓ suite loc
 ✗ test astMost
 
-Expectation failed at tests/TestSpec.hs:336
-  334:                     ),
-  335:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-✗ 336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+Expectation failed at tests/TestSpec.hs:337
+  335:                     ),
+  336:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+✗ 337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
 
 ▼
 2
@@ -104,16 +104,16 @@ Expectation failed at tests/TestSpec.hs:336
 1
 ▲
 
-↓ tests/TestSpec.hs:337
+↓ tests/TestSpec.hs:338
 ↓ suite loc
 ✗ test greatherThan
 
-Expectation failed at tests/TestSpec.hs:337
-  335:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-  336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-✗ 337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+Expectation failed at tests/TestSpec.hs:338
+  336:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+  337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+✗ 338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
 
 ▼
 1
@@ -123,16 +123,16 @@ Expectation failed at tests/TestSpec.hs:337
 2
 ▲
 
-↓ tests/TestSpec.hs:338
+↓ tests/TestSpec.hs:339
 ↓ suite loc
 ✗ test atLeast
 
-Expectation failed at tests/TestSpec.hs:338
-  336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-✗ 338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+Expectation failed at tests/TestSpec.hs:339
+  337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+✗ 339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
 
 ▼
 1
@@ -142,16 +142,16 @@ Expectation failed at tests/TestSpec.hs:338
 2
 ▲
 
-↓ tests/TestSpec.hs:339
+↓ tests/TestSpec.hs:340
 ↓ suite loc
 ✗ test within
 
-Expectation failed at tests/TestSpec.hs:339
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-✗ 339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  341:                   test "test true" (\_ -> Expect.true False),
+Expectation failed at tests/TestSpec.hs:340
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+✗ 340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  342:                   test "test true" (\_ -> Expect.true False),
 
 ▼
 2.0
@@ -161,16 +161,16 @@ Expectation failed at tests/TestSpec.hs:339
 1.0
 ▲
 
-↓ tests/TestSpec.hs:340
+↓ tests/TestSpec.hs:341
 ↓ suite loc
 ✗ test notWithin
 
-Expectation failed at tests/TestSpec.hs:340
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-✗ 340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  341:                   test "test true" (\_ -> Expect.true False),
-  342:                   test "test false" (\_ -> Expect.false True),
+Expectation failed at tests/TestSpec.hs:341
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+✗ 341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  342:                   test "test true" (\_ -> Expect.true False),
+  343:                   test "test false" (\_ -> Expect.false True),
 
 1.0
 ╷
@@ -178,94 +178,94 @@ Expectation failed at tests/TestSpec.hs:340
 ╵
 1.0
 
-↓ tests/TestSpec.hs:341
+↓ tests/TestSpec.hs:342
 ↓ suite loc
 ✗ test true
 
-Expectation failed at tests/TestSpec.hs:341
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-✗ 341:                   test "test true" (\_ -> Expect.true False),
-  342:                   test "test false" (\_ -> Expect.false True),
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
+Expectation failed at tests/TestSpec.hs:342
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+✗ 342:                   test "test true" (\_ -> Expect.true False),
+  343:                   test "test false" (\_ -> Expect.false True),
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
 
 I expected a True but got False
 
-↓ tests/TestSpec.hs:342
+↓ tests/TestSpec.hs:343
 ↓ suite loc
 ✗ test false
 
-Expectation failed at tests/TestSpec.hs:342
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  341:                   test "test true" (\_ -> Expect.true False),
-✗ 342:                   test "test false" (\_ -> Expect.false True),
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
+Expectation failed at tests/TestSpec.hs:343
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  342:                   test "test true" (\_ -> Expect.true False),
+✗ 343:                   test "test false" (\_ -> Expect.false True),
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
 
 I expected a False but got True
 
-↓ tests/TestSpec.hs:343
+↓ tests/TestSpec.hs:344
 ↓ suite loc
 ✗ test ok
 
-Expectation failed at tests/TestSpec.hs:343
-  341:                   test "test true" (\_ -> Expect.true False),
-  342:                   test "test false" (\_ -> Expect.false True),
-✗ 343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+Expectation failed at tests/TestSpec.hs:344
+  342:                   test "test true" (\_ -> Expect.true False),
+  343:                   test "test false" (\_ -> Expect.false True),
+✗ 344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
 
 I expected a Ok but got Err (())
 
-↓ tests/TestSpec.hs:344
+↓ tests/TestSpec.hs:345
 ↓ suite loc
 ✗ test err
 
-Expectation failed at tests/TestSpec.hs:344
-  342:                   test "test false" (\_ -> Expect.false True),
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-✗ 344:                   test "test err" (\_ -> Expect.err (Ok ())),
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+Expectation failed at tests/TestSpec.hs:345
+  343:                   test "test false" (\_ -> Expect.false True),
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+✗ 345:                   test "test err" (\_ -> Expect.err (Ok ())),
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
 
 I expected a Err but got Ok (())
 
-↓ tests/TestSpec.hs:345
+↓ tests/TestSpec.hs:346
 ↓ suite loc
 ✗ test succeeds
 
-Expectation failed at tests/TestSpec.hs:345
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
-✗ 345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  347:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+Expectation failed at tests/TestSpec.hs:346
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
+✗ 346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+  348:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
 
 "oops"
 
-↓ tests/TestSpec.hs:346
+↓ tests/TestSpec.hs:347
 ↓ suite loc
 ✗ test fails
 
-Expectation failed at tests/TestSpec.hs:346
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-✗ 346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  347:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  348:                 ]
+Expectation failed at tests/TestSpec.hs:347
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+✗ 347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+  348:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+  349:                 ]
 
 "Expected failure but succeeded with \"oops\""
 
-↓ tests/TestSpec.hs:347
+↓ tests/TestSpec.hs:348
 ↓ suite loc
 ✗ test andCheck
 
-Expectation failed at tests/TestSpec.hs:347
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-✗ 347:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  348:                 ]
-  349:         contents <-
+Expectation failed at tests/TestSpec.hs:348
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+✗ 348:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+  349:                 ]
+  350:         contents <-
 
 ▼
 1

--- a/nri-prelude/tests/golden-results-9.12/test-report-stdout-tests-failed-loc-one-file
+++ b/nri-prelude/tests/golden-results-9.12/test-report-stdout-tests-failed-loc-one-file
@@ -1,13 +1,13 @@
-↓ tests/TestSpec.hs:397
+↓ tests/TestSpec.hs:398
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:397
-  395:               describe
-  396:                 "suite loc"
-✗ 397:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  398:                   test "test equal" (\_ -> Expect.equal True True),
-  399:                   test "test notEqual" (\_ -> Expect.notEqual True False)
+Expectation failed at tests/TestSpec.hs:398
+  396:               describe
+  397:                 "suite loc"
+✗ 398:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  399:                   test "test equal" (\_ -> Expect.equal True True),
+  400:                   test "test notEqual" (\_ -> Expect.notEqual True False)
 
 fail
 

--- a/nri-prelude/tests/golden-results-9.12/test-report-stdout-tests-failed-loc-subset
+++ b/nri-prelude/tests/golden-results-9.12/test-report-stdout-tests-failed-loc-subset
@@ -1,13 +1,13 @@
-↓ tests/TestSpec.hs:369
+↓ tests/TestSpec.hs:370
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:369
-  367:               describe
-  368:                 "suite loc"
-✗ 369:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  370:                   test "test equal" (\_ -> Expect.equal True True),
-  371:                   test "test notEqual" (\_ -> Expect.notEqual True False)
+Expectation failed at tests/TestSpec.hs:370
+  368:               describe
+  369:                 "suite loc"
+✗ 370:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  371:                   test "test equal" (\_ -> Expect.equal True True),
+  372:                   test "test notEqual" (\_ -> Expect.notEqual True False)
 
 fail
 

--- a/nri-prelude/tests/golden-results-9.8/test-report-logfile-all-passed
+++ b/nri-prelude/tests/golden-results-9.8/test-report-logfile-all-passed
@@ -57,13 +57,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 429,
+        "endLine": 430,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 429
+        "startLine": 430
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.8/test-report-logfile-no-tests-in-suite
+++ b/nri-prelude/tests/golden-results-9.8/test-report-logfile-no-tests-in-suite
@@ -6,13 +6,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 468,
+        "endLine": 469,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 468
+        "startLine": 469
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.8/test-report-logfile-onlys-passed
+++ b/nri-prelude/tests/golden-results-9.8/test-report-logfile-onlys-passed
@@ -57,13 +57,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 444,
+        "endLine": 445,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 444
+        "startLine": 445
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.8/test-report-logfile-passed-with-skipped
+++ b/nri-prelude/tests/golden-results-9.8/test-report-logfile-passed-with-skipped
@@ -57,13 +57,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 459,
+        "endLine": 460,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 459
+        "startLine": 460
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.8/test-report-logfile-tests-failed
+++ b/nri-prelude/tests/golden-results-9.8/test-report-logfile-tests-failed
@@ -105,13 +105,13 @@
     "finished": 0,
     "frame": {
         "endCol": 50,
-        "endLine": 488,
+        "endLine": 489,
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
         "package": "nri-prelude-0.6.1.2-inplace-tests",
         "startCol": 22,
-        "startLine": 488
+        "startLine": 489
     },
     "name": "test run",
     "started": 0,

--- a/nri-prelude/tests/golden-results-9.8/test-report-stdout-tests-failed-loc
+++ b/nri-prelude/tests/golden-results-9.8/test-report-stdout-tests-failed-loc
@@ -1,26 +1,26 @@
-↓ tests/TestSpec.hs:324
+↓ tests/TestSpec.hs:325
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:324
-  322:               describe
-  323:                 "suite loc"
-✗ 324:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  325:                   test "test equal" (\_ -> Expect.equal True False),
-  326:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+Expectation failed at tests/TestSpec.hs:325
+  323:               describe
+  324:                 "suite loc"
+✗ 325:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  326:                   test "test equal" (\_ -> Expect.equal True False),
+  327:                   test "test notEqual" (\_ -> Expect.notEqual True True),
 
 fail
 
-↓ tests/TestSpec.hs:325
+↓ tests/TestSpec.hs:326
 ↓ suite loc
 ✗ test equal
 
-Expectation failed at tests/TestSpec.hs:325
-  323:                 "suite loc"
-  324:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-✗ 325:                   test "test equal" (\_ -> Expect.equal True False),
-  326:                   test "test notEqual" (\_ -> Expect.notEqual True True),
-  327:                   test
+Expectation failed at tests/TestSpec.hs:326
+  324:                 "suite loc"
+  325:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+✗ 326:                   test "test equal" (\_ -> Expect.equal True False),
+  327:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+  328:                   test
 
 ▼▼▼▼
 False
@@ -30,16 +30,16 @@ False
 True
 ▲▲▲
 
-↓ tests/TestSpec.hs:326
+↓ tests/TestSpec.hs:327
 ↓ suite loc
 ✗ test notEqual
 
-Expectation failed at tests/TestSpec.hs:326
-  324:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  325:                   test "test equal" (\_ -> Expect.equal True False),
-✗ 326:                   test "test notEqual" (\_ -> Expect.notEqual True True),
-  327:                   test
-  328:                     "test all"
+Expectation failed at tests/TestSpec.hs:327
+  325:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  326:                   test "test equal" (\_ -> Expect.equal True False),
+✗ 327:                   test "test notEqual" (\_ -> Expect.notEqual True True),
+  328:                   test
+  329:                     "test all"
 
 True
 ╷
@@ -47,16 +47,16 @@ True
 ╵
 True
 
-↓ tests/TestSpec.hs:327
+↓ tests/TestSpec.hs:328
 ↓ suite loc
 ✗ test all
 
-Expectation failed at tests/TestSpec.hs:332
-  330:                         True
-  331:                           |> Expect.all
-✗ 332:                             [ Expect.equal False
-  333:                             ]
-  334:                     ),
+Expectation failed at tests/TestSpec.hs:333
+  331:                         True
+  332:                           |> Expect.all
+✗ 333:                             [ Expect.equal False
+  334:                             ]
+  335:                     ),
 
 ▼▼▼
 True
@@ -66,16 +66,16 @@ True
 False
 ▲▲▲▲
 
-↓ tests/TestSpec.hs:335
+↓ tests/TestSpec.hs:336
 ↓ suite loc
 ✗ test lessThan
 
-Expectation failed at tests/TestSpec.hs:335
-  333:                             ]
-  334:                     ),
-✗ 335:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-  336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+Expectation failed at tests/TestSpec.hs:336
+  334:                             ]
+  335:                     ),
+✗ 336:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+  337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
 
 ▼
 2
@@ -85,16 +85,16 @@ Expectation failed at tests/TestSpec.hs:335
 1
 ▲
 
-↓ tests/TestSpec.hs:336
+↓ tests/TestSpec.hs:337
 ↓ suite loc
 ✗ test astMost
 
-Expectation failed at tests/TestSpec.hs:336
-  334:                     ),
-  335:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-✗ 336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+Expectation failed at tests/TestSpec.hs:337
+  335:                     ),
+  336:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+✗ 337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
 
 ▼
 2
@@ -104,16 +104,16 @@ Expectation failed at tests/TestSpec.hs:336
 1
 ▲
 
-↓ tests/TestSpec.hs:337
+↓ tests/TestSpec.hs:338
 ↓ suite loc
 ✗ test greatherThan
 
-Expectation failed at tests/TestSpec.hs:337
-  335:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
-  336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-✗ 337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+Expectation failed at tests/TestSpec.hs:338
+  336:                   test "test lessThan" (\_ -> Expect.lessThan 1 (2 :: Int)),
+  337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+✗ 338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
 
 ▼
 1
@@ -123,16 +123,16 @@ Expectation failed at tests/TestSpec.hs:337
 2
 ▲
 
-↓ tests/TestSpec.hs:338
+↓ tests/TestSpec.hs:339
 ↓ suite loc
 ✗ test atLeast
 
-Expectation failed at tests/TestSpec.hs:338
-  336:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-✗ 338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+Expectation failed at tests/TestSpec.hs:339
+  337:                   test "test astMost" (\_ -> Expect.atMost 1 (2 :: Int)),
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+✗ 339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
 
 ▼
 1
@@ -142,16 +142,16 @@ Expectation failed at tests/TestSpec.hs:338
 2
 ▲
 
-↓ tests/TestSpec.hs:339
+↓ tests/TestSpec.hs:340
 ↓ suite loc
 ✗ test within
 
-Expectation failed at tests/TestSpec.hs:339
-  337:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-✗ 339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  341:                   test "test true" (\_ -> Expect.true False),
+Expectation failed at tests/TestSpec.hs:340
+  338:                   test "test greatherThan" (\_ -> Expect.greaterThan 2 (1 :: Int)),
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+✗ 340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  342:                   test "test true" (\_ -> Expect.true False),
 
 ▼
 2.0
@@ -161,16 +161,16 @@ Expectation failed at tests/TestSpec.hs:339
 1.0
 ▲
 
-↓ tests/TestSpec.hs:340
+↓ tests/TestSpec.hs:341
 ↓ suite loc
 ✗ test notWithin
 
-Expectation failed at tests/TestSpec.hs:340
-  338:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-✗ 340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  341:                   test "test true" (\_ -> Expect.true False),
-  342:                   test "test false" (\_ -> Expect.false True),
+Expectation failed at tests/TestSpec.hs:341
+  339:                   test "test atLeast" (\_ -> Expect.atLeast 2 (1 :: Int)),
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+✗ 341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  342:                   test "test true" (\_ -> Expect.true False),
+  343:                   test "test false" (\_ -> Expect.false True),
 
 1.0
 ╷
@@ -178,94 +178,94 @@ Expectation failed at tests/TestSpec.hs:340
 ╵
 1.0
 
-↓ tests/TestSpec.hs:341
+↓ tests/TestSpec.hs:342
 ↓ suite loc
 ✗ test true
 
-Expectation failed at tests/TestSpec.hs:341
-  339:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-✗ 341:                   test "test true" (\_ -> Expect.true False),
-  342:                   test "test false" (\_ -> Expect.false True),
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
+Expectation failed at tests/TestSpec.hs:342
+  340:                   test "test within" (\_ -> Expect.within (Expect.Absolute 0.1) 1 2),
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+✗ 342:                   test "test true" (\_ -> Expect.true False),
+  343:                   test "test false" (\_ -> Expect.false True),
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
 
 I expected a True but got False
 
-↓ tests/TestSpec.hs:342
+↓ tests/TestSpec.hs:343
 ↓ suite loc
 ✗ test false
 
-Expectation failed at tests/TestSpec.hs:342
-  340:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
-  341:                   test "test true" (\_ -> Expect.true False),
-✗ 342:                   test "test false" (\_ -> Expect.false True),
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
+Expectation failed at tests/TestSpec.hs:343
+  341:                   test "test notWithin" (\_ -> Expect.notWithin (Expect.Relative 0.1) 1 1),
+  342:                   test "test true" (\_ -> Expect.true False),
+✗ 343:                   test "test false" (\_ -> Expect.false True),
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
 
 I expected a False but got True
 
-↓ tests/TestSpec.hs:343
+↓ tests/TestSpec.hs:344
 ↓ suite loc
 ✗ test ok
 
-Expectation failed at tests/TestSpec.hs:343
-  341:                   test "test true" (\_ -> Expect.true False),
-  342:                   test "test false" (\_ -> Expect.false True),
-✗ 343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+Expectation failed at tests/TestSpec.hs:344
+  342:                   test "test true" (\_ -> Expect.true False),
+  343:                   test "test false" (\_ -> Expect.false True),
+✗ 344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
 
 I expected a Ok but got Err (())
 
-↓ tests/TestSpec.hs:344
+↓ tests/TestSpec.hs:345
 ↓ suite loc
 ✗ test err
 
-Expectation failed at tests/TestSpec.hs:344
-  342:                   test "test false" (\_ -> Expect.false True),
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-✗ 344:                   test "test err" (\_ -> Expect.err (Ok ())),
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+Expectation failed at tests/TestSpec.hs:345
+  343:                   test "test false" (\_ -> Expect.false True),
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+✗ 345:                   test "test err" (\_ -> Expect.err (Ok ())),
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
 
 I expected a Err but got Ok (())
 
-↓ tests/TestSpec.hs:345
+↓ tests/TestSpec.hs:346
 ↓ suite loc
 ✗ test succeeds
 
-Expectation failed at tests/TestSpec.hs:345
-  343:                   test "test ok" (\_ -> Expect.ok (Err ())),
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
-✗ 345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  347:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+Expectation failed at tests/TestSpec.hs:346
+  344:                   test "test ok" (\_ -> Expect.ok (Err ())),
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
+✗ 346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+  348:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
 
 "oops"
 
-↓ tests/TestSpec.hs:346
+↓ tests/TestSpec.hs:347
 ↓ suite loc
 ✗ test fails
 
-Expectation failed at tests/TestSpec.hs:346
-  344:                   test "test err" (\_ -> Expect.err (Ok ())),
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-✗ 346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-  347:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  348:                 ]
+Expectation failed at tests/TestSpec.hs:347
+  345:                   test "test err" (\_ -> Expect.err (Ok ())),
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+✗ 347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+  348:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+  349:                 ]
 
 "Expected failure but succeeded with \"oops\""
 
-↓ tests/TestSpec.hs:347
+↓ tests/TestSpec.hs:348
 ↓ suite loc
 ✗ test andCheck
 
-Expectation failed at tests/TestSpec.hs:347
-  345:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
-  346:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
-✗ 347:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
-  348:                 ]
-  349:         contents <-
+Expectation failed at tests/TestSpec.hs:348
+  346:                   test "test succeeds" (\_ -> Expect.succeeds (Task.fail "oops")),
+  347:                   test "test fails" (\_ -> Expect.fails (Task.succeed "oops")),
+✗ 348:                   test "test andCheck" (\_ -> Task.succeed (1 :: Int) |> Expect.andCheck (Expect.equal 2) |> map (\_ -> ()))
+  349:                 ]
+  350:         contents <-
 
 ▼
 1

--- a/nri-prelude/tests/golden-results-9.8/test-report-stdout-tests-failed-loc-one-file
+++ b/nri-prelude/tests/golden-results-9.8/test-report-stdout-tests-failed-loc-one-file
@@ -1,13 +1,13 @@
-↓ tests/TestSpec.hs:397
+↓ tests/TestSpec.hs:398
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:397
-  395:               describe
-  396:                 "suite loc"
-✗ 397:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  398:                   test "test equal" (\_ -> Expect.equal True True),
-  399:                   test "test notEqual" (\_ -> Expect.notEqual True False)
+Expectation failed at tests/TestSpec.hs:398
+  396:               describe
+  397:                 "suite loc"
+✗ 398:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  399:                   test "test equal" (\_ -> Expect.equal True True),
+  400:                   test "test notEqual" (\_ -> Expect.notEqual True False)
 
 fail
 

--- a/nri-prelude/tests/golden-results-9.8/test-report-stdout-tests-failed-loc-subset
+++ b/nri-prelude/tests/golden-results-9.8/test-report-stdout-tests-failed-loc-subset
@@ -1,13 +1,13 @@
-↓ tests/TestSpec.hs:369
+↓ tests/TestSpec.hs:370
 ↓ suite loc
 ✗ test fail
 
-Expectation failed at tests/TestSpec.hs:369
-  367:               describe
-  368:                 "suite loc"
-✗ 369:                 [ test "test fail" (\_ -> Expect.fail "fail"),
-  370:                   test "test equal" (\_ -> Expect.equal True True),
-  371:                   test "test notEqual" (\_ -> Expect.notEqual True False)
+Expectation failed at tests/TestSpec.hs:370
+  368:               describe
+  369:                 "suite loc"
+✗ 370:                 [ test "test fail" (\_ -> Expect.fail "fail"),
+  371:                   test "test equal" (\_ -> Expect.equal True True),
+  372:                   test "test notEqual" (\_ -> Expect.notEqual True False)
 
 fail
 


### PR DESCRIPTION
This adds a new function `Expect.runExpectation`,  which takes an Expectation and runs it into an `IO`. This is necessary for using the `Llm.Test.Cached` API from the `llm-client` library we now have.