### PR TITLE
nri-prelude: thread an analytics callback through LogHandler

### DIFF
--- a/nri-env-parser/nri-env-parser.cabal
+++ b/nri-env-parser/nri-env-parser.cabal
@@ -53,7 +53,7 @@ library
       base >=4.18 && <4.22
     , modern-uri >=0.3.1.0 && <0.4
     , network-uri >=2.6.2.0 && <2.8
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.1.0.0 && <0.8
     , text >=1.2.3.1 && <2.2
   default-language: Haskell2010
 
@@ -86,6 +86,6 @@ test-suite tests
       base >=4.18 && <4.22
     , modern-uri >=0.3.1.0 && <0.4
     , network-uri >=2.6.2.0 && <2.8
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.1.0.0 && <0.8
     , text >=1.2.3.1 && <2.2
   default-language: Haskell2010

--- a/nri-env-parser/package.yaml
+++ b/nri-env-parser/package.yaml
@@ -16,7 +16,7 @@ extra-doc-files:
 library:
   dependencies: &dependencies
     - base >= 4.18 && < 4.22
-    - nri-prelude >= 0.1.0.0 && < 0.7
+    - nri-prelude >= 0.1.0.0 && < 0.8
     - modern-uri >= 0.3.1.0 && < 0.4
     - network-uri >= 2.6.2.0 && < 2.8
     - text >= 1.2.3.1 && < 2.2

--- a/nri-http/nri-http.cabal
+++ b/nri-http/nri-http.cabal
@@ -65,7 +65,7 @@ library
     , mime-types >=0.1.0.0 && <0.2
     , network-uri >=2.6.0.0 && <2.8
     , nri-observability >=0.1.0.0 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , safe-exceptions >=0.1.7.0 && <1.3
     , text >=1.2.3.1 && <2.2
   default-language: Haskell2010
@@ -111,7 +111,7 @@ test-suite spec
     , mime-types >=0.1.0.0 && <0.2
     , network-uri >=2.6.0.0 && <2.8
     , nri-observability >=0.1.0.0 && <0.4
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , safe-exceptions >=0.1.7.0 && <1.3
     , text >=1.2.3.1 && <2.2
     , wai >=3.2.0 && <3.3

--- a/nri-http/package.yaml
+++ b/nri-http/package.yaml
@@ -17,7 +17,7 @@ library:
     - aeson >= 2.0 && < 2.3
     - base >= 4.18 && < 4.22
     - bytestring >= 0.10.8.2 && < 0.13
-    - nri-prelude >= 0.1.0.0 && < 0.7
+    - nri-prelude >= 0.7.0.0 && < 0.8
     - nri-observability >= 0.1.0.0 && < 0.5
     - conduit >= 1.3.0 && < 1.4
     - case-insensitive >= 1.1 && < 2.0
@@ -38,7 +38,7 @@ tests:
       - aeson >= 2.0 && < 2.3
       - base >= 4.18 && < 4.22
       - bytestring >= 0.10.8.2 && < 0.13
-      - nri-prelude >= 0.1.0.0 && < 0.7
+      - nri-prelude >= 0.7.0.0 && < 0.8
       - nri-observability >= 0.1.0.0 && < 0.4
       - conduit >= 1.3.0 && < 1.4
       - case-insensitive >= 1.1 && < 2.0

--- a/nri-http/test/Main.hs
+++ b/nri-http/test/Main.hs
@@ -233,6 +233,7 @@ spanForTask task = do
     Expect.fromIO <| do
       Platform.rootTracingSpanIO
         "test-request"
+        Platform.silentTrack
         (MVar.putMVar spanVar)
         "test-root"
         (\log -> Task.attempt log task)

--- a/nri-kafka/nri-kafka.cabal
+++ b/nri-kafka/nri-kafka.cabal
@@ -80,7 +80,7 @@ library
     , hw-kafka-client >=4.0.3 && <5.0
     , nri-env-parser >=0.1.0.0 && <0.5
     , nri-observability >=0.1.1.1 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , safe-exceptions >=0.1.7.0 && <1.3
     , stm >=2.4 && <2.6
     , text >=1.2.3.1 && <2.2
@@ -125,7 +125,7 @@ executable pause-resume-bug-consumer
     , nri-env-parser >=0.1.0.0 && <0.5
     , nri-kafka
     , nri-observability >=0.1.1.1 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , safe-exceptions >=0.1.7.0 && <1.3
     , stm >=2.4 && <2.6
     , text >=1.2.3.1 && <2.2
@@ -174,7 +174,7 @@ executable pause-resume-bug-producer
     , nri-env-parser >=0.1.0.0 && <0.5
     , nri-kafka
     , nri-observability >=0.1.1.1 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , safe-exceptions >=0.1.7.0 && <1.3
     , stm >=2.4 && <2.6
     , text >=1.2.3.1 && <2.2
@@ -221,7 +221,7 @@ executable sync-write-benchmark
     , nri-env-parser >=0.1.0.0 && <0.5
     , nri-kafka
     , nri-observability >=0.1.1.1 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , safe-exceptions >=0.1.7.0 && <1.3
     , stm >=2.4 && <2.6
     , text >=1.2.3.1 && <2.2
@@ -284,7 +284,7 @@ test-suite tests
     , hw-kafka-client >=4.0.3 && <5.0
     , nri-env-parser >=0.1.0.0 && <0.5
     , nri-observability >=0.1.1.1 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , safe-exceptions >=0.1.7.0 && <1.3
     , stm >=2.4 && <2.6
     , text >=1.2.3.1 && <2.2

--- a/nri-kafka/package.yaml
+++ b/nri-kafka/package.yaml
@@ -23,7 +23,7 @@ dependencies:
   - hw-kafka-client >=4.0.3 && < 5.0
   - nri-env-parser >= 0.1.0.0 && < 0.5
   - nri-observability >= 0.1.1.1 && < 0.5
-  - nri-prelude >= 0.1.0.0 && < 0.7
+  - nri-prelude >= 0.7.0.0 && < 0.8
   - safe-exceptions >= 0.1.7.0 && < 1.3
   - stm >= 2.4 && < 2.6
   - text >= 1.2.3.1 && < 2.2

--- a/nri-kafka/src/Kafka/Worker/Internal.hs
+++ b/nri-kafka/src/Kafka/Worker/Internal.hs
@@ -456,6 +456,7 @@ cleanUp observabilityHandler rebalanceInfo stopping maybeException consumer = do
   -- at some point, k8s should report system crashes. In the mean time, we'll do it.
   Platform.rootTracingSpanIO
     requestId
+    Platform.silentTrack
     (Observability.report observabilityHandler requestId)
     "Kafka consumer shutting down"
     <| \log -> do

--- a/nri-kafka/src/Kafka/Worker/Partition.hs
+++ b/nri-kafka/src/Kafka/Worker/Partition.hs
@@ -248,6 +248,7 @@ processMsgLoop skipOrNot messageFormat commitOffsets observabilityHandler state 
       (RequestId requestId, details) <- getTracingDetails (analytics state) processAttempts record
       Platform.rootTracingSpanIO
         requestId
