### PR TITLE
Bump libs after nri prelude 0.7

### DIFF
--- a/nri-env-parser/LICENSE
+++ b/nri-env-parser/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, NoRedInk
+Copyright (c) 2026, NoRedInk
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/nri-env-parser/nri-env-parser.cabal
+++ b/nri-env-parser/nri-env-parser.cabal
@@ -13,7 +13,7 @@ homepage:       https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-env
 bug-reports:    https://github.com/NoRedInk/haskell-libraries/issues
 author:         NoRedInk
 maintainer:     haskell-open-source@noredink.com
-copyright:      2024 NoRedInk Corp.
+copyright:      2026 NoRedInk Corp.
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/nri-env-parser/package.yaml
+++ b/nri-env-parser/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-env-parse
 author: NoRedInk
 version: 0.4.0.0
 maintainer: haskell-open-source@noredink.com
-copyright: 2024 NoRedInk Corp.
+copyright: 2026 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/env-parser
 license-file: LICENSE
 category: Web

--- a/nri-http/CHANGELOG.md
+++ b/nri-http/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.0.1
+
+- Require `nri-prelude >= 0.7.0.0`
+
 # 0.7.0.0
 
 - Support GHC 9.10.2, GHC 9.12.2

--- a/nri-http/LICENSE
+++ b/nri-http/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, NoRedInk
+Copyright (c) 2026, NoRedInk
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/nri-http/nri-http.cabal
+++ b/nri-http/nri-http.cabal
@@ -13,7 +13,7 @@ homepage:       https://github.com/NoRedInk/haskell-libraries#readme
 bug-reports:    https://github.com/NoRedInk/haskell-libraries/issues
 author:         NoRedInk
 maintainer:     haskell-open-source@noredink.com
-copyright:      2024 NoRedInk Corp.
+copyright:      2026 NoRedInk Corp.
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/nri-http/nri-http.cabal
+++ b/nri-http/nri-http.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           nri-http
-version:        0.7.0.0
+version:        0.7.0.1
 synopsis:       Make Elm style HTTP requests
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-http#readme>.
 category:       Web

--- a/nri-http/package.yaml
+++ b/nri-http/package.yaml
@@ -2,7 +2,7 @@ name: nri-http
 synopsis: Make Elm style HTTP requests
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-http#readme>.
 author: NoRedInk
-version: 0.7.0.0
+version: 0.7.0.1
 maintainer: haskell-open-source@noredink.com
 copyright: 2024 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-http

--- a/nri-http/package.yaml
+++ b/nri-http/package.yaml
@@ -4,7 +4,7 @@ description: Please see the README at <https://github.com/NoRedInk/haskell-libra
 author: NoRedInk
 version: 0.7.0.1
 maintainer: haskell-open-source@noredink.com
-copyright: 2024 NoRedInk Corp.
+copyright: 2026 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-http
 license-file: LICENSE
 category: Web

--- a/nri-kafka/CHANGELOG.md
+++ b/nri-kafka/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0.1
+
+- Require `nri-prelude >= 0.7.0.0`
+
 # 0.4.0.0
 
 - Support GHC 9.10.2, GHC 9.12.2, `containers-0.7.x`

--- a/nri-kafka/LICENSE
+++ b/nri-kafka/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, NoRedInk
+Copyright (c) 2026, NoRedInk
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/nri-kafka/nri-kafka.cabal
+++ b/nri-kafka/nri-kafka.cabal
@@ -13,7 +13,7 @@ homepage:       https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-kaf
 bug-reports:    https://github.com/NoRedInk/haskell-libraries/issues
 author:         NoRedInk
 maintainer:     haskell-open-source@noredink.com
-copyright:      2024 NoRedInk Corp.
+copyright:      2026 NoRedInk Corp.
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/nri-kafka/nri-kafka.cabal
+++ b/nri-kafka/nri-kafka.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           nri-kafka
-version:        0.4.0.0
+version:        0.4.0.1
 synopsis:       Functions for working with Kafka
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-kafka#readme>.
 category:       Web

