### PR TITLE
WIP: `Test.run` intermittent `<<loop>>` under `-threaded -N`

### DIFF
--- a/nri-prelude/nri-prelude.cabal
+++ b/nri-prelude/nri-prelude.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.18
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 
@@ -28,6 +28,10 @@ source-repository head
   type: git
   location: https://github.com/NoRedInk/haskell-libraries
   subdir: nri-prelude
+
+flag parallel-loop-bug
+  manual: False
+  default: False
 
 library
   exposed-modules:
@@ -113,6 +117,40 @@ library
     , unix >=2.7.2.2 && <2.9
     , vector >=0.12.1.2 && <0.14
   default-language: Haskell2010
+
+executable parallel-loop-bug
+  main-is: Main.hs
+  other-modules:
+      Paths_nri_prelude
+  hs-source-dirs:
+      scripts/parallel-loop-bug
+  default-extensions:
+      DataKinds
+      DeriveGeneric
+      FlexibleContexts
+      FlexibleInstances
+      GeneralizedNewtypeDeriving
+      MultiParamTypeClasses
+      NamedFieldPuns
+      NoImplicitPrelude
+      OverloadedStrings
+      PartialTypeSignatures
+      ScopedTypeVariables
+      Strict
+      TypeOperators
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wincomplete-uni-patterns -threaded -rtsopts "-with-rtsopts=-N -T" -O2
+  build-depends:
+      aeson
+    , base
+    , bytestring
+    , nri-prelude
+    , text
+    , yaml
+  default-language: Haskell2010
+  if flag(parallel-loop-bug)
+    buildable: True
+  else
+    buildable: False
 
 test-suite tests
   type: exitcode-stdio-1.0

--- a/nri-prelude/package.yaml
+++ b/nri-prelude/package.yaml
@@ -102,3 +102,28 @@ tests:
       - -fno-warn-type-defaults
     default-extensions:
       - ExtendedDefaultRules
+flags:
+  parallel-loop-bug:
+    default: false
+    manual: false
+executables:
+  parallel-loop-bug:
+    source-dirs: scripts/parallel-loop-bug
+    main: Main.hs
+    dependencies:
+      - aeson
+      - base
+      - bytestring
+      - nri-prelude
+      - text
+      - yaml
+    ghc-options:
+      - -threaded
+      - -rtsopts "-with-rtsopts=-N -T"
+      - -O2
+    when:
+      - condition: flag(parallel-loop-bug)
+        then:
+          buildable: true
+        else:
+          buildable: false

