### PR TITLE
Late span reparenting

### DIFF
--- a/nri-prelude/CHANGELOG.md
+++ b/nri-prelude/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix: tracing spans finishing after their parent span already finished are no longer silently lost. They now attach to the still-open trace root, or are reported as a separate root span if the whole trace has already closed. This makes it safe to capture `Platform.logHandler` for deferred work (streamed response bodies, callbacks, fire-and-forget tasks). Parent finalization and child attachment are now atomic and race-safe, and repeated finalization of the same span is idempotent. Normal synchronous span nesting, the public API, and the serialized `TracingSpan` format are unchanged.
+
 # 0.7.0.0
 
 - **Breaking:** `Platform.rootTracingSpanIO` and the internal `mkHandler` now take an additional `Aeson.Value -> Task Never ()` callback for analytics event delivery. Existing callers should pass `Platform.silentTrack` to preserve previous behavior.

--- a/nri-prelude/src/Platform/Internal.hs
+++ b/nri-prelude/src/Platform/Internal.hs
@@ -596,16 +596,14 @@ data LogHandler = LogHandler
 silentTrack :: Aeson.Value -> Task Never ()
 silentTrack _ = Task (\_ -> pure (Ok ()))
 
--- | The lifecycle of the mutable state behind a single tracing span. A span
--- starts 'Open', accepting child attachments and detail mutations. When
--- finalization begins the span moves to 'Closing', atomically ending the
--- attachment window, and to 'Finished' once its completed snapshot has been
--- handed off. Only the 'Open' state carries data: after 'beginFinish' the
--- draft span lives on the finalizing thread's stack, not in the 'IORef'.
+-- | The lifecycle of a tracing span
 data SpanState
-  = Open TracingSpan
-  | Closing
-  | Finished
+  = -- Initial state of a tracing span. Accepts children and detail mutations
+    Open TracingSpan
+  | -- Span stops accepting children and its stats are being calculated
+    Closing
+  | -- Span has been finalized and will take no further changes
+    Finished
 
 -- | The mutable attachment point for a single span.
 newtype SpanTarget = SpanTarget (IORef.IORef SpanState)