--- a/nri-kafka/package.yaml
+++ b/nri-kafka/package.yaml
@@ -3,7 +3,7 @@ synopsis: Functions for working with Kafka
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-kafka#readme>.
 homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-kafka#readme
 author: NoRedInk
-version: 0.4.0.0
+version: 0.4.0.1
 maintainer: haskell-open-source@noredink.com
 copyright: 2024 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-kafka

--- a/nri-kafka/package.yaml
+++ b/nri-kafka/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-kafka#rea
 author: NoRedInk
 version: 0.4.0.1
 maintainer: haskell-open-source@noredink.com
-copyright: 2024 NoRedInk Corp.
+copyright: 2026 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-kafka
 license-file: LICENSE
 category: Web

--- a/nri-log-explorer/LICENSE
+++ b/nri-log-explorer/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, NoRedInk
+Copyright (c) 2026, NoRedInk
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/nri-log-explorer/nri-log-explorer.cabal
+++ b/nri-log-explorer/nri-log-explorer.cabal
@@ -13,7 +13,7 @@ homepage:       https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-log
 bug-reports:    https://github.com/NoRedInk/haskell-libraries/issues
 author:         NoRedInk
 maintainer:     haskell-open-source@noredink.com
-copyright:      2024 NoRedInk Corp.
+copyright:      2026 NoRedInk Corp.
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/nri-log-explorer/package.yaml
+++ b/nri-log-explorer/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-log-explo
 author: NoRedInk
 version: 0.4.0.0
 maintainer: haskell-open-source@noredink.com
-copyright: 2024 NoRedInk Corp.
+copyright: 2026 NoRedInk Corp.
 github: NoRedInk/haskell-libraries
 license-file: LICENSE
 category: Web

--- a/nri-observability/CHANGELOG.md
+++ b/nri-observability/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0.1
+
+- Require `nri-prelude >= 0.7.0.0`
+
 # 0.3.0.1
 
 - Support GHC 9.10.2, GHC 9.12.2

--- a/nri-observability/LICENSE
+++ b/nri-observability/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, NoRedInk
+Copyright (c) 2026, NoRedInk
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/nri-observability/nri-observability.cabal
+++ b/nri-observability/nri-observability.cabal
@@ -13,7 +13,7 @@ homepage:       https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-obs
 bug-reports:    https://github.com/NoRedInk/haskell-libraries/issues
 author:         NoRedInk
 maintainer:     haskell-open-source@noredink.com
-copyright:      2024 NoRedInk Corp.
+copyright:      2026 NoRedInk Corp.
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/nri-observability/nri-observability.cabal
+++ b/nri-observability/nri-observability.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           nri-observability
-version:        0.4.0.0
+version:        0.4.0.1
 synopsis:       Report log spans collected by nri-prelude.
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-observability#readme>.
 category:       Web

--- a/nri-observability/package.yaml
+++ b/nri-observability/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-observabi
 author: NoRedInk
 version: 0.4.0.1
 maintainer: haskell-open-source@noredink.com
-copyright: 2024 NoRedInk Corp.
+copyright: 2026 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/observability
 license-file: LICENSE
 category: Web

--- a/nri-observability/package.yaml
+++ b/nri-observability/package.yaml
@@ -3,7 +3,7 @@ synopsis: Report log spans collected by nri-prelude.
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-observability#readme>.
 homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-observability#readme
 author: NoRedInk
-version: 0.4.0.0
+version: 0.4.0.1
 maintainer: haskell-open-source@noredink.com
 copyright: 2024 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/observability

--- a/nri-postgresql/CHANGELOG.md
+++ b/nri-postgresql/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0.1
+
+- Require `nri-prelude >= 0.7.0.0`
+
 # 0.3.0.1
 
 - Support GHC 9.10.2, GHC 9.12.2, `network-3.3.x.x`, `filepath-1.5.x`, `template-haskell-2.23.x.x`