--- a/nri-prelude/scripts/parallel-loop-bug/Main.hs
+++ b/nri-prelude/scripts/parallel-loop-bug/Main.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
+-- | Reproduction for an intermittent `<<loop>>` (NonTermination) crash from
+-- `Test.run` under the threaded RTS with multiple capabilities (`+RTS -N`).
+--
+-- The suite below is a dozen *ungrouped* tests (so `Test.run` executes them in
+-- parallel via `Task.parallel`), each decoding a tiny document to a *distinct*
+-- type — i.e. each forces a distinct per-type decoder CAF. Looping the binary
+-- on a multi-core box crashes with `parallel-loop-bug: <<loop>>` in a small
+-- fraction of runs at `-N >= 4`, and never at `-N1`.
+--
+-- See scripts/parallel-loop-bug/README.md for how to run it and what we know.
+module Main (main) where
+
+import Data.Aeson (FromJSON)
+import qualified Data.ByteString.Char8 as BS
+import Data.Text (Text)
+import qualified Data.Yaml as Yaml
+import qualified Expect
+import GHC.Generics (Generic)
+import Test (Test, describe, run, test)
+import qualified Prelude
+import Prelude (Either (..), IO, Int, Maybe, Show)
+
+-- A dozen DISTINCT record types => a dozen distinct FromJSON decoder CAFs.
+-- Distinct field names; each field optional so the one document decodes into
+-- every type. The decode is small but real (YAML); the trigger is the *variety
+-- of distinct decoders forced concurrently*, not how big each document is.
+data R1 = R1 {a1 :: Maybe Int} deriving (Show, Generic, FromJSON)
+data R2 = R2 {a2 :: Maybe Int} deriving (Show, Generic, FromJSON)
+data R3 = R3 {a3 :: Maybe Int} deriving (Show, Generic, FromJSON)
+data R4 = R4 {a4 :: Maybe Int} deriving (Show, Generic, FromJSON)
+data R5 = R5 {a5 :: Maybe Int} deriving (Show, Generic, FromJSON)
+data R6 = R6 {a6 :: Maybe Int} deriving (Show, Generic, FromJSON)
+data R7 = R7 {a7 :: Maybe Int} deriving (Show, Generic, FromJSON)
+data R8 = R8 {a8 :: Maybe Int} deriving (Show, Generic, FromJSON)
+data R9 = R9 {a9 :: Maybe Int} deriving (Show, Generic, FromJSON)
+data R10 = R10 {a10 :: Maybe Int} deriving (Show, Generic, FromJSON)
+data R11 = R11 {a11 :: Maybe Int} deriving (Show, Generic, FromJSON)
+data R12 = R12 {a12 :: Maybe Int} deriving (Show, Generic, FromJSON)
+
+doc :: BS.ByteString
+doc = "{}\n"
+
+mk :: (Show a) => Text -> (BS.ByteString -> Either Yaml.ParseException a) -> Test
+mk name dec =
+  test name (\_ ->
+    case dec doc of
+      Right x -> Expect.equal (Prelude.length (Prelude.show x)) (Prelude.length (Prelude.show x))
+      Left _ -> Expect.fail "decode failed")
+
+main :: IO ()
+main =
+  run
+    (describe
+      "parallel-loop-bug"
+      [ mk "r1" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R1),
+        mk "r2" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R2),
+        mk "r3" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R3),
+        mk "r4" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R4),
+        mk "r5" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R5),
+        mk "r6" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R6),
+        mk "r7" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R7),
+        mk "r8" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R8),
+        mk "r9" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R9),
+        mk "r10" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R10),
+        mk "r11" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R11),
+        mk "r12" (Yaml.decodeEither' :: BS.ByteString -> Either Yaml.ParseException R12)
+      ])

--- a/nri-prelude/scripts/parallel-loop-bug/README.md
+++ b/nri-prelude/scripts/parallel-loop-bug/README.md
@@ -30,14 +30,15 @@ and zero at `-N1`.
 
 - ~0.2–0.3% of runs at `-N12` (12-core); **0 at `-N1`/`-N2`**; the rate scales
   with `-N`.