@@ -624,10 +622,9 @@ newSpanTarget :: TracingSpan -> IO SpanTarget
 newSpanTarget tracingSpan' =
   map SpanTarget (IORef.newIORef (Open tracingSpan'))
 
--- | Atomically close the attachment window of a span. Only the first caller
--- receives the draft span, making repeated finalization a no-op. Children
--- attaching after this see 'Closing' and get reparented, so the final
--- timestamp (read after this) is never earlier than an included child's.
+-- | Atomically close the attachment window of a span.
+--
+-- Atomicity here prevents adding new children to a finished span
 beginFinish :: SpanTarget -> IO (Maybe TracingSpan)
 beginFinish (SpanTarget ref) =
   IORef.atomicModifyIORef' ref <| \state ->
@@ -657,9 +654,7 @@ tryAttach (SpanTarget ref) child =
 
 -- | Apply a mutation to a span that is still open. Spans that have begun
 -- finalization no longer change: mutating them would be invisible in the
--- reported trace anyway, which matches the pre-lifecycle behavior where late
--- mutations landed in a private 'IORef' after its contents had been copied
--- out.
+-- reported trace anyway.
 modifyOpenSpan :: SpanTarget -> (TracingSpan -> TracingSpan) -> IO ()
 modifyOpenSpan (SpanTarget ref) f =
   IORef.atomicModifyIORef' ref <| \state ->
@@ -668,27 +663,25 @@ modifyOpenSpan (SpanTarget ref) f =
       Closing -> (Closing, ())
       Finished -> (Finished, ())
 
--- | Hand off a completed non-root span: preferably to its intended parent, to
--- the trace root if the parent has already finished, or through the root
--- reporter as a separate root span if the whole trace has already closed.
+-- | Hand off a completed non-root span.
 completeChild :: TraceRoot -> SpanTarget -> TracingSpan -> IO ()
 completeChild traceRoot intendedParent child = do
   attached <- tryAttach intendedParent child
   if attached
+    -- our parent was open, so we attached successfully
     then pure ()
     else do
+      -- parent was closed. try to attach to the root span
       attachedToRoot <- tryAttach (rootTarget traceRoot) child
       if attachedToRoot
         then pure ()
+        -- root was closed, report this as a new root
         else reportRoot traceRoot child
 
 -- | Helper that creates one of the handler's above. This is intended for
 -- internal use in this library only and not for exposing. Outside of this
 -- library the @rootTracingSpanIO@ is the more user-friendly way to get hands
 -- on a @LogHandler@.
---
--- This constructs the handler for a root span, starting a new trace. Child
--- handlers are constructed by `mkChildHandler` via `startChildTracingSpan`.
 mkHandler ::
   (Stack.HasCallStack) =>
   Text ->

--- a/nri-prelude/src/Platform/Internal.hs
+++ b/nri-prelude/src/Platform/Internal.hs
@@ -596,10 +596,75 @@ data LogHandler = LogHandler
 silentTrack :: Aeson.Value -> Task Never ()
 silentTrack _ = Task (\_ -> pure (Ok ()))
 
+-- | The lifecycle of the mutable state behind a single tracing span. A span
+-- starts 'Open', accepting child attachments and detail mutations. When
+-- finalization begins the span moves to 'Closing', atomically ending the
+-- attachment window, and to 'Finished' once its completed snapshot has been
+-- handed off. Only the 'Open' state carries data: after 'beginFinish' the
+-- draft span lives on the finalizing thread's stack, not in the 'IORef'.
+data SpanState
+  = Open TracingSpan
+  | Closing
+  | Finished
+
+-- | The mutable attachment point for a single span.
+newtype SpanTarget = SpanTarget (IORef.IORef SpanState)
+
+newSpanTarget :: TracingSpan -> IO SpanTarget
+newSpanTarget tracingSpan' =
+  map SpanTarget (IORef.newIORef (Open tracingSpan'))
+
+-- | Atomically close the attachment window of a span. Only the first caller
+-- receives the draft span, making repeated finalization a no-op. Children
+-- attaching after this see 'Closing' and are rejected, so the final
+-- timestamp (read after this) is never earlier than an included child's.
+beginFinish :: SpanTarget -> IO (Maybe TracingSpan)
+beginFinish (SpanTarget ref) =
+  IORef.atomicModifyIORef' ref <| \state ->
+    case state of
+      Open tracingSpan' -> (Closing, Just tracingSpan')
+      Closing -> (Closing, Nothing)
+      Finished -> (Finished, Nothing)
+
+markFinished :: SpanTarget -> IO ()
+markFinished (SpanTarget ref) =
+  IORef.atomicWriteIORef ref Finished
+
+-- | Attach a completed child to a span, if that span is still accepting
+-- children. Together with 'beginFinish' this forms the linearization point of
+-- the attachment/finalization race: whichever atomic update wins determines
+-- whether the child is included in the parent's snapshot or rejected.
+tryAttach :: SpanTarget -> TracingSpan -> IO Bool
+tryAttach (SpanTarget ref) child =
+  IORef.atomicModifyIORef' ref <| \state ->
+    case state of
+      Open parent ->
+        -- Note child tracingSpans are consed to the front of the list, so
+        -- children are ordered new-to-old.
+        (Open parent {children = child : children parent}, True)
+      Closing -> (Closing, False)
+      Finished -> (Finished, False)
+
+-- | Apply a mutation to a span that is still open. Spans that have begun
+-- finalization no longer change: mutating them would be invisible in the
+-- reported trace anyway, which matches the pre-lifecycle behavior where late
+-- mutations landed in a private 'IORef' after its contents had been copied
+-- out.
+modifyOpenSpan :: SpanTarget -> (TracingSpan -> TracingSpan) -> IO ()
+modifyOpenSpan (SpanTarget ref) f =
+  IORef.atomicModifyIORef' ref <| \state ->
+    case state of
+      Open tracingSpan' -> (Open (f tracingSpan'), ())
+      Closing -> (Closing, ())
+      Finished -> (Finished, ())
+
 -- | Helper that creates one of the handler's above. This is intended for
 -- internal use in this library only and not for exposing. Outside of this
 -- library the @rootTracingSpanIO@ is the more user-friendly way to get hands
 -- on a @LogHandler@.
+--
+-- This constructs the handler for a root span, starting a new trace. Child
+-- handlers are constructed by `mkChildHandler` via `startChildTracingSpan`.
 mkHandler ::
   (Stack.HasCallStack) =>
   Text ->
@@ -614,28 +679,78 @@ mkHandler ::
   IO LogHandler
 mkHandler requestId clock trackEvent' onFinish onFinishRoot' name' = do
   let onFinishRoot = Maybe.withDefault onFinish onFinishRoot'
-  tracingSpanRef <-
+  target <-
     Stack.withFrozenCallStack startTracingSpan clock name'
-      |> andThen IORef.newIORef
+      |> andThen newSpanTarget
+  mkTracingHandler requestId clock trackEvent' onFinishRoot target onFinish
+
+-- | Construct the handler for a child span of the span behind `parentTarget`.
+-- A child completing after its parent already finished is dropped.
+mkChildHandler ::
+  (Stack.HasCallStack) =>
+  Text ->
+  Clock ->
+  (Aeson.Value -> Task Never ()) ->
+  (TracingSpan -> IO ()) ->
+  SpanTarget ->
+  Text ->
+  IO LogHandler
+mkChildHandler requestId clock trackEvent' onFinishRoot parentTarget name' = do
+  target <-
+    Stack.withFrozenCallStack startTracingSpan clock name'
+      |> andThen newSpanTarget
+  mkTracingHandler
+    requestId
+    clock
+    trackEvent'
+    onFinishRoot
+    target
+    ( \child -> do
+        _ <- tryAttach parentTarget child
+        pure ()
+    )
+
+-- | Shared plumbing of `mkHandler` and `mkChildHandler`: the two only differ
+-- in what happens to the completed span (report it as a trace root, or attach
+-- it to its parent).
+mkTracingHandler ::
+  Text ->
+  Clock ->
+  (Aeson.Value -> Task Never ()) ->
+  (TracingSpan -> IO ()) ->
+  SpanTarget ->
+  (TracingSpan -> IO ()) ->
+  IO LogHandler
+mkTracingHandler requestId clock trackEvent' onFinishRoot target complete = do
   allocationCounterStartVal <- System.Mem.getAllocationCounter
   pure
     LogHandler
       { requestId,
-        startChildTracingSpan = mkHandler requestId clock trackEvent' (appendTracingSpanToParent tracingSpanRef) (Just onFinishRoot),
+        startChildTracingSpan = mkChildHandler requestId clock trackEvent' onFinishRoot target,
         startNewRoot = mkHandler requestId clock trackEvent' onFinishRoot Nothing,
         setTracingSpanDetailsIO = \details' ->
-          updateIORef
-            tracingSpanRef
+          modifyOpenSpan
+            target
             (\tracingSpan' -> tracingSpan' {details = Just (toTracingSpanDetails details')}),
         setTracingSpanSummaryIO = \text ->
-          updateIORef
-            tracingSpanRef
+          modifyOpenSpan
+            target
             (\tracingSpan' -> tracingSpan' {summary = Just text}),
         markTracingSpanFailedIO =
-          updateIORef
-            tracingSpanRef
+          modifyOpenSpan
+            target
             (\tracingSpan' -> tracingSpan' {succeeded = succeeded tracingSpan' ++ Failed, containsFailures = True}),
-        finishTracingSpan = finalizeTracingSpan clock allocationCounterStartVal tracingSpanRef >> andThen onFinish,
+        finishTracingSpan = \maybeException -> do
+          maybeDraft <- beginFinish target
+          case maybeDraft of
+            Nothing -> pure ()
+            Just draft -> do
+              completed <- finalizeTracingSpan clock allocationCounterStartVal draft maybeException
+              -- The span must read as finished before the completion callback
+              -- runs, so concurrent operations never see a reported span as
+              -- still accepting children, even if the callback throws.
+              markFinished target
+              complete completed,
         trackAnalyticsEvent = trackEvent'
       }
 
@@ -758,11 +873,10 @@ startTracingSpan clock name = do
       }
 
 -- | Some final properties to set on a tracingSpan before calling it done.
-finalizeTracingSpan :: Clock -> Int -> IORef.IORef TracingSpan -> Maybe Exception.SomeException -> IO TracingSpan
-finalizeTracingSpan clock allocationCounterStartVal tracingSpanRef maybeException = do
+finalizeTracingSpan :: Clock -> Int -> TracingSpan -> Maybe Exception.SomeException -> IO TracingSpan
+finalizeTracingSpan clock allocationCounterStartVal tracingSpan' maybeException = do
   finished <- monotonicTimeInMsec clock
   allocationCounterEndVal <- System.Mem.getAllocationCounter
-  tracingSpan' <- IORef.readIORef tracingSpanRef
   pure
     tracingSpan'
       { finished,
@@ -781,16 +895,6 @@ finalizeTracingSpan clock allocationCounterStartVal tracingSpanRef maybeExceptio
         -- subtract in this order to get a positive number.
         allocated = allocationCounterStartVal - allocationCounterEndVal
       }
-
-appendTracingSpanToParent :: IORef.IORef TracingSpan -> TracingSpan -> IO ()
-appendTracingSpanToParent parentRef child =
-  updateIORef parentRef <| \parentTracingSpan ->
-    -- Note child tracingSpans are consed to the front of the list, so children
-    -- are ordered new-to-old.
-    parentTracingSpan {children = child : children parentTracingSpan}
-
-updateIORef :: IORef.IORef a -> (a -> a) -> IO ()
-updateIORef ref f = IORef.atomicModifyIORef' ref (\x -> (f x, ()))
 
 --
 -- SPAN CONSTRUCTION

--- a/nri-prelude/src/Platform/Internal.hs
+++ b/nri-prelude/src/Platform/Internal.hs
@@ -610,13 +610,22 @@ data SpanState
 -- | The mutable attachment point for a single span.
 newtype SpanTarget = SpanTarget (IORef.IORef SpanState)
 
+-- | The trace a handler belongs to. A late span -- one finishing after its
+-- intended parent already finished -- is reparented to 'rootTarget' if the
+-- root is still open. That is preferable to silently dropping it, which is
+-- what used to happen when a captured handler outlived its span.
+data TraceRoot = TraceRoot
+  { rootTarget :: SpanTarget,
+    reportRoot :: TracingSpan -> IO ()
+  }
+
 newSpanTarget :: TracingSpan -> IO SpanTarget
 newSpanTarget tracingSpan' =
   map SpanTarget (IORef.newIORef (Open tracingSpan'))
 
 -- | Atomically close the attachment window of a span. Only the first caller
 -- receives the draft span, making repeated finalization a no-op. Children
--- attaching after this see 'Closing' and are rejected, so the final
+-- attaching after this see 'Closing' and get reparented, so the final
 -- timestamp (read after this) is never earlier than an included child's.
 beginFinish :: SpanTarget -> IO (Maybe TracingSpan)
 beginFinish (SpanTarget ref) =
@@ -633,7 +642,7 @@ markFinished (SpanTarget ref) =
 -- | Attach a completed child to a span, if that span is still accepting
 -- children. Together with 'beginFinish' this forms the linearization point of
 -- the attachment/finalization race: whichever atomic update wins determines
--- whether the child is included in the parent's snapshot or rejected.
+-- whether the child is included in the parent's snapshot or reparented.
 tryAttach :: SpanTarget -> TracingSpan -> IO Bool
 tryAttach (SpanTarget ref) child =
   IORef.atomicModifyIORef' ref <| \state ->
@@ -657,6 +666,17 @@ modifyOpenSpan (SpanTarget ref) f =
       Open tracingSpan' -> (Open (f tracingSpan'), ())
       Closing -> (Closing, ())
       Finished -> (Finished, ())
+
+-- | Hand off a completed non-root span: preferably to its intended parent, or
+-- to the trace root if the parent has already finished.
+completeChild :: TraceRoot -> SpanTarget -> TracingSpan -> IO ()
+completeChild traceRoot intendedParent child = do
+  attached <- tryAttach intendedParent child
+  if attached
+    then pure ()
+    else do
+      _ <- tryAttach (rootTarget traceRoot) child
+      pure ()
 
 -- | Helper that creates one of the handler's above. This is intended for
 -- internal use in this library only and not for exposing. Outside of this
@@ -682,33 +702,25 @@ mkHandler requestId clock trackEvent' onFinish onFinishRoot' name' = do
   target <-
     Stack.withFrozenCallStack startTracingSpan clock name'
       |> andThen newSpanTarget
-  mkTracingHandler requestId clock trackEvent' onFinishRoot target onFinish
+  let traceRoot = TraceRoot {rootTarget = target, reportRoot = onFinishRoot}
+  mkTracingHandler requestId clock trackEvent' traceRoot target onFinish
 
--- | Construct the handler for a child span of the span behind `parentTarget`.
--- A child completing after its parent already finished is dropped.
+-- | Construct the handler for a child span of the span behind `parentTarget`,
+-- belonging to the trace of `traceRoot`.
 mkChildHandler ::
   (Stack.HasCallStack) =>
   Text ->
   Clock ->
   (Aeson.Value -> Task Never ()) ->
-  (TracingSpan -> IO ()) ->
+  TraceRoot ->
   SpanTarget ->
   Text ->
   IO LogHandler
-mkChildHandler requestId clock trackEvent' onFinishRoot parentTarget name' = do
+mkChildHandler requestId clock trackEvent' traceRoot parentTarget name' = do
   target <-
     Stack.withFrozenCallStack startTracingSpan clock name'
       |> andThen newSpanTarget
-  mkTracingHandler
-    requestId
-    clock
-    trackEvent'
-    onFinishRoot
-    target
-    ( \child -> do
-        _ <- tryAttach parentTarget child
-        pure ()
-    )
+  mkTracingHandler requestId clock trackEvent' traceRoot target (completeChild traceRoot parentTarget)
 
 -- | Shared plumbing of `mkHandler` and `mkChildHandler`: the two only differ
 -- in what happens to the completed span (report it as a trace root, or attach
@@ -717,17 +729,17 @@ mkTracingHandler ::
   Text ->
   Clock ->
   (Aeson.Value -> Task Never ()) ->
-  (TracingSpan -> IO ()) ->
+  TraceRoot ->
   SpanTarget ->
   (TracingSpan -> IO ()) ->
   IO LogHandler
-mkTracingHandler requestId clock trackEvent' onFinishRoot target complete = do
+mkTracingHandler requestId clock trackEvent' traceRoot target complete = do
   allocationCounterStartVal <- System.Mem.getAllocationCounter
   pure
     LogHandler
       { requestId,
-        startChildTracingSpan = mkChildHandler requestId clock trackEvent' onFinishRoot target,
-        startNewRoot = mkHandler requestId clock trackEvent' onFinishRoot Nothing,
+        startChildTracingSpan = mkChildHandler requestId clock trackEvent' traceRoot target,
+        startNewRoot = mkHandler requestId clock trackEvent' (reportRoot traceRoot) Nothing,
         setTracingSpanDetailsIO = \details' ->
           modifyOpenSpan
             target

--- a/nri-prelude/src/Platform/Internal.hs
+++ b/nri-prelude/src/Platform/Internal.hs
@@ -600,10 +600,9 @@ silentTrack _ = Task (\_ -> pure (Ok ()))
 data SpanState
   = -- Initial state of a tracing span. Accepts children and detail mutations
     Open TracingSpan
-  | -- Span stops accepting children and its stats are being calculated
-    Closing
-  | -- Span has been finalized and will take no further changes
-    Finished
+  | -- Span has begun finalizing and will take no further changes. The span
+    -- data now lives with the finalizing caller, not in this state.
+    Closed
 
 -- | The mutable attachment point for a single span.
 newtype SpanTarget = SpanTarget (IORef.IORef SpanState)
@@ -629,13 +628,8 @@ beginFinish :: SpanTarget -> IO (Maybe TracingSpan)
 beginFinish (SpanTarget ref) =
   IORef.atomicModifyIORef' ref <| \state ->
     case state of
-      Open tracingSpan' -> (Closing, Just tracingSpan')
-      Closing -> (Closing, Nothing)
-      Finished -> (Finished, Nothing)
-
-markFinished :: SpanTarget -> IO ()
-markFinished (SpanTarget ref) =
-  IORef.atomicWriteIORef ref Finished
+      Open tracingSpan' -> (Closed, Just tracingSpan')
+      Closed -> (Closed, Nothing)
 
 -- | Attach a completed child to a span, if that span is still accepting
 -- children. Together with 'beginFinish' this forms the linearization point of
@@ -649,8 +643,7 @@ tryAttach (SpanTarget ref) child =
         -- Note child tracingSpans are consed to the front of the list, so
         -- children are ordered new-to-old.
         (Open parent {children = child : children parent}, True)
-      Closing -> (Closing, False)
-      Finished -> (Finished, False)
+      Closed -> (Closed, False)
 
 -- | Apply a mutation to a span that is still open. Spans that have begun
 -- finalization no longer change: mutating them would be invisible in the
@@ -660,8 +653,7 @@ modifyOpenSpan (SpanTarget ref) f =
   IORef.atomicModifyIORef' ref <| \state ->
     case state of
       Open tracingSpan' -> (Open (f tracingSpan'), ())
-      Closing -> (Closing, ())
-      Finished -> (Finished, ())
+      Closed -> (Closed, ())
 
 -- | Hand off a completed non-root span.
 completeChild :: TraceRoot -> SpanTarget -> TracingSpan -> IO ()
@@ -755,10 +747,6 @@ mkTracingHandler requestId clock trackEvent' traceRoot target onComplete = do
             Nothing -> pure ()
             Just draft -> do
               completed <- finalizeTracingSpan clock allocationCounterStartVal draft maybeException
-              -- The span must read as finished before the completion callback
-              -- runs, so concurrent operations never see a reported span as
-              -- still accepting children, even if the callback throws.
-              markFinished target
               onComplete completed,
         trackAnalyticsEvent = trackEvent'
       }

--- a/nri-prelude/src/Platform/Internal.hs
+++ b/nri-prelude/src/Platform/Internal.hs
@@ -737,7 +737,7 @@ mkTracingHandler ::
   SpanTarget ->
   (TracingSpan -> IO ()) ->
   IO LogHandler
-mkTracingHandler requestId clock trackEvent' traceRoot target complete = do
+mkTracingHandler requestId clock trackEvent' traceRoot target onComplete = do
   allocationCounterStartVal <- System.Mem.getAllocationCounter
   pure
     LogHandler
@@ -766,7 +766,7 @@ mkTracingHandler requestId clock trackEvent' traceRoot target complete = do
               -- runs, so concurrent operations never see a reported span as
               -- still accepting children, even if the callback throws.
               markFinished target
-              complete completed,
+              onComplete completed,
         trackAnalyticsEvent = trackEvent'
       }
 

--- a/nri-prelude/src/Platform/Internal.hs
+++ b/nri-prelude/src/Platform/Internal.hs
@@ -612,7 +612,8 @@ newtype SpanTarget = SpanTarget (IORef.IORef SpanState)
 
 -- | The trace a handler belongs to. A late span -- one finishing after its
 -- intended parent already finished -- is reparented to 'rootTarget' if the
--- root is still open. That is preferable to silently dropping it, which is
+-- root is still open, and otherwise reported through 'reportRoot' as a
+-- separate root span. Either is preferable to silently dropping it, which is
 -- what used to happen when a captured handler outlived its span.
 data TraceRoot = TraceRoot
   { rootTarget :: SpanTarget,
@@ -667,16 +668,19 @@ modifyOpenSpan (SpanTarget ref) f =
       Closing -> (Closing, ())
       Finished -> (Finished, ())
 
--- | Hand off a completed non-root span: preferably to its intended parent, or
--- to the trace root if the parent has already finished.
+-- | Hand off a completed non-root span: preferably to its intended parent, to
+-- the trace root if the parent has already finished, or through the root
+-- reporter as a separate root span if the whole trace has already closed.
 completeChild :: TraceRoot -> SpanTarget -> TracingSpan -> IO ()
 completeChild traceRoot intendedParent child = do
   attached <- tryAttach intendedParent child
   if attached
     then pure ()
     else do
-      _ <- tryAttach (rootTarget traceRoot) child
-      pure ()
+      attachedToRoot <- tryAttach (rootTarget traceRoot) child
+      if attachedToRoot
+        then pure ()
+        else reportRoot traceRoot child
 
 -- | Helper that creates one of the handler's above. This is intended for
 -- internal use in this library only and not for exposing. Outside of this

--- a/nri-prelude/tests/PlatformSpec.hs
+++ b/nri-prelude/tests/PlatformSpec.hs
@@ -178,6 +178,36 @@ lateSpanReparentingTests =
           childNames rootSpan |> Expect.equal ["child", "parent"]
           Expect.true (Platform.containsFailures rootSpan)
         _ -> Expect.fail "expected exactly one reported root span",
+    test "child finishing after the root closed is reported as a separate root" <| \_ -> do
+      reported <-
+        Expect.fromIO <| do
+          reportedRef <- IORef.newIORef []
+          childVar <- MVar.newEmptyMVar
+          Platform.rootTracingSpanIO
+            "test-request"
+            Platform.silentTrack
+            (\span -> IORef.modifyIORef' reportedRef (\spans -> spans ++ [span]))
+            "root"
+            ( \root -> do
+                child <- Platform.Internal.startChildTracingSpan root "late-child"
+                MVar.putMVar childVar child
+            )
+          child <- MVar.takeMVar childVar
+          Platform.Internal.finishTracingSpan child Nothing
+          IORef.readIORef reportedRef
+      List.map Platform.Internal.name reported |> Expect.equal ["root", "late-child"]
+      case reported of
+        [rootSpan, _] -> childNames rootSpan |> Expect.equal []
+        _ -> Expect.fail "expected exactly two reported root spans",
+    test "repeated finalization attaches the span only once" <| \_ -> do
+      reported <-
+        reportedSpansFor <| \root -> do
+          parent <- Platform.Internal.startChildTracingSpan root "parent"
+          Platform.Internal.finishTracingSpan parent Nothing
+          Platform.Internal.finishTracingSpan parent Nothing
+      case reported of
+        [rootSpan] -> childNames rootSpan |> Expect.equal ["parent"]
+        _ -> Expect.fail "expected exactly one reported root span",
     test "late children inside Platform.newRoot reparent to the new root, not the surrounding trace" <| \_ -> do
       reported <-
         reportedSpansFor <| \root -> do
@@ -193,15 +223,6 @@ lateSpanReparentingTests =
           childNames newRootSpan |> Expect.equal ["inner-parent", "late-child"]
           childNames rootSpan |> Expect.equal []
         _ -> Expect.fail "expected exactly two reported root spans",
-    test "repeated finalization attaches the span only once" <| \_ -> do
-      reported <-
-        reportedSpansFor <| \root -> do
-          parent <- Platform.Internal.startChildTracingSpan root "parent"
-          Platform.Internal.finishTracingSpan parent Nothing
-          Platform.Internal.finishTracingSpan parent Nothing
-      case reported of
-        [rootSpan] -> childNames rootSpan |> Expect.equal ["parent"]
-        _ -> Expect.fail "expected exactly one reported root span",
     test "silent handler remains a no-op for late children" <| \_ -> do
       Expect.fromIO <| do
         child <- Platform.Internal.startChildTracingSpan Platform.Internal.nullHandler "child"

--- a/nri-prelude/tests/PlatformSpec.hs
+++ b/nri-prelude/tests/PlatformSpec.hs
@@ -5,6 +5,7 @@ import Control.Monad.Catch (catchAll)
 import Data.Aeson as Aeson
 import qualified Data.IORef as IORef
 import qualified Expect
+import qualified List
 import qualified Log
 import NriPrelude
 import qualified Platform
@@ -43,14 +44,14 @@ tests =
                     IORef.atomicModifyIORef' ref (\xs -> (v : xs, ()))
                     Prelude.pure (Ok ())
                 )
-        Expect.fromIO
-          <| Platform.rootTracingSpanIO "test-req" track (\_ -> Prelude.pure ()) "root"
-          <| \log -> do
-            child <- Platform.Internal.startChildTracingSpan log "child-span"
-            let Platform.Internal.Task runTrack =
-                  Platform.Internal.trackAnalyticsEvent child (Aeson.toJSON ("hello" :: Text))
-            _ <- runTrack child
-            Prelude.pure ()
+        Expect.fromIO <|
+          Platform.rootTracingSpanIO "test-req" track (\_ -> Prelude.pure ()) "root" <|
+            \log -> do
+              child <- Platform.Internal.startChildTracingSpan log "child-span"
+              let Platform.Internal.Task runTrack =
+                    Platform.Internal.trackAnalyticsEvent child (Aeson.toJSON ("hello" :: Text))
+              _ <- runTrack child
+              Prelude.pure ()
         observed <- Expect.fromIO (IORef.readIORef ref)
         observed |> Expect.equal [Aeson.toJSON ("hello" :: Text)],
       test "nullHandler.trackAnalyticsEvent is a silent no-op" <| \_ -> do
@@ -68,9 +69,9 @@ tests =
                 )
         let event = Aeson.object ["kind" Aeson..= ("LessonStarted" :: Text)]
         result <-
-          Expect.fromIO
-            <| Platform.rootTracingSpanIO "test-req" track (\_ -> Prelude.pure ()) "root"
-            <| \log -> Task.attempt log (Platform.Analytics.Internal.trackEvent event)
+          Expect.fromIO <|
+            Platform.rootTracingSpanIO "test-req" track (\_ -> Prelude.pure ()) "root" <|
+              \log -> Task.attempt log (Platform.Analytics.Internal.trackEvent event)
         case result of
           Ok () -> Expect.pass
           Err _ -> Expect.fail "trackEvent task failed"
@@ -80,17 +81,51 @@ tests =
         spanVar <- Expect.fromIO MVar.newEmptyMVar
         let event = Aeson.object ["kind" Aeson..= ("LessonStarted" :: Text)]
         _ <-
-          Expect.fromIO
-            <| Platform.rootTracingSpanIO "test-req" Platform.silentTrack (MVar.putMVar spanVar) "root"
-            <| \log -> Task.attempt log (Platform.Analytics.Internal.trackEvent event)
+          Expect.fromIO <|
+            Platform.rootTracingSpanIO "test-req" Platform.silentTrack (MVar.putMVar spanVar) "root" <|
+              \log -> Task.attempt log (Platform.Analytics.Internal.trackEvent event)
         root <- Expect.fromIO (MVar.takeMVar spanVar)
         case Prelude.filter (\s -> Platform.Internal.name s == "analytics.track") (Platform.Internal.children root) of
           [child] -> do
             Platform.Internal.name child |> Expect.equal "analytics.track"
             NriPrelude.map Aeson.toJSON (Platform.Internal.details child) |> Expect.equal (Just event)
           [] -> Expect.fail "expected an analytics.track child span; found none"
-          _ -> Expect.fail "expected exactly one analytics.track child span"
+          _ -> Expect.fail "expected exactly one analytics.track child span",
+      describe "late span reparenting" lateSpanReparentingTests
     ]