--- a/nri-postgresql/LICENSE
+++ b/nri-postgresql/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, NoRedInk
+Copyright (c) 2026, NoRedInk
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/nri-postgresql/nri-postgresql.cabal
+++ b/nri-postgresql/nri-postgresql.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           nri-postgresql
-version:        0.4.0.0
+version:        0.4.0.1
 synopsis:       Make queries against Postgresql.
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-postgresql#readme>.
 category:       Web

--- a/nri-postgresql/nri-postgresql.cabal
+++ b/nri-postgresql/nri-postgresql.cabal
@@ -13,7 +13,7 @@ homepage:       https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-pos
 bug-reports:    https://github.com/NoRedInk/haskell-libraries/issues
 author:         NoRedInk
 maintainer:     haskell-open-source@noredink.com
-copyright:      2024 NoRedInk Corp.
+copyright:      2026 NoRedInk Corp.
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/nri-postgresql/package.yaml
+++ b/nri-postgresql/package.yaml
@@ -3,7 +3,7 @@ synopsis: Make queries against Postgresql.
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-postgresql#readme>.
 homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-postgresql#readme
 author: NoRedInk
-version: 0.4.0.0
+version: 0.4.0.1
 maintainer: haskell-open-source@noredink.com
 copyright: 2024 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/postgresql

--- a/nri-postgresql/package.yaml
+++ b/nri-postgresql/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-postgresq
 author: NoRedInk
 version: 0.4.0.1
 maintainer: haskell-open-source@noredink.com
-copyright: 2024 NoRedInk Corp.
+copyright: 2026 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/postgresql
 license-file: LICENSE
 category: Web