-- Needs **both** >1 capability **and** a *variety of distinct decoders, each
-  doing a small but real parse*. Identical/duplicated decoders don't trip it,
-  nor do pure `Expect.pass` tests; ~12 *distinct* ones do. The document can be
-  tiny (each test decodes `"{}"`), but the parse must do real work: a dozen
-  distinct YAML decoders reproduce it, whereas a dozen distinct *aeson*
-  `eitherDecodeStrict' "{}"` decodes did **not** (0/10000) — that decode is
-  essentially free. So the driver is the number of distinct decoder CAFs forced
-  concurrently; we didn't map exactly which codecs/sizes qualify.
+- Needs **both** >1 capability **and** a *variety of distinct decoders*.
+  Identical/duplicated decoders don't trip it, nor do pure `Expect.pass` tests;
+  ~12 *distinct* YAML decoders do (each decodes a tiny `"{}"`).
+- **Appears specific to the YAML/libyaml decode path.** A pure-`aeson`
+  equivalent did **not** reproduce in any variant we tried (all 0/10000 at
+  `-N12`): trivial `eitherDecodeStrict' "{}"`, a rich 8-field nested record, and
+  20 distinct *recursive* types. So the trigger seems tied to something the
+  `yaml` package does (it parses via libyaml over FFI, with `unsafePerformIO`),
+  not to concurrent decoding in general. We did not exhaustively rule out aeson.
 - Wrapping the suite in `Test.serialize` avoids it (sequential execution) — the
   current workaround for affected suites.
 - The exception escapes **uncaught** (outside the per-test bodies that

--- a/nri-prelude/scripts/parallel-loop-bug/README.md
+++ b/nri-prelude/scripts/parallel-loop-bug/README.md
@@ -1,0 +1,50 @@
+# parallel-loop-bug
+
+`Test.run` runs ungrouped tests in parallel (`Task.parallel` →
+`Async.forConcurrently`). Under the threaded RTS with multiple capabilities
+(`+RTS -N`), a suite that forces a *variety of distinct decoder CAFs*
+concurrently intermittently crashes with an uncaught `<<loop>>`
+(`NonTermination`) before printing a report — i.e. a CI flake.
+
+This program is a minimal reproduction: a dozen ungrouped tests, each decoding a
+tiny document to a *distinct* type (a distinct `FromJSON` decoder CAF).
+
+## Run
+
+The crash is rare, so loop the binary on a multi-core box and count crashes:
+
+```sh
+cabal build parallel-loop-bug -fparallel-loop-bug
+BIN=$(cabal list-bin parallel-loop-bug -fparallel-loop-bug)
+loops=0
+for i in $(seq 1 10000); do
+  "$BIN" +RTS -N -RTS >/dev/null 2>err || grep -q '<<loop>>' err && loops=$((loops+1))
+done
+echo "loop crashes: $loops / 10000"
+```
+
+You should see a handful of `parallel-loop-bug: <<loop>>` crashes at `-N >= 4`,
+and zero at `-N1`.
+
+## What we know
+
+- ~0.2–0.3% of runs at `-N12` (12-core); **0 at `-N1`/`-N2`**; the rate scales
+  with `-N`.
+- Needs **both** >1 capability **and** a *variety of distinct decoders, each
+  doing a small but real parse*. Identical/duplicated decoders don't trip it,
+  nor do pure `Expect.pass` tests; ~12 *distinct* ones do. The document can be
+  tiny (each test decodes `"{}"`), but the parse must do real work: a dozen
+  distinct YAML decoders reproduce it, whereas a dozen distinct *aeson*
+  `eitherDecodeStrict' "{}"` decodes did **not** (0/10000) — that decode is
+  essentially free. So the driver is the number of distinct decoder CAFs forced
+  concurrently; we didn't map exactly which codecs/sizes qualify.
+- Wrapping the suite in `Test.serialize` avoids it (sequential execution) — the
+  current workaround for affected suites.
+- The exception escapes **uncaught** (outside the per-test bodies that
+  `Test.run` would catch and report).
+- **Masked by profiling**: a `-fprof-late` build run with `+RTS -xc` does not
+  reproduce it, so we have no Haskell-level stack. That's the signature of a
+  low-level threaded-RTS black-hole / deadlock-detector race rather than a
+  cyclic binding (and `-N1` cleanliness rules out a real cycle).
+- **Not** GHC #13751 (`<<loop>>` under concurrent STM) — fixed in 8.2.1; this is
+  GHC 9.8.4.


### PR DESCRIPTION
# WIP: `Test.run` intermittent `<<loop>>` under `-threaded -N`

**WIP** — this PR adds a minimal reproduction under
[`nri-prelude/scripts/parallel-loop-bug`](nri-prelude/scripts/parallel-loop-bug)
so we can work on a fix. No library change yet.

## Summary

A test executable built with `Test.run`, compiled `-threaded` and run with
`+RTS -N` (multiple capabilities), intermittently crashes with an uncaught

```
<<loop>>
```

(`NonTermination`) before printing a report — i.e. a CI flake (~0.2–0.3% of runs
on a 12-core box). It comes from the **parallel execution of ungrouped tests**
(`Test.Internal.runStrategy` → `Task.parallel` → `Async.forConcurrently`).
`Test.serialize` makes it disappear, which is the current workaround.

## Reproduction

See `scripts/parallel-loop-bug/` (README + `Main.hs`). It's a dozen ungrouped
tests, each decoding a tiny document to a *distinct* type. Build it flag-gated
and loop it on a multi-core box:

```sh
cabal build parallel-loop-bug -fparallel-loop-bug
BIN=$(cabal list-bin parallel-loop-bug -fparallel-loop-bug)
loops=0
for i in $(seq 1 10000); do
  "$BIN" +RTS -N -RTS >/dev/null 2>err || grep -q '<<loop>>' err && loops=$((loops+1))
done
echo "loop crashes: $loops / 10000"
```

Observed **27/10000 (~0.27%)** at `-N12`; **0/10000** at `-N1`.

## Symptom

- Exits non-zero with `<<loop>>` on stderr and **no test report**.
- The exception is **uncaught** — it escapes the per-test bodies (which the
  runner wraps and reports as failures), so it originates in the
  orchestration/forcing layer, not inside a test.
- Fully **intermittent**: same binary, same inputs.

## Observations (GHC 9.8.4, 12-core, looping the process)

| Configuration | `<<loop>>` rate |
| --- | --- |
| `-N1` / `-N2` | 0 |
| `-N4` | ~0.07% |
| `-N8` / `-N12` | ~0.3% |
| 12 distinct YAML decoders (this repro), `-N12` | 27 / 10000 |
| 50 **identical** decoders (one type, repeated), `-N12` | 0 |
| 200 trivial `Expect.pass` tests, `-N12` | 0 |
| **aeson** decoders — trivial `"{}"`, rich nested record, AND 20 recursive types, `-N12` | 0 (all) |
| Same decode via bare `Async.forConcurrently` (no `Test.run`), `-N12` | 0 |
| Suite wrapped in `Test.serialize`, `-N12` | 0 / 8000 |

Takeaways:

1. **Concurrency-gated**: 0 at `-N1`/`-N2`; scales with capability count.
2. **Needs the runner**: bare `Async.forConcurrently` of the same decode work
   never reproduced it; going through `Test.run` does.
3. **Needs a *variety* of distinct decoders, not volume**: identical decoders
   and `Expect.pass` suites never loop; ~12 distinct ones do.
4. **Appears specific to the YAML/libyaml path**: a pure-`aeson` equivalent did
   not reproduce in any variant tried (trivial `"{}"`, a rich nested record, and
   20 distinct recursive types — all 0/10000), while YAML does. So the trigger
   seems tied to what the `yaml` package does (libyaml over FFI, with
   `unsafePerformIO`), not to concurrent decoding in general.
5. **`Test.serialize` reliably avoids it.**

## What we ruled out

- **A cyclic binding in user code** — `-N1` is clean across thousands of runs; a
  real self-referential thunk would loop regardless of `-N`.
- **GHC #13751** (`<<loop>>` under concurrent STM) — fixed in 8.2.1; this is 9.8.4.
- **Concurrent decoding in general** — a pure-aeson equivalent did not reproduce
  (see above); it's specific to the libyaml-backed YAML path. (We did not
  exhaustively rule out aeson.)

## Hypothesis

A threaded-RTS **black-hole / deadlock-detector** firing on concurrent forcing
of multiple distinct shared CAFs (per-type decoder dictionaries/thunks). When
several capabilities each enter a different CAF and then need one another's
(already black-holed) CAFs, an unlucky interleaving forms a transient
block-cycle the RTS reports as `NonTermination`. Consistent with: identical
decoders not tripping it, scaling with `-N`, and being **masked by profiling**
(a `-fprof-late` build run with `+RTS -xc` does not reproduce — so no
Haskell-level stack; a timing race, not a deterministic cycle).

## Open questions / directions

1. Is this a known interaction with `Task.parallel`? Should test parallelism be
   opt-in or capped, or `serialize` documented as the remedy for `<<loop>>`?
2. Does anything in `runSingle` (per-test tracing-span `MVar`/`IORef`, the
   `Task.timeout` racer) widen the window, vs. this being a pure GHC RTS issue
   to report upstream?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