+
+lateSpanReparentingTests :: List Test
+lateSpanReparentingTests =
+  [ test "child finishing before its parent nests normally" <| \_ -> do
+      reported <-
+        reportedSpansFor <| \root -> do
+          parent <- Platform.Internal.startChildTracingSpan root "parent"
+          child <- Platform.Internal.startChildTracingSpan parent "child"
+          Platform.Internal.finishTracingSpan child Nothing
+          Platform.Internal.finishTracingSpan parent Nothing
+      case reported of
+        [rootSpan] -> do
+          childNames rootSpan |> Expect.equal ["parent"]
+          case Platform.Internal.children rootSpan of
+            [parentSpan] -> childNames parentSpan |> Expect.equal ["child"]
+            _ -> Expect.fail "expected exactly one child under the root"
+        _ -> Expect.fail "expected exactly one reported root span",
+    test "repeated finalization attaches the span only once" <| \_ -> do
+      reported <-
+        reportedSpansFor <| \root -> do
+          parent <- Platform.Internal.startChildTracingSpan root "parent"
+          Platform.Internal.finishTracingSpan parent Nothing
+          Platform.Internal.finishTracingSpan parent Nothing
+      case reported of
+        [rootSpan] -> childNames rootSpan |> Expect.equal ["parent"]
+        _ -> Expect.fail "expected exactly one reported root span",
+    test "silent handler remains a no-op for late children" <| \_ -> do
+      Expect.fromIO <| do
+        child <- Platform.Internal.startChildTracingSpan Platform.Internal.nullHandler "child"
+        Platform.Internal.setTracingSpanSummaryIO child "summary"
+        Platform.Internal.finishTracingSpan child Nothing
+      Expect.pass
+  ]
 
 newtype CustomTracingSpanDetails = CustomTracingSpanDetails Text
   deriving (Aeson.ToJSON, Show, Eq)
