### PR TITLE
Expose hedgehog function for testing

### DIFF
--- a/nri-prelude/src/Test.hs
+++ b/nri-prelude/src/Test.hs
@@ -12,6 +12,7 @@ module Test
     Internal.fuzz,
     Internal.fuzz2,
     Internal.fuzz3,
+    Internal.hedgehog,
 
     -- * Serialize test execution
     Internal.serialize,

--- a/nri-prelude/src/Test/Internal.hs
+++ b/nri-prelude/src/Test/Internal.hs
@@ -216,7 +216,7 @@ serialize groupKey (Test tests) =
 -- elsewhere called property-based tests, generative tests, or QuickCheck-style
 -- tests.
 fuzz :: (Stack.HasCallStack, Show a) => Fuzzer a -> Text -> (a -> Expectation) -> Test
-fuzz fuzzer name expectation =
+fuzz (Fuzzer gen) name expectation =
   Test
     [ SingleTest
         { describes = [],
@@ -224,7 +224,7 @@ fuzz fuzzer name expectation =
           loc = Stack.withFrozenCallStack getFrame name,
           group = Ungrouped,
           label = None,
-          body = fuzzBody fuzzer expectation
+          body = fuzzBody gen expectation
         }
     ]
 
@@ -240,7 +240,7 @@ fuzz2 (Fuzzer genA) (Fuzzer genB) name expectation =
           label = None,
           body =
             fuzzBody
-              (Fuzzer (map2 (,) genA genB))
+              (map2 (,) genA genB)
               (\(a, b) -> expectation a b)
         }
     ]
@@ -257,13 +257,28 @@ fuzz3 (Fuzzer genA) (Fuzzer genB) (Fuzzer genC) name expectation =
           label = None,
           body =
             fuzzBody
-              (Fuzzer (map3 (,,) genA genB genC))
+              (map3 (,,) genA genB genC)
               (\(a, b, c) -> expectation a b c)
         }
     ]
 
-fuzzBody :: (Show a) => Fuzzer a -> (a -> Expectation) -> Expectation
-fuzzBody (Fuzzer gen) expectation = do
+-- | Run a fuzz test using a hedgehog generator
+hedgehog :: (Stack.HasCallStack, Show a) => Hedgehog.Gen a -> Text -> (a -> Expectation) -> Test
+hedgehog gen name expectation = 
+  Test
+    [ SingleTest
+        { describes = [],
+          name = name,
+          loc = Stack.withFrozenCallStack getFrame name,
+          group = Ungrouped,
+          label = None,
+          body = fuzzBody gen expectation
+        }
+    ]
+
+
+fuzzBody :: (Show a) => Hedgehog.Gen a -> (a -> Expectation) -> Expectation
+fuzzBody gen expectation = do
   Expectation <|
     Platform.Internal.Task
       ( \_log -> do


### PR DESCRIPTION
This PR exposes a new function from the `Test` module called `hedgehog`.  This function is almost identical to the `fuzz` function except that we accept the `Gen` type that underlies the `Fuzz` opaque type:

```hs
hedgehog :: (Stack.HasCallStack, Show a) => Hedgehog.Gen a -> Text -> (a -> Expectation) -> Test
```

This allows consumers of the library to use the raw powerful Hedgehog combinators if they need to instead of our Elm-like wrappers. 

### Why do we need this?

I'm trying to write a Fuzzer for a recursive type that is an extension of a JSON object (for json-render): 

```hs 
newtype StatePath = StatePath Text

data Exp
  = Object (Map Text Exp)
  | Array [Exp]
  | String Text
  | Number Scientific
  | Bool Bool
  | BindState StatePath
```
A first attempt at a fuzzer might look like: 

```hs
fuzzExp :: Fuzzer Exp
fuzzExp = 
  Fuzz.oneOf
    [ map (Map.fromList >> Object) (Fuzz.list (Fuzz.tuple (Fuzz.text, fuzzExp))),
      map Array (Fuzz.list fuzzExp)
      map String Fuzz.text,
      map (fromFloatDigits >> Number) Fuzz.float,
      map Bool Fuzz.bool, 
      map (StatePath >> BindState) Fuzz.Text
    ]
```
  
This of course will cause an infinite recursion.  (It's odd that this library doesn't expose [lazy](https://package.elm-lang.org/packages/elm-explorations/test/latest/Fuzz#lazy) like Elm's does). 

The documentation from [`frequency`](https://hackage-content.haskell.org/package/nri-prelude-0.7.0.0/docs/Fuzz.html#v:frequency) suggests manually passing a depth parameter:

```hs
fuzzExp :: Int -> Fuzzer Exp
fuzzExp depth =
  if depth <= 0 then 
    Fuzz.oneOf
      [ map String Fuzz.text,
        map (fromFloatDigits >> Number) Fuzz.float,
        map Bool Fuzz.bool, 
        map (StatePath >> BindState) Fuzz.Text
      ]
  else
    Fuzz.oneOf
      [ map (Map.fromList >> Object) (Fuzz.list (Fuzz.tuple (Fuzz.text, fuzzExp))),
        map Array (Fuzz.list fuzzExp)
        map String Fuzz.text,
        map (fromFloatDigits >> Number) Fuzz.float,
        map Bool Fuzz.bool, 
        map (StatePath >> BindState) Fuzz.Text
      ]
```

 This still has exponential behavior in terms of depth however.  This leads to trees that are wide but not deep as leave can have an `Object` or `Array` with a potentially large `list`.  
 
 Hedgehog provides a [`recursive`](https://hackage-content.haskell.org/package/hedgehog-1.7/docs/Hedgehog-Gen.html#v:recursive) function that reduces the `Size` parameter by half.  This ensures that the size of lists continues to shrink as we recuse and when size hits zero evenutally then we stop recursing entirely. 

I'm currently hitting hangs and *system* out of memory errors when running `fuzzExp 4`. 

Aside from recursion issues, I also find it frustrating how I cannot build up fuzzers constructively.  In one case I only want a string of alpha numeric characters and AFAICT the only way to do that is build up a `Text` and map into it to remove unwanted things.  Aside from being harder than it needs to be (see Hedgehogs `alphaNum ` and `element` functions), I'm sure this has less than ideal shrinking behavior. 