+        Platform.silentTrack
         (Observability.report observabilityHandler requestId)
         "Assigned Kafka message"
         ( \log -> do

--- a/nri-log-explorer/nri-log-explorer.cabal
+++ b/nri-log-explorer/nri-log-explorer.cabal
@@ -59,7 +59,7 @@ executable log-explorer
     , fuzzy >=0.1.0.0 && <0.2
     , io-streams >=1.5.0.0 && <1.6
     , microlens >=0.4.11.0 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.1.0.0 && <0.8
     , pcre-light >=0.4.1.0 && <0.4.2
     , process >=1.6.0.0 && <1.7
     , safe-exceptions >=0.1.7.0 && <1.3

--- a/nri-log-explorer/package.yaml
+++ b/nri-log-explorer/package.yaml
@@ -28,7 +28,7 @@ executables:
       - pcre-light >= 0.4.1.0 && < 0.4.2
       - unordered-containers >= 0.2.0.0 && < 0.3
       - microlens >= 0.4.11.0 && < 0.5
-      - nri-prelude >= 0.1.0.0 && < 0.7
+      - nri-prelude >= 0.1.0.0 && < 0.8
       - process >= 1.6.0.0 && < 1.7
       - safe-exceptions >= 0.1.7.0 && < 1.3
       - text >= 1.2.3.1 && < 2.2

--- a/nri-observability/nri-observability.cabal
+++ b/nri-observability/nri-observability.cabal
@@ -77,7 +77,7 @@ library
     , http-client >=0.6.0 && <0.8
     , http-client-tls >=0.3.0 && <0.4
     , nri-env-parser >=0.1.0.0 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , random >=1.1 && <1.3
     , safe-exceptions >=0.1.7.0 && <1.3
     , stm >=2.4 && <2.6
@@ -123,7 +123,7 @@ executable memory-leak-test
     , http-client-tls >=0.3.0 && <0.4
     , nri-env-parser >=0.1.0.0 && <0.5
     , nri-observability
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , random >=1.1 && <1.3
     , safe-exceptions >=0.1.7.0 && <1.3
     , stm >=2.4 && <2.6
@@ -194,7 +194,7 @@ test-suite tests
     , http-client >=0.6.0 && <0.8
     , http-client-tls >=0.3.0 && <0.4
     , nri-env-parser >=0.1.0.0 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , random >=1.1 && <1.3
     , safe-exceptions >=0.1.7.0 && <1.3
     , stm >=2.4 && <2.6

--- a/nri-observability/package.yaml
+++ b/nri-observability/package.yaml
@@ -26,7 +26,7 @@ dependencies:
   - http-client-tls >= 0.3.0 && < 0.4
   - hostname >= 1.0 && < 1.1
   - nri-env-parser >= 0.1.0.0 && < 0.5
-  - nri-prelude >= 0.1.0.0 && < 0.7
+  - nri-prelude >= 0.7.0.0 && < 0.8
   - random >= 1.1 && < 1.3
   - unordered-containers >= 0.2.0.0 && < 0.3
   - safe-exceptions >= 0.1.7.0 && < 1.3

--- a/nri-observability/scripts/memory-leak-test/Main.hs
+++ b/nri-observability/scripts/memory-leak-test/Main.hs
@@ -35,6 +35,7 @@ runRequests handler =
     ( \requestId -> do
         Platform.rootTracingSpanIO
           requestId
+          Platform.silentTrack
           (handler.report requestId)
           ("Running task" ++ requestId)
           ( \log -> do

--- a/nri-postgresql/nri-postgresql.cabal
+++ b/nri-postgresql/nri-postgresql.cabal
@@ -68,7 +68,7 @@ library
     , network >=3.1.0.0 && <3.3
     , nri-env-parser >=0.1.0.0 && <0.5
     , nri-observability >=0.1.0.0 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , postgresql-typed ==0.6.*
     , resource-pool >=0.2.0.0 && <0.5
     , resourcet >=1.2.0 && <1.4
@@ -126,7 +126,7 @@ test-suite tests
     , network >=3.1.0.0 && <3.3
     , nri-env-parser >=0.1.0.0 && <0.5
     , nri-observability >=0.1.0.0 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , postgresql-typed ==0.6.*
     , resource-pool >=0.2.0.0 && <0.5
     , resourcet >=1.2.0 && <1.4

--- a/nri-postgresql/package.yaml
+++ b/nri-postgresql/package.yaml
@@ -23,7 +23,7 @@ dependencies:
   - network >= 3.1.0.0 && < 3.3
   - nri-env-parser >= 0.1.0.0 && < 0.5
   - nri-observability >= 0.1.0.0 && < 0.5
-  - nri-prelude >= 0.1.0.0 && < 0.7
+  - nri-prelude >= 0.7.0.0 && < 0.8
   - postgresql-typed >= 0.6 && < 0.7
   - resource-pool >= 0.2.0.0 && < 0.5
   - resourcet >= 1.2.0 && < 1.4

--- a/nri-postgresql/test/ObservabilitySpec.hs
+++ b/nri-postgresql/test/ObservabilitySpec.hs
@@ -53,6 +53,7 @@ spanForTask task =
     res <-
       Platform.rootTracingSpanIO
         "test-request"
+        Platform.silentTrack
         (MVar.putMVar spanVar)
         "test-root"
         (\log -> Task.attempt log task)

--- a/nri-prelude/CHANGELOG.md
+++ b/nri-prelude/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# 0.7.0.0
+
+- **Breaking:** `Platform.rootTracingSpanIO` and the internal `mkHandler` now take an additional `Aeson.Value -> Task Never ()` callback for analytics event delivery. Existing callers should pass `Platform.silentTrack` to preserve previous behavior.
+- New: `Platform.Analytics.Internal.trackEvent`. The `.Internal` suffix is intentional — wrap it in your own typed `track` API. This module is NOT re-exported from `Platform`.
+- New: `Platform.silentTrack` (a no-op `Aeson.Value -> Task Never ()`). The `Task`-shaped callback gives wire-layer implementations access to the surrounding `LogHandler` for logging and tracing, so delivery errors flow through the normal observability pipeline.
+- New: `LogHandler.trackAnalyticsEvent` field. `nullHandler` defaults this to `silentTrack`.
 - Drop support for GHC 8.10.7, GHC 9.2.x, GHC 9.4.x, `aeson-1.x`
 - Support GHC 9.6.7, GHC 9.8.4, GHC 9.10.2, GHC 9.12.2, `bytestring-0.12.x.x`, `text-2.1.x`, `aeson-2.2.x.x`, `safe-coloured-text-0.3.x.x`, `safe-coloured-text-terminfo-0.3.x.x`, `lens-5.3.x`, `hedgehog-1.5.x`, `auto-update-0.2.x`, `containers-0.7.x`, `filepath-1.5.x`
 - Allow specifying where devlogs for log-explorer go through `NRI_DEV_LOG` environment variable.

--- a/nri-prelude/nri-prelude.cabal
+++ b/nri-prelude/nri-prelude.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           nri-prelude
-version:        0.6.1.2
+version:        0.7.0.0
 synopsis:       A Prelude inspired by the Elm programming language
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-prelude#readme>.
 category:       Web
@@ -45,6 +45,7 @@ library
       NriPrelude
       NriPrelude.Plugin
       Platform
+      Platform.Analytics.Internal
       Process
       Result
       Set
@@ -146,6 +147,7 @@ test-suite tests
       NriPrelude.Plugin
       NriPrelude.Plugin.GhcVersionDependent
       Platform
+      Platform.Analytics.Internal
       Platform.DevLog
       Platform.DoAnything
       Platform.Internal

--- a/nri-prelude/package.yaml
+++ b/nri-prelude/package.yaml
@@ -3,7 +3,7 @@ synopsis: A Prelude inspired by the Elm programming language
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-prelude#readme>.
 homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-prelude#readme
 author: NoRedInk
-version: 0.6.1.2
+version: 0.7.0.0
 maintainer: haskell-open-source@noredink.com
 copyright: 2024 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-prelude
@@ -57,6 +57,7 @@ library:
     - NriPrelude
     - NriPrelude.Plugin
     - Platform
+    - Platform.Analytics.Internal
     - Process
     - Result
     - Set

--- a/nri-prelude/src/Platform.hs
+++ b/nri-prelude/src/Platform.hs
@@ -13,6 +13,7 @@ module Platform
     logHandler,
     requestId,
     silentHandler,
+    Internal.silentTrack,
 
     -- * Creating custom tracingSpans in libraries
     Internal.tracingSpan,

--- a/nri-prelude/src/Platform/Analytics/Internal.hs
+++ b/nri-prelude/src/Platform/Analytics/Internal.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE FlexibleInstances #-}
+
+-- | Internal entry point for emitting analytics events from `Task` code.
+--
+-- This module is intentionally `.Internal`. It is NOT re-exported from
+-- the prelude's public `Platform` module. Higher layers (NoRedInk's
+-- `Analytics.track`) wrap this and own the user-facing API; downstream
+-- code that imports `Platform.Analytics.Internal` directly is bypassing
+-- the closed event dictionary and should be flagged in review.
+module Platform.Analytics.Internal
+  ( trackEvent,
+    AnalyticsEventDetails,
+  )
+where
+
+import qualified Data.Aeson as Aeson
+import NriPrelude
+import qualified Platform
+import qualified Platform.Internal as Internal
+import qualified Prelude
+
+-- | Send an analytics event. Opens a child tracing span named
+-- @analytics.track@, attaches the JSON payload as the span's details,
+-- and invokes the `LogHandler`'s analytics callback. The callback runs
+-- as a `Task` with the current `LogHandler`, so any errors it logs flow
+-- through the normal observability pipeline.
+trackEvent :: (Aeson.ToJSON e) => e -> Task err ()
+trackEvent event =
+  let value = Aeson.toJSON event
+   in Platform.tracingSpan "analytics.track" <| do
+        Platform.setTracingSpanDetails (AnalyticsEventDetails value)
+        Internal.Task
+          ( \handler -> do
+              let Internal.Task runCallback = Internal.trackAnalyticsEvent handler value
+              _ <- runCallback handler
+              Prelude.pure (Ok ())
+          )
+
+-- | A `TracingSpanDetails` wrapper around the analytics event payload, so
+-- that the JSON we send to the analytics backend is also attached to the
+-- @analytics.track@ span and visible in the existing observability
+-- reporters.
+newtype AnalyticsEventDetails = AnalyticsEventDetails Aeson.Value
+  deriving (Aeson.ToJSON)
+
+instance Internal.TracingSpanDetails AnalyticsEventDetails

--- a/nri-prelude/src/Platform/Internal.hs
+++ b/nri-prelude/src/Platform/Internal.hs
@@ -573,8 +573,19 @@ data LogHandler = LogHandler
     -- platform(s) are used. Once we're done collecting data for child
     -- tracingSpans we'll want to add the "completed" child tracingSpan to
     -- its parent.
-    finishTracingSpan :: Maybe Exception.SomeException -> IO ()
+    finishTracingSpan :: Maybe Exception.SomeException -> IO (),
+    -- | Deliver an analytics event payload to the configured analytics
+    -- backend. The prelude knows nothing about the backend; it only
+    -- threads this opaque callback from `rootTracingSpanIO` through
+    -- every child `LogHandler`. See `Platform.Analytics.Internal.trackEvent`
+    -- for the user-facing wrapper. Default: `silentTrack`.
+    trackAnalyticsEventIO :: Aeson.Value -> IO ()
   }
+
+-- | A no-op analytics callback. Used as the default for `nullHandler`
+-- and for platforms that have not opted in to analytics tracking yet.
+silentTrack :: Aeson.Value -> IO ()
+silentTrack _ = pure ()
 
 -- | Helper that creates one of the handler's above. This is intended for
 -- internal use in this library only and not for exposing. Outside of this
@@ -584,13 +595,15 @@ mkHandler ::
   (Stack.HasCallStack) =>
   Text ->
   Clock ->
+  -- | Analytics callback, propagated to every descendant `LogHandler`.
+  (Aeson.Value -> IO ()) ->
   -- Finalizer for this loghandler
   (TracingSpan -> IO ()) ->
   -- Root finalizer
   Maybe (TracingSpan -> IO ()) ->
   Text ->
   IO LogHandler
-mkHandler requestId clock onFinish onFinishRoot' name' = do
+mkHandler requestId clock trackEventIO onFinish onFinishRoot' name' = do
   let onFinishRoot = Maybe.withDefault onFinish onFinishRoot'
   tracingSpanRef <-
     Stack.withFrozenCallStack startTracingSpan clock name'
@@ -599,8 +612,8 @@ mkHandler requestId clock onFinish onFinishRoot' name' = do
   pure
     LogHandler
       { requestId,
-        startChildTracingSpan = mkHandler requestId clock (appendTracingSpanToParent tracingSpanRef) (Just onFinishRoot),
-        startNewRoot = mkHandler requestId clock onFinishRoot Nothing,
+        startChildTracingSpan = mkHandler requestId clock trackEventIO (appendTracingSpanToParent tracingSpanRef) (Just onFinishRoot),
+        startNewRoot = mkHandler requestId clock trackEventIO onFinishRoot Nothing,
         setTracingSpanDetailsIO = \details' ->
           updateIORef
             tracingSpanRef
@@ -613,7 +626,8 @@ mkHandler requestId clock onFinish onFinishRoot' name' = do
           updateIORef
             tracingSpanRef
             (\tracingSpan' -> tracingSpan' {succeeded = succeeded tracingSpan' ++ Failed, containsFailures = True}),
-        finishTracingSpan = finalizeTracingSpan clock allocationCounterStartVal tracingSpanRef >> andThen onFinish
+        finishTracingSpan = finalizeTracingSpan clock allocationCounterStartVal tracingSpanRef >> andThen onFinish,
+        trackAnalyticsEventIO = trackEventIO
       }
 
 -- | Helper that creates a handler that does nothing. This is intended to power
@@ -632,7 +646,8 @@ nullHandler = do
       setTracingSpanDetailsIO = \_ -> pure (),
       setTracingSpanSummaryIO = \_ -> pure (),
       markTracingSpanFailedIO = pure (),
-      finishTracingSpan = \_ -> pure ()
+      finishTracingSpan = \_ -> pure (),
+      trackAnalyticsEventIO = silentTrack
     }
 
 -- | Set the details for a tracingSpan created using the @tracingSpan@
@@ -842,14 +857,22 @@ newRootIO handler name run = do
 -- Instead of taking a parent handler it takes a continuation that will be
 -- called with this root tracingSpan after it has run.
 --
--- > rootTracingSpanIO "request-23" Prelude.print "incoming request" <| \handler ->
+-- > rootTracingSpanIO "request-23" silentTrack Prelude.print "incoming request" <| \handler ->
 -- >   handleRequest
 -- >   |> Task.perform handler
-rootTracingSpanIO :: (Stack.HasCallStack) => Text -> (TracingSpan -> IO ()) -> Text -> (LogHandler -> IO a) -> IO a
-rootTracingSpanIO requestId onFinish name runIO = do
+rootTracingSpanIO ::
+  (Stack.HasCallStack) =>
+  Text ->
+  -- | Analytics callback. Pass `silentTrack` for platforms that don't track.
+  (Aeson.Value -> IO ()) ->
+  (TracingSpan -> IO ()) ->
+  Text ->
+  (LogHandler -> IO a) ->
+  IO a
+rootTracingSpanIO requestId trackEventIO onFinish name runIO = do
   clock' <- mkClock
   Exception.bracketWithError
-    (Stack.withFrozenCallStack mkHandler requestId clock' onFinish Nothing name)
+    (Stack.withFrozenCallStack mkHandler requestId clock' trackEventIO onFinish Nothing name)
     (Prelude.flip finishTracingSpan)
     runIO
 

--- a/nri-prelude/src/Platform/Internal.hs
+++ b/nri-prelude/src/Platform/Internal.hs
@@ -578,14 +578,23 @@ data LogHandler = LogHandler
     -- backend. The prelude knows nothing about the backend; it only
     -- threads this opaque callback from `rootTracingSpanIO` through
     -- every child `LogHandler`. See `Platform.Analytics.Internal.trackEvent`
-    -- for the user-facing wrapper. Default: `silentTrack`.
-    trackAnalyticsEventIO :: Aeson.Value -> IO ()
+    -- for the user-facing wrapper.
+    --
+    -- The callback is `Task`-shaped (not `IO`) so the wire-layer
+    -- implementation can use the surrounding `LogHandler` for logging
+    -- and tracing — delivery errors flow through the same observability
+    -- pipeline as everything else. The `Never` error guarantees the
+    -- callback can't fail the outer `track` call; the wire layer is
+    -- expected to swallow and log its own failures.
+    --
+    -- Default: `silentTrack`.
+    trackAnalyticsEvent :: Aeson.Value -> Task Never ()
   }
 
 -- | A no-op analytics callback. Used as the default for `nullHandler`
 -- and for platforms that have not opted in to analytics tracking yet.
-silentTrack :: Aeson.Value -> IO ()
-silentTrack _ = pure ()
+silentTrack :: Aeson.Value -> Task Never ()
+silentTrack _ = Task (\_ -> pure (Ok ()))
 
 -- | Helper that creates one of the handler's above. This is intended for
 -- internal use in this library only and not for exposing. Outside of this
@@ -596,14 +605,14 @@ mkHandler ::
   Text ->
   Clock ->
   -- | Analytics callback, propagated to every descendant `LogHandler`.
-  (Aeson.Value -> IO ()) ->
+  (Aeson.Value -> Task Never ()) ->
   -- Finalizer for this loghandler
   (TracingSpan -> IO ()) ->
   -- Root finalizer
   Maybe (TracingSpan -> IO ()) ->
   Text ->
   IO LogHandler
-mkHandler requestId clock trackEventIO onFinish onFinishRoot' name' = do
+mkHandler requestId clock trackEvent' onFinish onFinishRoot' name' = do
   let onFinishRoot = Maybe.withDefault onFinish onFinishRoot'
   tracingSpanRef <-
     Stack.withFrozenCallStack startTracingSpan clock name'
@@ -612,8 +621,8 @@ mkHandler requestId clock trackEventIO onFinish onFinishRoot' name' = do
   pure
     LogHandler
       { requestId,
-        startChildTracingSpan = mkHandler requestId clock trackEventIO (appendTracingSpanToParent tracingSpanRef) (Just onFinishRoot),
-        startNewRoot = mkHandler requestId clock trackEventIO onFinishRoot Nothing,
+        startChildTracingSpan = mkHandler requestId clock trackEvent' (appendTracingSpanToParent tracingSpanRef) (Just onFinishRoot),
+        startNewRoot = mkHandler requestId clock trackEvent' onFinishRoot Nothing,
         setTracingSpanDetailsIO = \details' ->
           updateIORef
             tracingSpanRef
@@ -627,7 +636,7 @@ mkHandler requestId clock trackEventIO onFinish onFinishRoot' name' = do
             tracingSpanRef
             (\tracingSpan' -> tracingSpan' {succeeded = succeeded tracingSpan' ++ Failed, containsFailures = True}),
         finishTracingSpan = finalizeTracingSpan clock allocationCounterStartVal tracingSpanRef >> andThen onFinish,
-        trackAnalyticsEventIO = trackEventIO
+        trackAnalyticsEvent = trackEvent'
       }
 
 -- | Helper that creates a handler that does nothing. This is intended to power
@@ -647,7 +656,7 @@ nullHandler = do
       setTracingSpanSummaryIO = \_ -> pure (),
       markTracingSpanFailedIO = pure (),
       finishTracingSpan = \_ -> pure (),
-      trackAnalyticsEventIO = silentTrack
+      trackAnalyticsEvent = silentTrack
     }
 
 -- | Set the details for a tracingSpan created using the @tracingSpan@
@@ -864,15 +873,15 @@ rootTracingSpanIO ::
   (Stack.HasCallStack) =>
   Text ->
   -- | Analytics callback. Pass `silentTrack` for platforms that don't track.
-  (Aeson.Value -> IO ()) ->
+  (Aeson.Value -> Task Never ()) ->
   (TracingSpan -> IO ()) ->
   Text ->
   (LogHandler -> IO a) ->
   IO a
-rootTracingSpanIO requestId trackEventIO onFinish name runIO = do
+rootTracingSpanIO requestId trackEvent' onFinish name runIO = do
   clock' <- mkClock
   Exception.bracketWithError
-    (Stack.withFrozenCallStack mkHandler requestId clock' trackEventIO onFinish Nothing name)
+    (Stack.withFrozenCallStack mkHandler requestId clock' trackEvent' onFinish Nothing name)
     (Prelude.flip finishTracingSpan)
     runIO
 

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -533,6 +533,7 @@ runSingle test' =
         res <-
           Platform.Internal.rootTracingSpanIO
             ""
+            Platform.Internal.silentTrack
             ( \span -> do
                 when (Platform.Internal.name span == spanName) <|
                   MVar.putMVar spanVar span

--- a/nri-prelude/tests/LogSpec.hs
+++ b/nri-prelude/tests/LogSpec.hs
@@ -195,6 +195,7 @@ newHandler = do
       Internal.mkHandler
       ""
       (Internal.Clock (Prelude.pure 0))
+      Internal.silentTrack
       (\span -> IORef.modifyIORef recordedTracingSpans (\cs -> cs ++ Internal.children span))
       Nothing
       ""

--- a/nri-prelude/tests/PlatformSpec.hs
+++ b/nri-prelude/tests/PlatformSpec.hs
@@ -3,10 +3,12 @@ module PlatformSpec (tests) where
 import qualified Control.Concurrent.MVar as MVar
 import Control.Monad.Catch (catchAll)
 import Data.Aeson as Aeson
+import qualified Data.IORef as IORef
 import qualified Expect
 import qualified Log
 import NriPrelude
 import qualified Platform
+import qualified Platform.Internal
 import Task
 import Test (Test, describe, test)
 import qualified Prelude
@@ -31,7 +33,20 @@ tests =
           runTaskAndExpectTacingSpan <| Log.error "error" []
 
         Expect.true (isSucceeded span)
-        Expect.true (Platform.containsFailures span)
+        Expect.true (Platform.containsFailures span),
+      test "trackAnalyticsEventIO threaded by rootTracingSpanIO is invoked from a child span" <| \_ -> do
+        ref <- Expect.fromIO (IORef.newIORef [])
+        let track v = IORef.atomicModifyIORef' ref (\xs -> (v : xs, ()))
+        Expect.fromIO
+          <| Platform.rootTracingSpanIO "test-req" track (\_ -> Prelude.pure ()) "root"
+          <| \log -> do
+            child <- Platform.Internal.startChildTracingSpan log "child-span"
+            Platform.Internal.trackAnalyticsEventIO child (Aeson.toJSON ("hello" :: Text))
+        observed <- Expect.fromIO (IORef.readIORef ref)
+        observed |> Expect.equal [Aeson.toJSON ("hello" :: Text)],
+      test "nullHandler.trackAnalyticsEventIO is a silent no-op" <| \_ ->
+        Expect.fromIO
+          <| Platform.Internal.trackAnalyticsEventIO Platform.Internal.nullHandler Aeson.Null
     ]
 
 newtype CustomTracingSpanDetails = CustomTracingSpanDetails Text
@@ -48,6 +63,7 @@ runTaskAndExpectTacingSpan task =
       catchAll
         ( Platform.rootTracingSpanIO
             ""
+            Platform.silentTrack
             (MVar.putMVar spanVar)
             "test"
             (\log -> Task.attempt log task)

--- a/nri-prelude/tests/PlatformSpec.hs
+++ b/nri-prelude/tests/PlatformSpec.hs
@@ -8,6 +8,7 @@ import qualified Expect
 import qualified Log
 import NriPrelude
 import qualified Platform
+import qualified Platform.Analytics.Internal
 import qualified Platform.Internal
 import Task
 import Test (Test, describe, test)
@@ -34,19 +35,61 @@ tests =
 
         Expect.true (isSucceeded span)
         Expect.true (Platform.containsFailures span),
-      test "trackAnalyticsEventIO threaded by rootTracingSpanIO is invoked from a child span" <| \_ -> do
+      test "trackAnalyticsEvent threaded by rootTracingSpanIO is invoked from a child span" <| \_ -> do
         ref <- Expect.fromIO (IORef.newIORef [])
-        let track v = IORef.atomicModifyIORef' ref (\xs -> (v : xs, ()))
+        let track v =
+              Platform.Internal.Task
+                ( \_ -> do
+                    IORef.atomicModifyIORef' ref (\xs -> (v : xs, ()))
+                    Prelude.pure (Ok ())
+                )
         Expect.fromIO
           <| Platform.rootTracingSpanIO "test-req" track (\_ -> Prelude.pure ()) "root"
           <| \log -> do
             child <- Platform.Internal.startChildTracingSpan log "child-span"
-            Platform.Internal.trackAnalyticsEventIO child (Aeson.toJSON ("hello" :: Text))
+            let Platform.Internal.Task runTrack =
+                  Platform.Internal.trackAnalyticsEvent child (Aeson.toJSON ("hello" :: Text))
+            _ <- runTrack child
+            Prelude.pure ()
         observed <- Expect.fromIO (IORef.readIORef ref)
         observed |> Expect.equal [Aeson.toJSON ("hello" :: Text)],
-      test "nullHandler.trackAnalyticsEventIO is a silent no-op" <| \_ ->
-        Expect.fromIO
-          <| Platform.Internal.trackAnalyticsEventIO Platform.Internal.nullHandler Aeson.Null
+      test "nullHandler.trackAnalyticsEvent is a silent no-op" <| \_ -> do
+        let Platform.Internal.Task runTrack =
+              Platform.Internal.trackAnalyticsEvent Platform.Internal.nullHandler Aeson.Null
+        _ <- Expect.fromIO (runTrack Platform.Internal.nullHandler)
+        Expect.pass,
+      test "Platform.Analytics.Internal.trackEvent invokes the current LogHandler's analytics callback with toJSON of the event" <| \_ -> do
+        ref <- Expect.fromIO (IORef.newIORef [])
+        let track v =
+              Platform.Internal.Task
+                ( \_ -> do
+                    IORef.atomicModifyIORef' ref (\xs -> (v : xs, ()))
+                    Prelude.pure (Ok ())
+                )
+        let event = Aeson.object ["kind" Aeson..= ("LessonStarted" :: Text)]
+        result <-
+          Expect.fromIO
+            <| Platform.rootTracingSpanIO "test-req" track (\_ -> Prelude.pure ()) "root"
+            <| \log -> Task.attempt log (Platform.Analytics.Internal.trackEvent event)
+        case result of
+          Ok () -> Expect.pass
+          Err _ -> Expect.fail "trackEvent task failed"
+        observed <- Expect.fromIO (IORef.readIORef ref)
+        observed |> Expect.equal [event],
+      test "Platform.Analytics.Internal.trackEvent opens an analytics.track child span carrying the JSON payload as details" <| \_ -> do
+        spanVar <- Expect.fromIO MVar.newEmptyMVar
+        let event = Aeson.object ["kind" Aeson..= ("LessonStarted" :: Text)]
+        _ <-
+          Expect.fromIO
+            <| Platform.rootTracingSpanIO "test-req" Platform.silentTrack (MVar.putMVar spanVar) "root"
+            <| \log -> Task.attempt log (Platform.Analytics.Internal.trackEvent event)
+        root <- Expect.fromIO (MVar.takeMVar spanVar)
+        case Prelude.filter (\s -> Platform.Internal.name s == "analytics.track") (Platform.Internal.children root) of
+          [child] -> do
+            Platform.Internal.name child |> Expect.equal "analytics.track"
+            NriPrelude.map Aeson.toJSON (Platform.Internal.details child) |> Expect.equal (Just event)
+          [] -> Expect.fail "expected an analytics.track child span; found none"
+          _ -> Expect.fail "expected exactly one analytics.track child span"
     ]
 
 newtype CustomTracingSpanDetails = CustomTracingSpanDetails Text

--- a/nri-prelude/tests/golden-results-9.10/debug
+++ b/nri-prelude/tests/golden-results-9.10/debug
@@ -6,7 +6,7 @@
         Just
           ( "debug"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 40

--- a/nri-prelude/tests/golden-results-9.10/debug-todo-stacktrace
+++ b/nri-prelude/tests/golden-results-9.10/debug-todo-stacktrace
@@ -1,6 +1,6 @@
 foo
 CallStack (from HasCallStack):
-  todo, called at tests/TestSpec.hs:177:20 in nri-prelude-0.6.1.2-inplace-tests:TestSpec
+  todo, called at tests/TestSpec.hs:177:20 in nri-prelude-0.7.0.0-inplace-tests:TestSpec
 HasCallStack backtrace:
-  todo, called at tests/TestSpec.hs:177:20 in nri-prelude-0.6.1.2-inplace-tests:TestSpec
+  todo, called at tests/TestSpec.hs:177:20 in nri-prelude-0.7.0.0-inplace-tests:TestSpec
 

--- a/nri-prelude/tests/golden-results-9.10/error
+++ b/nri-prelude/tests/golden-results-9.10/error
@@ -6,7 +6,7 @@
         Just
           ( "error"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 66

--- a/nri-prelude/tests/golden-results-9.10/log-async-exceptions
+++ b/nri-prelude/tests/golden-results-9.10/log-async-exceptions
@@ -6,7 +6,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 113
@@ -29,7 +29,7 @@
                 Just
                   ( "withContext"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 112

--- a/nri-prelude/tests/golden-results-9.10/log-info
+++ b/nri-prelude/tests/golden-results-9.10/log-info
@@ -6,7 +6,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 30

--- a/nri-prelude/tests/golden-results-9.10/log-nested-spans
+++ b/nri-prelude/tests/golden-results-9.10/log-nested-spans
@@ -6,7 +6,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 81
@@ -29,7 +29,7 @@
                 Just
                   ( "withContext"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 80
@@ -52,7 +52,7 @@
                         Just
                           ( "info"
                           , SrcLoc
-                              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                               , srcLocModule = "LogSpec"
                               , srcLocFile = "tests/LogSpec.hs"
                               , srcLocStartLine = 79

--- a/nri-prelude/tests/golden-results-9.10/log-new-root
+++ b/nri-prelude/tests/golden-results-9.10/log-new-root
@@ -6,7 +6,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 174
@@ -30,7 +30,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 177
@@ -54,7 +54,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 176
@@ -78,7 +78,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 173
@@ -101,7 +101,7 @@
                 Just
                   ( "info"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 173

--- a/nri-prelude/tests/golden-results-9.10/log-unexpected-exceptions
+++ b/nri-prelude/tests/golden-results-9.10/log-unexpected-exceptions
@@ -6,7 +6,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 94
@@ -29,7 +29,7 @@
                 Just
                   ( "withContext"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 93

--- a/nri-prelude/tests/golden-results-9.10/test-report-logfile-all-passed
+++ b/nri-prelude/tests/golden-results-9.10/test-report-logfile-all-passed
@@ -61,7 +61,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 430
     },

--- a/nri-prelude/tests/golden-results-9.10/test-report-logfile-no-tests-in-suite
+++ b/nri-prelude/tests/golden-results-9.10/test-report-logfile-no-tests-in-suite
@@ -10,7 +10,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 469
     },

--- a/nri-prelude/tests/golden-results-9.10/test-report-logfile-onlys-passed
+++ b/nri-prelude/tests/golden-results-9.10/test-report-logfile-onlys-passed
@@ -61,7 +61,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 445
     },

--- a/nri-prelude/tests/golden-results-9.10/test-report-logfile-passed-with-skipped
+++ b/nri-prelude/tests/golden-results-9.10/test-report-logfile-passed-with-skipped
@@ -61,7 +61,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 460
     },

--- a/nri-prelude/tests/golden-results-9.10/test-report-logfile-tests-failed
+++ b/nri-prelude/tests/golden-results-9.10/test-report-logfile-tests-failed
@@ -109,7 +109,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 489
     },

--- a/nri-prelude/tests/golden-results-9.10/warn
+++ b/nri-prelude/tests/golden-results-9.10/warn
@@ -6,7 +6,7 @@
         Just
           ( "warn"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 53

--- a/nri-prelude/tests/golden-results-9.12/debug
+++ b/nri-prelude/tests/golden-results-9.12/debug
@@ -6,7 +6,7 @@
         Just
           ( "debug"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 40

--- a/nri-prelude/tests/golden-results-9.12/error
+++ b/nri-prelude/tests/golden-results-9.12/error
@@ -6,7 +6,7 @@
         Just
           ( "error"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 66

--- a/nri-prelude/tests/golden-results-9.12/log-async-exceptions
+++ b/nri-prelude/tests/golden-results-9.12/log-async-exceptions
@@ -6,7 +6,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 113
@@ -29,7 +29,7 @@
                 Just
                   ( "withContext"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 112

--- a/nri-prelude/tests/golden-results-9.12/log-info
+++ b/nri-prelude/tests/golden-results-9.12/log-info
@@ -6,7 +6,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 30

--- a/nri-prelude/tests/golden-results-9.12/log-nested-spans
+++ b/nri-prelude/tests/golden-results-9.12/log-nested-spans
@@ -6,7 +6,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 81
@@ -29,7 +29,7 @@
                 Just
                   ( "withContext"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 80
@@ -52,7 +52,7 @@
                         Just
                           ( "info"
                           , SrcLoc
-                              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                               , srcLocModule = "LogSpec"
                               , srcLocFile = "tests/LogSpec.hs"
                               , srcLocStartLine = 79

--- a/nri-prelude/tests/golden-results-9.12/log-new-root
+++ b/nri-prelude/tests/golden-results-9.12/log-new-root
@@ -6,7 +6,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 174
@@ -30,7 +30,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 177
@@ -54,7 +54,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 176
@@ -78,7 +78,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 173
@@ -101,7 +101,7 @@
                 Just
                   ( "info"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 173

--- a/nri-prelude/tests/golden-results-9.12/log-unexpected-exceptions
+++ b/nri-prelude/tests/golden-results-9.12/log-unexpected-exceptions
@@ -6,7 +6,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 94
@@ -29,7 +29,7 @@
                 Just
                   ( "withContext"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 93

--- a/nri-prelude/tests/golden-results-9.12/test-report-logfile-all-passed
+++ b/nri-prelude/tests/golden-results-9.12/test-report-logfile-all-passed
@@ -61,7 +61,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 430
     },

--- a/nri-prelude/tests/golden-results-9.12/test-report-logfile-no-tests-in-suite
+++ b/nri-prelude/tests/golden-results-9.12/test-report-logfile-no-tests-in-suite
@@ -10,7 +10,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 469
     },

--- a/nri-prelude/tests/golden-results-9.12/test-report-logfile-onlys-passed
+++ b/nri-prelude/tests/golden-results-9.12/test-report-logfile-onlys-passed
@@ -61,7 +61,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 445
     },

--- a/nri-prelude/tests/golden-results-9.12/test-report-logfile-passed-with-skipped
+++ b/nri-prelude/tests/golden-results-9.12/test-report-logfile-passed-with-skipped
@@ -61,7 +61,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 460
     },

--- a/nri-prelude/tests/golden-results-9.12/test-report-logfile-tests-failed
+++ b/nri-prelude/tests/golden-results-9.12/test-report-logfile-tests-failed
@@ -109,7 +109,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 489
     },

--- a/nri-prelude/tests/golden-results-9.12/warn
+++ b/nri-prelude/tests/golden-results-9.12/warn
@@ -6,7 +6,7 @@
         Just
           ( "warn"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 53

--- a/nri-prelude/tests/golden-results-9.8/debug
+++ b/nri-prelude/tests/golden-results-9.8/debug
@@ -6,7 +6,7 @@
         Just
           ( "debug"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 40

--- a/nri-prelude/tests/golden-results-9.8/debug-todo-stacktrace
+++ b/nri-prelude/tests/golden-results-9.8/debug-todo-stacktrace
@@ -1,3 +1,3 @@
 foo
 CallStack (from HasCallStack):
-  todo, called at tests/TestSpec.hs:177:20 in nri-prelude-0.6.1.2-inplace-tests:TestSpec
+  todo, called at tests/TestSpec.hs:177:20 in nri-prelude-0.7.0.0-inplace-tests:TestSpec

--- a/nri-prelude/tests/golden-results-9.8/error
+++ b/nri-prelude/tests/golden-results-9.8/error
@@ -6,7 +6,7 @@
         Just
           ( "error"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 66

--- a/nri-prelude/tests/golden-results-9.8/log-async-exceptions
+++ b/nri-prelude/tests/golden-results-9.8/log-async-exceptions
@@ -6,7 +6,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 113
@@ -29,7 +29,7 @@
                 Just
                   ( "withContext"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 112

--- a/nri-prelude/tests/golden-results-9.8/log-info
+++ b/nri-prelude/tests/golden-results-9.8/log-info
@@ -6,7 +6,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 30

--- a/nri-prelude/tests/golden-results-9.8/log-nested-spans
+++ b/nri-prelude/tests/golden-results-9.8/log-nested-spans
@@ -6,7 +6,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 81
@@ -29,7 +29,7 @@
                 Just
                   ( "withContext"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 80
@@ -52,7 +52,7 @@
                         Just
                           ( "info"
                           , SrcLoc
-                              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                               , srcLocModule = "LogSpec"
                               , srcLocFile = "tests/LogSpec.hs"
                               , srcLocStartLine = 79

--- a/nri-prelude/tests/golden-results-9.8/log-new-root
+++ b/nri-prelude/tests/golden-results-9.8/log-new-root
@@ -6,7 +6,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 174
@@ -30,7 +30,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 177
@@ -54,7 +54,7 @@
         Just
           ( "info"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 176
@@ -78,7 +78,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 173
@@ -101,7 +101,7 @@
                 Just
                   ( "info"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 173

--- a/nri-prelude/tests/golden-results-9.8/log-unexpected-exceptions
+++ b/nri-prelude/tests/golden-results-9.8/log-unexpected-exceptions
@@ -6,7 +6,7 @@
         Just
           ( "withContext"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 94
@@ -29,7 +29,7 @@
                 Just
                   ( "withContext"
                   , SrcLoc
-                      { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+                      { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
                       , srcLocModule = "LogSpec"
                       , srcLocFile = "tests/LogSpec.hs"
                       , srcLocStartLine = 93

--- a/nri-prelude/tests/golden-results-9.8/test-report-logfile-all-passed
+++ b/nri-prelude/tests/golden-results-9.8/test-report-logfile-all-passed
@@ -61,7 +61,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 430
     },

--- a/nri-prelude/tests/golden-results-9.8/test-report-logfile-no-tests-in-suite
+++ b/nri-prelude/tests/golden-results-9.8/test-report-logfile-no-tests-in-suite
@@ -10,7 +10,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 469
     },

--- a/nri-prelude/tests/golden-results-9.8/test-report-logfile-onlys-passed
+++ b/nri-prelude/tests/golden-results-9.8/test-report-logfile-onlys-passed
@@ -61,7 +61,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 445
     },

--- a/nri-prelude/tests/golden-results-9.8/test-report-logfile-passed-with-skipped
+++ b/nri-prelude/tests/golden-results-9.8/test-report-logfile-passed-with-skipped
@@ -61,7 +61,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 460
     },

--- a/nri-prelude/tests/golden-results-9.8/test-report-logfile-tests-failed
+++ b/nri-prelude/tests/golden-results-9.8/test-report-logfile-tests-failed
@@ -109,7 +109,7 @@
         "file": "tests/TestSpec.hs",
         "module": "TestSpec",
         "name": "report",
-        "package": "nri-prelude-0.6.1.2-inplace-tests",
+        "package": "nri-prelude-0.7.0.0-inplace-tests",
         "startCol": 22,
         "startLine": 489
     },

--- a/nri-prelude/tests/golden-results-9.8/warn
+++ b/nri-prelude/tests/golden-results-9.8/warn
@@ -6,7 +6,7 @@
         Just
           ( "warn"
           , SrcLoc
-              { srcLocPackage = "nri-prelude-0.6.1.2-inplace-tests"
+              { srcLocPackage = "nri-prelude-0.7.0.0-inplace-tests"
               , srcLocModule = "LogSpec"
               , srcLocFile = "tests/LogSpec.hs"
               , srcLocStartLine = 53

--- a/nri-redis/nri-redis.cabal
+++ b/nri-redis/nri-redis.cabal
@@ -76,7 +76,7 @@ library
     , modern-uri >=0.3.1.0 && <0.4
     , nri-env-parser >=0.1.0.0 && <0.5
     , nri-observability >=0.1.0 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , pcre-light >=0.4.1.0 && <0.4.2
     , resourcet >=1.2.0 && <1.4
     , safe-exceptions >=0.1.7.0 && <1.3
@@ -141,7 +141,7 @@ test-suite tests
     , modern-uri >=0.3.1.0 && <0.4
     , nri-env-parser >=0.1.0.0 && <0.5
     , nri-observability >=0.1.0 && <0.5
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.7.0.0 && <0.8
     , pcre-light >=0.4.1.0 && <0.4.2
     , resourcet >=1.2.0 && <1.4
     , safe-exceptions >=0.1.7.0 && <1.3

--- a/nri-redis/package.yaml
+++ b/nri-redis/package.yaml
@@ -28,7 +28,7 @@ dependencies:
   - modern-uri >= 0.3.1.0 && < 0.4
   - nri-env-parser >= 0.1.0.0 && < 0.5
   - nri-observability >= 0.1.0 && < 0.5
-  - nri-prelude >= 0.1.0.0 && < 0.7
+  - nri-prelude >= 0.7.0.0 && < 0.8
   - pcre-light >= 0.4.1.0 && < 0.4.2
   - resourcet >= 1.2.0 && < 1.4
   - safe-exceptions >= 0.1.7.0 && < 1.3

--- a/nri-redis/test/Spec/Redis.hs
+++ b/nri-redis/test/Spec/Redis.hs
@@ -30,6 +30,7 @@ spanForTask task =
     res <-
       Platform.rootTracingSpanIO
         "test-request"
+        Platform.silentTrack
         (MVar.putMVar spanVar)
         "test-root"
         (\log -> Task.attempt log task)
@@ -46,6 +47,7 @@ spanForFailingTask task =
     res <-
       Platform.rootTracingSpanIO
         "test-request"
+        Platform.silentTrack
         (MVar.putMVar spanVar)
         "test-root"
         (\log -> Task.attempt log task)

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-query
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
-                    , srcLocStartLine = 124
+                    , srcLocStartLine = 126
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 124
+                    , srcLocEndLine = 126
                     , srcLocEndCol = 28
                     }
                 )

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-transaction
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
-                    , srcLocStartLine = 131
+                    , srcLocStartLine = 133
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 131
+                    , srcLocEndLine = 133
                     , srcLocEndCol = 34
                     }
                 )

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-query
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
-                    , srcLocStartLine = 96
+                    , srcLocStartLine = 98
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 96
+                    , srcLocEndLine = 98
                     , srcLocEndCol = 25
                     }
                 )

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-transaction
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
-                    , srcLocStartLine = 103
+                    , srcLocStartLine = 105
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 103
+                    , srcLocEndLine = 105
                     , srcLocEndCol = 31
                     }
                 )

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-query
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
-                    , srcLocStartLine = 110
+                    , srcLocStartLine = 112
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 110
+                    , srcLocEndLine = 112
                     , srcLocEndCol = 25
                     }
                 )

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-transaction
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
-                    , srcLocStartLine = 117
+                    , srcLocStartLine = 119
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 117
+                    , srcLocEndLine = 119
                     , srcLocEndCol = 31
                     }
                 )

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
-                    , srcLocStartLine = 82
+                    , srcLocStartLine = 84
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 82
+                    , srcLocEndLine = 84
                     , srcLocEndCol = 20
                     }
                 )

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query-timeout
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query-timeout
@@ -9,9 +9,9 @@ TracingSpan
             { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
-            , srcLocStartLine = 47
+            , srcLocStartLine = 48
             , srcLocStartCol = 7
-            , srcLocEndLine = 47
+            , srcLocEndLine = 48
             , srcLocEndCol = 33
             }
         )
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
-                    , srcLocStartLine = 141
+                    , srcLocStartLine = 143
                     , srcLocStartCol = 13
-                    , srcLocEndLine = 141
+                    , srcLocEndLine = 143
                     , srcLocEndCol = 24
                     }
                 )

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-transaction
@@ -32,9 +32,9 @@ TracingSpan
                     { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
-                    , srcLocStartLine = 89
+                    , srcLocStartLine = 91
                     , srcLocStartCol = 9
-                    , srcLocEndLine = 89
+                    , srcLocEndLine = 91
                     , srcLocEndCol = 26
                     }
                 )

--- a/nri-test-encoding/nri-test-encoding.cabal
+++ b/nri-test-encoding/nri-test-encoding.cabal
@@ -58,7 +58,7 @@ library
     , base >=4.18 && <4.22
     , bytestring >=0.10.8.2 && <0.13
     , filepath >=1.4.2.1 && <1.6
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.1.0.0 && <0.8
     , nri-redis >=0.1.0.0 && <0.5
     , servant >=0.20.2 && <0.21
     , servant-auth-server >=0.4.9.0 && <0.5
@@ -99,7 +99,7 @@ test-suite tests
     , base >=4.18 && <4.22
     , bytestring >=0.10.8.2 && <0.13
     , filepath >=1.4.2.1 && <1.6
-    , nri-prelude >=0.1.0.0 && <0.7
+    , nri-prelude >=0.1.0.0 && <0.8
     , nri-redis >=0.1.0.0 && <0.5
     , servant >=0.20.2 && <0.21
     , servant-auth-server >=0.4.9.0 && <0.5

--- a/nri-test-encoding/package.yaml
+++ b/nri-test-encoding/package.yaml
@@ -23,7 +23,7 @@ dependencies:
   - servant-auth-server >= 0.4.9.0 && < 0.5
   - servant-server >= 0.20.2 && < 0.21
   - text >= 1.2.3.1 && < 2.2
-  - nri-prelude >= 0.1.0.0 && < 0.7
+  - nri-prelude >= 0.1.0.0 && < 0.8
   - nri-redis >= 0.1.0.0 && < 0.5
 library:
   exposed-modules:


### PR DESCRIPTION
Large changeset but easy to review, I promise.

# Context

We're introducing analytics events to our Haskell backend.

Compared to tracing spans, those events should have a one-notch-higher level of deliverability guarantees. It's not vital that they are delivered, but it shouldn't be easy to drop them.

We decided to go for a design where they are synchronously delivered at the time they're emitted, and where you don't have to carry around an `AnalyticsHandler` throughout the call stack.

This spells out changes in our Platform.

# How we did it

Platform gets a `track event :: Task err ()`, bypassing the need for threading a handler argument through every function that wants to emit. Matches the ergonomics of `Log.withContext` — ambient context carried by `Task`, no explicit handler in user code.

The mechanism is generic. `Platform.Analytics.Internal.trackEvent` takes any `ToJSON` value, opens an `analytics.track` child tracing span, attaches the JSON as span details, and invokes a `LogHandler`-carried `Aeson.Value -> Task Never ()` callback. The callback runs as a `Task` against the surrounding `LogHandler` — so a wire-layer implementation can `Log.error` on delivery failure, open its own child spans, and generally participate in the existing observability pipeline. The `Never` error type encodes the contract that analytics failure never fails the outer track call; downstream is expected to swallow and log its own failures.

# What changes

- `LogHandler` gains a `trackAnalyticsEvent :: Aeson.Value -> Task Never ()` field, propagated through `mkHandler` to every child handler.
- `rootTracingSpanIO` gains the callback as a new parameter. **Breaking change.** `silentTrack` ships as the no-op default for callers who don't want analytics.
- New module `Platform.Analytics.Internal` exposes `trackEvent :: ToJSON e => e -> Task err ()`. The `.Internal` suffix signals it's not meant for direct product-code use; applications should wrap it behind a typed entry point that enforces their event dictionary at the type level. Haskell has no cross-package import fence, so the convention + downstream lint rules are the available enforcement.
- Sibling packages that now use `Platform.silentTrack` (`nri-kafka`, `nri-http`, `nri-redis`, `nri-postgresql`, `nri-observability`) bump their `nri-prelude` bound to `>= 0.7.0.0 && < 0.8`. The rest just bump the upper bound to `< 0.8`. Also fixes `nri-kafka`'s `sync-write-benchmark` stanza, which the previous hpack pass left at `<0.7`.
- Bump to `0.7.0.0` to flag the breaking change.
- Refreshes golden files: `nri-prelude` (version-bump string changes across 9.8/9.10/9.12) and `nri-redis` (source-line shifts from the new `silentTrack` arg in `spanForTask`/`spanForFailingTask`, plus the version-string bump after rebasing onto `1adf200`).

# Test plan

- [x] `cabal build all` green
- [x] `cabal test nri-prelude` — 278 passed; new test verifies the `analytics.track` child span carries the JSON payload as `details`, on top of the existing callback-invocation test
- [x] `cabal test nri-redis` — 100 passed; goldens regenerated for the new line numbers
- [x] Sibling packages build clean under the tightened bounds
- [x] NRI Monorepo builds and downstream API consumers work with these changes

🤖 PR drafted with [Claude Code](https://claude.com/claude-code)