@@ -120,3 +155,27 @@ isSucceeded span =
   case Platform.succeeded span of
     Platform.Succeeded -> True
     _ -> False
+
+-- | Run some IO against a root span's handler and collect every span the root
+-- reporter receives, in reporting order.
+reportedSpansForIO :: (Platform.Internal.LogHandler -> Prelude.IO ()) -> Prelude.IO [Platform.TracingSpan]
+reportedSpansForIO run = do
+  reportedRef <- IORef.newIORef []
+  Platform.rootTracingSpanIO
+    "test-request"
+    Platform.silentTrack
+    (\span -> IORef.modifyIORef' reportedRef (\spans -> spans ++ [span]))
+    "root"
+    run
+  IORef.readIORef reportedRef
+
+reportedSpansFor :: (Platform.Internal.LogHandler -> Prelude.IO ()) -> Expect.Expectation' [Platform.TracingSpan]
+reportedSpansFor run = Expect.fromIO (reportedSpansForIO run)
+
+-- | The names of a span's direct children, sorted for order-independent
+-- assertions (children are stored new-to-old).
+childNames :: Platform.TracingSpan -> List Text
+childNames span =
+  Platform.Internal.children span
+    |> List.map Platform.Internal.name
+    |> List.sort

--- a/nri-prelude/tests/PlatformSpec.hs
+++ b/nri-prelude/tests/PlatformSpec.hs
@@ -1,5 +1,6 @@
 module PlatformSpec (tests) where
 
+import qualified Control.Concurrent
 import qualified Control.Concurrent.MVar as MVar
 import Control.Monad.Catch (catchAll)
 import Data.Aeson as Aeson
@@ -110,6 +111,88 @@ lateSpanReparentingTests =
             [parentSpan] -> childNames parentSpan |> Expect.equal ["child"]
             _ -> Expect.fail "expected exactly one child under the root"
         _ -> Expect.fail "expected exactly one reported root span",
+    test "child created after its parent finished is reparented to the root" <| \_ -> do
+      reported <-
+        reportedSpansFor <| \root -> do
+          parent <- Platform.Internal.startChildTracingSpan root "parent"
+          Platform.Internal.finishTracingSpan parent Nothing
+          child <- Platform.Internal.startChildTracingSpan parent "child"
+          Platform.Internal.finishTracingSpan child Nothing
+      case reported of
+        [rootSpan] -> do
+          childNames rootSpan |> Expect.equal ["child", "parent"]
+          rootSpan
+            |> Platform.Internal.children
+            |> List.concatMap Platform.Internal.children
+            |> List.map Platform.Internal.name
+            |> Expect.equal []
+        _ -> Expect.fail "expected exactly one reported root span",
+    test "child started before its parent finished but finishing after is reparented to the root" <| \_ -> do
+      reported <-
+        reportedSpansFor <| \root -> do
+          parent <- Platform.Internal.startChildTracingSpan root "parent"
+          child <- Platform.Internal.startChildTracingSpan parent "child"
+          Platform.Internal.finishTracingSpan parent Nothing
+          Platform.Internal.finishTracingSpan child Nothing
+      case reported of
+        [rootSpan] -> childNames rootSpan |> Expect.equal ["child", "parent"]
+        _ -> Expect.fail "expected exactly one reported root span",
+    test "racing parent and child finalization never loses or duplicates the child" <| \_ -> do
+      counts <-
+        Expect.fromIO <|
+          Prelude.mapM
+            ( \_ -> do
+                reported <-
+                  reportedSpansForIO <| \root -> do
+                    parent <- Platform.Internal.startChildTracingSpan root "parent"
+                    child <- Platform.Internal.startChildTracingSpan parent "child"
+                    parentDone <- MVar.newEmptyMVar
+                    childDone <- MVar.newEmptyMVar
+                    _ <-
+                      Control.Concurrent.forkIO <| do
+                        Platform.Internal.finishTracingSpan parent Nothing
+                        MVar.putMVar parentDone ()
+                    _ <-
+                      Control.Concurrent.forkIO <| do
+                        Platform.Internal.finishTracingSpan child Nothing
+                        MVar.putMVar childDone ()
+                    MVar.takeMVar parentDone
+                    MVar.takeMVar childDone
+                reported
+                  |> List.concatMap (descendantsNamed "child")
+                  |> List.length
+                  |> Prelude.pure
+            )
+            (List.range 1 200)
+      counts |> Expect.equal (List.repeat 200 1),
+    test "failed reparented child marks the root as containing failures" <| \_ -> do
+      reported <-
+        reportedSpansFor <| \root -> do
+          parent <- Platform.Internal.startChildTracingSpan root "parent"
+          Platform.Internal.finishTracingSpan parent Nothing
+          child <- Platform.Internal.startChildTracingSpan parent "child"
+          Platform.Internal.markTracingSpanFailedIO child
+          Platform.Internal.finishTracingSpan child Nothing
+      case reported of
+        [rootSpan] -> do
+          childNames rootSpan |> Expect.equal ["child", "parent"]
+          Expect.true (Platform.containsFailures rootSpan)
+        _ -> Expect.fail "expected exactly one reported root span",
+    test "late children inside Platform.newRoot reparent to the new root, not the surrounding trace" <| \_ -> do
+      reported <-
+        reportedSpansFor <| \root -> do
+          newRootHandler <- Platform.Internal.startNewRoot root "new-root"
+          parent <- Platform.Internal.startChildTracingSpan newRootHandler "inner-parent"
+          Platform.Internal.finishTracingSpan parent Nothing
+          child <- Platform.Internal.startChildTracingSpan parent "late-child"
+          Platform.Internal.finishTracingSpan child Nothing
+          Platform.Internal.finishTracingSpan newRootHandler Nothing
+      List.map Platform.Internal.name reported |> Expect.equal ["new-root", "root"]
+      case reported of
+        [newRootSpan, rootSpan] -> do
+          childNames newRootSpan |> Expect.equal ["inner-parent", "late-child"]
+          childNames rootSpan |> Expect.equal []
+        _ -> Expect.fail "expected exactly two reported root spans",
     test "repeated finalization attaches the span only once" <| \_ -> do
       reported <-
         reportedSpansFor <| \root -> do
@@ -179,3 +262,10 @@ childNames span =
   Platform.Internal.children span
     |> List.map Platform.Internal.name
     |> List.sort
+
+descendantsNamed :: Text -> Platform.TracingSpan -> List Platform.TracingSpan
+descendantsNamed name span =
+  let rest = List.concatMap (descendantsNamed name) (Platform.Internal.children span)
+   in if Platform.Internal.name span == name
+        then span : rest
+        else rest


### PR DESCRIPTION
A child span can end after its parent span has ended. This can happen in a few scenarios:

- a thread started inside a span and joined outside it
- fire-and-forget tasks
- lazy streaming values created inside a Task but consumed after it returns

In these cases, the child was getting lost, because it was being attached to a parent that had already been copied out of its `IORef` and into its parent.

The solution we found is:

- detecting when this happens
- trying to reparent to the root span
- promoting the child to a new root if the root itself is closed

Alternatively, we could have added support for attaching children to finished parents, by keeping `IORef`s around until the root is processed. That was a much more invasive change, and for the use-case we're handling while we hit this, reparenting to root looks good, so I decided to go with that.

ps: i have tested integrating this into the NoRedInk monorepo pre-merge and have confirmed the fix