--- a/nri-postgresql/test/golden-results/observability-spec-postgres-reporting-ghc-9
+++ b/nri-postgresql/test/golden-results/observability-spec-postgres-reporting-ghc-9
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-postgresql-0.4.0.0-inplace-tests"
+            { srcLocPackage = "nri-postgresql-0.4.0.1-inplace-tests"
             , srcLocModule = "ObservabilitySpec"
             , srcLocFile = "test/ObservabilitySpec.hs"
             , srcLocStartLine = 54
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "doQuery"
                 , SrcLoc
-                    { srcLocPackage = "nri-postgresql-0.4.0.0-inplace-tests"
+                    { srcLocPackage = "nri-postgresql-0.4.0.1-inplace-tests"
                     , srcLocModule = "ObservabilitySpec"
                     , srcLocFile = "test/ObservabilitySpec.hs"
                     , srcLocStartLine = 35
@@ -54,7 +54,7 @@ TracingSpan
                       Just
                         ( "withContext"
                         , SrcLoc
-                            { srcLocPackage = "nri-postgresql-0.4.0.0-inplace-tests"
+                            { srcLocPackage = "nri-postgresql-0.4.0.1-inplace-tests"
                             , srcLocModule = "Postgres"
                             , srcLocFile = "src/Postgres.hs"
                             , srcLocStartLine = 225

--- a/nri-prelude/LICENSE
+++ b/nri-prelude/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, NoRedInk
+Copyright (c) 2026, NoRedInk
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/nri-prelude/nri-prelude.cabal
+++ b/nri-prelude/nri-prelude.cabal
@@ -13,7 +13,7 @@ homepage:       https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-pre
 bug-reports:    https://github.com/NoRedInk/haskell-libraries/issues
 author:         NoRedInk
 maintainer:     haskell-open-source@noredink.com
-copyright:      2024 NoRedInk Corp.
+copyright:      2026 NoRedInk Corp.
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/nri-prelude/package.yaml
+++ b/nri-prelude/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-prelude#r
 author: NoRedInk
 version: 0.7.0.0
 maintainer: haskell-open-source@noredink.com
-copyright: 2024 NoRedInk Corp.
+copyright: 2026 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-prelude
 license-file: LICENSE
 category: Web

--- a/nri-redis/CHANGELOG.md
+++ b/nri-redis/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.1.1
+
+- Require `nri-prelude >= 0.7.0.0`
+
 # 0.4.1.0
 
 - Add `handlerWithoutNamespace` for creating Redis handlers that skip

--- a/nri-redis/LICENSE
+++ b/nri-redis/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, NoRedInk
+Copyright (c) 2026, NoRedInk
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/nri-redis/nri-redis.cabal
+++ b/nri-redis/nri-redis.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           nri-redis
-version:        0.4.1.0
+version:        0.4.1.1
 synopsis:       An intuitive hedis wrapper library.
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-redis#readme>.
 category:       Web

--- a/nri-redis/nri-redis.cabal
+++ b/nri-redis/nri-redis.cabal
@@ -13,7 +13,7 @@ homepage:       https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-red
 bug-reports:    https://github.com/NoRedInk/haskell-libraries/issues
 author:         NoRedInk
 maintainer:     haskell-open-source@noredink.com
-copyright:      2024 NoRedInk Corp.
+copyright:      2026 NoRedInk Corp.
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/nri-redis/package.yaml
+++ b/nri-redis/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-redis#rea
 author: NoRedInk
 version: 0.4.1.1
 maintainer: haskell-open-source@noredink.com
-copyright: 2024 NoRedInk Corp.
+copyright: 2026 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-redis
 license-file: LICENSE
 category: Web

--- a/nri-redis/package.yaml
+++ b/nri-redis/package.yaml
@@ -3,7 +3,7 @@ synopsis: An intuitive hedis wrapper library.
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-redis#readme>.
 homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-redis#readme
 author: NoRedInk
-version: 0.4.1.0
+version: 0.4.1.1
 maintainer: haskell-open-source@noredink.com
 copyright: 2024 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-redis

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-query
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "query"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 126

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-transaction
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "transaction"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 133

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-query
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "query"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 98

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-transaction
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "transaction"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 105

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-query
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "query"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 112

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-transaction
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "transaction"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 119

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "query"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 84

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query-timeout
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query-timeout
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 48
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "query"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 143

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-transaction
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "transaction"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 91

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-with-query-timout
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-with-query-timout
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "withContext"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
                     , srcLocModule = "Redis.Handler"
                     , srcLocFile = "src/Redis/Handler.hs"
                     , srcLocStartLine = 79

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-without-query-timout
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-without-query-timout
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "withContext"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.0-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
                     , srcLocModule = "Redis.Handler"
                     , srcLocFile = "src/Redis/Handler.hs"
                     , srcLocStartLine = 86

--- a/nri-test-encoding/LICENSE
+++ b/nri-test-encoding/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, NoRedInk
+Copyright (c) 2026, NoRedInk
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/nri-test-encoding/nri-test-encoding.cabal
+++ b/nri-test-encoding/nri-test-encoding.cabal
@@ -13,7 +13,7 @@ homepage:       https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-tes
 bug-reports:    https://github.com/NoRedInk/haskell-libraries/issues
 author:         NoRedInk
 maintainer:     haskell-open-source@noredink.com
-copyright:      2024 NoRedInk Corp.
+copyright:      2026 NoRedInk Corp.
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple

--- a/nri-test-encoding/package.yaml
+++ b/nri-test-encoding/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-test-enco
 author: NoRedInk
 version: 0.4.0.0
 maintainer: haskell-open-source@noredink.com
-copyright: 2024 NoRedInk Corp.
+copyright: 2026 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-test-encoding
 license-file: LICENSE
 category: Testing


### PR DESCRIPTION
I bumped nri-prelude to 0.7 in #152 bc of breaking changes.

I should have also bumped these packages, whose version boundaries against nri-prelude changed due to the breaking change.

I'm planning to publish them all so I bumped the copyright year too (our release.sh script checks it).