### PR TITLE
nri-redis: add zcard, zrem, zremrangebyscore to Redis.SortedSet

### DIFF
--- a/nri-redis/CHANGELOG.md
+++ b/nri-redis/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.2.0
+
+- Adds `zcard`, `zrem`, and `zremrangebyscore` to `Redis.SortedSet`.
+
 # 0.4.1.1
 
 - Require `nri-prelude >= 0.7.0.0`

--- a/nri-redis/CHANGELOG.md
+++ b/nri-redis/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.4.2.0
 
-- Adds `zcard`, `zrem`, and `zremrangebyscore` to `Redis.SortedSet`.
+- Adds `zcard`, `zrem`, and `zremRangeByScore` to `Redis.SortedSet`.
 
 # 0.4.1.1
 

--- a/nri-redis/nri-redis.cabal
+++ b/nri-redis/nri-redis.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           nri-redis
-version:        0.4.1.1
+version:        0.4.2.0
 synopsis:       An intuitive hedis wrapper library.
 description:    Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-redis#readme>.
 category:       Web

--- a/nri-redis/package.yaml
+++ b/nri-redis/package.yaml
@@ -3,7 +3,7 @@ synopsis: An intuitive hedis wrapper library.
 description: Please see the README at <https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-redis#readme>.
 homepage: https://github.com/NoRedInk/haskell-libraries/tree/trunk/nri-redis#readme
 author: NoRedInk
-version: 0.4.1.1
+version: 0.4.2.0
 maintainer: haskell-open-source@noredink.com
 copyright: 2026 NoRedInk Corp.
 github: NoRedInk/haskell-libraries/nri-redis

--- a/nri-redis/src/Redis/Handler.hs
+++ b/nri-redis/src/Redis/Handler.hs
@@ -352,7 +352,7 @@ doRawQuery query =
       Database.Redis.zrem (toB key) (NonEmpty.toList vals)
         |> PreparedQuery
         |> map (Ok << Prelude.fromIntegral)
-    Internal.Zremrangebyscore key lower upper ->
+    Internal.ZremRangeByScore key lower upper ->
       Database.Redis.zremrangebyscore (toB key) lower upper
         |> PreparedQuery
         |> map (Ok << Prelude.fromIntegral)

--- a/nri-redis/src/Redis/Handler.hs
+++ b/nri-redis/src/Redis/Handler.hs
@@ -348,6 +348,10 @@ doRawQuery query =
       Database.Redis.zrank (toB key) member
         |> PreparedQuery
         |> map (Ok << map Prelude.fromIntegral)
+    Internal.Zremrangebyscore key lower upper ->
+      Database.Redis.zremrangebyscore (toB key) lower upper
+        |> PreparedQuery
+        |> map (Ok << Prelude.fromIntegral)
     Internal.Zrevrank key member ->
       Database.Redis.zrevrank (toB key) member
         |> PreparedQuery

--- a/nri-redis/src/Redis/Handler.hs
+++ b/nri-redis/src/Redis/Handler.hs
@@ -348,6 +348,10 @@ doRawQuery query =
       Database.Redis.zrank (toB key) member
         |> PreparedQuery
         |> map (Ok << map Prelude.fromIntegral)
+    Internal.Zrem key vals ->
+      Database.Redis.zrem (toB key) (NonEmpty.toList vals)
+        |> PreparedQuery
+        |> map (Ok << Prelude.fromIntegral)
     Internal.Zremrangebyscore key lower upper ->
       Database.Redis.zremrangebyscore (toB key) lower upper
         |> PreparedQuery

--- a/nri-redis/src/Redis/Handler.hs
+++ b/nri-redis/src/Redis/Handler.hs
@@ -326,6 +326,10 @@ doRawQuery query =
         |> Database.Redis.zadd (toB key)
         |> PreparedQuery
         |> map (Ok << Prelude.fromIntegral)
+    Internal.Zcard key ->
+      Database.Redis.zcard (toB key)
+        |> PreparedQuery
+        |> map (Ok << Prelude.fromIntegral)
     Internal.Zrange key start stop ->
       Database.Redis.zrange
         (toB key)

--- a/nri-redis/src/Redis/Internal.hs
+++ b/nri-redis/src/Redis/Internal.hs
@@ -121,6 +121,7 @@ cmds query'' =
     Zrange key start stop -> [unwords ["ZRANGE", key, Text.fromInt start, Text.fromInt stop]]
     ZrangeByScoreWithScores key start stop -> [unwords ["ZRANGE", key, "BYSCORE", Text.fromFloat start, Text.fromFloat stop, "WITHSCORES"]]
     Zrank key _ -> [unwords ["ZRANK", key, "*****"]]
+    Zrem key vals -> [unwords ("ZREM" : key : List.map (\_ -> "*****") (NonEmpty.toList vals))]
     Zremrangebyscore key lower upper -> [unwords ["ZREMRANGEBYSCORE", key, Text.fromFloat lower, Text.fromFloat upper]]
     Zrevrank key _ -> [unwords ["ZREVRANK", key, "*****"]]
     Pure _ -> []
@@ -181,6 +182,7 @@ data Query a where
   Zrange :: Text -> Int -> Int -> Query [ByteString]
   ZrangeByScoreWithScores :: Text -> Float -> Float -> Query [(ByteString, Float)]
   Zrank :: Text -> ByteString -> Query (Maybe Int)
+  Zrem :: Text -> NonEmpty ByteString -> Query Int
   Zremrangebyscore :: Text -> Float -> Float -> Query Int
   Zrevrank :: Text -> ByteString -> Query (Maybe Int)
   -- The constructors below are not Redis-related, but support using functions
@@ -337,6 +339,7 @@ mapKeys fn query' =
     Zrange key start stop -> Task.map (\newKey -> Zrange newKey start stop) (fn key)
     ZrangeByScoreWithScores key start stop -> Task.map (\newKey -> ZrangeByScoreWithScores newKey start stop) (fn key)
     Zrank key member -> Task.map (\newKey -> Zrank newKey member) (fn key)
+    Zrem key vals -> Task.map (\newKey -> Zrem newKey vals) (fn key)
     Zremrangebyscore key lower upper -> Task.map (\newKey -> Zremrangebyscore newKey lower upper) (fn key)
     Zrevrank key member -> Task.map (\newKey -> Zrevrank newKey member) (fn key)
     Pure x -> Task.succeed (Pure x)
@@ -383,6 +386,7 @@ mapReturnedKeys fn query' =
     Zrange key start stop -> Zrange key start stop
     ZrangeByScoreWithScores key start stop -> ZrangeByScoreWithScores key start stop
     Zrank key member -> Zrank key member
+    Zrem key vals -> Zrem key vals
     Zremrangebyscore key lower upper -> Zremrangebyscore key lower upper
     Zrevrank key member -> Zrevrank key member
     Pure x -> Pure x
@@ -446,6 +450,7 @@ keysTouchedByQuery query' =
     Zrange key _ _ -> Set.singleton key
     ZrangeByScoreWithScores key _ _ -> Set.singleton key
     Zrank key _ -> Set.singleton key
+    Zrem key _ -> Set.singleton key
     Zremrangebyscore key _ _ -> Set.singleton key
     Zrevrank key _ -> Set.singleton key
     WithResult _ q -> keysTouchedByQuery q

--- a/nri-redis/src/Redis/Internal.hs
+++ b/nri-redis/src/Redis/Internal.hs
@@ -121,6 +121,7 @@ cmds query'' =
     Zrange key start stop -> [unwords ["ZRANGE", key, Text.fromInt start, Text.fromInt stop]]
     ZrangeByScoreWithScores key start stop -> [unwords ["ZRANGE", key, "BYSCORE", Text.fromFloat start, Text.fromFloat stop, "WITHSCORES"]]
     Zrank key _ -> [unwords ["ZRANK", key, "*****"]]
+    Zremrangebyscore key lower upper -> [unwords ["ZREMRANGEBYSCORE", key, Text.fromFloat lower, Text.fromFloat upper]]
     Zrevrank key _ -> [unwords ["ZREVRANK", key, "*****"]]
     Pure _ -> []
     Apply f x -> cmds f ++ cmds x
@@ -180,6 +181,7 @@ data Query a where
   Zrange :: Text -> Int -> Int -> Query [ByteString]
   ZrangeByScoreWithScores :: Text -> Float -> Float -> Query [(ByteString, Float)]
   Zrank :: Text -> ByteString -> Query (Maybe Int)
+  Zremrangebyscore :: Text -> Float -> Float -> Query Int
   Zrevrank :: Text -> ByteString -> Query (Maybe Int)
   -- The constructors below are not Redis-related, but support using functions
   -- like `map` and `map2` on queries.
@@ -335,6 +337,7 @@ mapKeys fn query' =
     Zrange key start stop -> Task.map (\newKey -> Zrange newKey start stop) (fn key)
     ZrangeByScoreWithScores key start stop -> Task.map (\newKey -> ZrangeByScoreWithScores newKey start stop) (fn key)
     Zrank key member -> Task.map (\newKey -> Zrank newKey member) (fn key)
+    Zremrangebyscore key lower upper -> Task.map (\newKey -> Zremrangebyscore newKey lower upper) (fn key)
     Zrevrank key member -> Task.map (\newKey -> Zrevrank newKey member) (fn key)
     Pure x -> Task.succeed (Pure x)
     Apply f x -> Task.map2 Apply (mapKeys fn f) (mapKeys fn x)
@@ -380,6 +383,7 @@ mapReturnedKeys fn query' =
     Zrange key start stop -> Zrange key start stop
     ZrangeByScoreWithScores key start stop -> ZrangeByScoreWithScores key start stop
     Zrank key member -> Zrank key member
+    Zremrangebyscore key lower upper -> Zremrangebyscore key lower upper
     Zrevrank key member -> Zrevrank key member
     Pure x -> Pure x
     Apply f x -> Apply (mapReturnedKeys fn f) (mapReturnedKeys fn x)
@@ -442,6 +446,7 @@ keysTouchedByQuery query' =
     Zrange key _ _ -> Set.singleton key
     ZrangeByScoreWithScores key _ _ -> Set.singleton key
     Zrank key _ -> Set.singleton key
+    Zremrangebyscore key _ _ -> Set.singleton key
     Zrevrank key _ -> Set.singleton key
     WithResult _ q -> keysTouchedByQuery q
 

--- a/nri-redis/src/Redis/Internal.hs
+++ b/nri-redis/src/Redis/Internal.hs
@@ -122,7 +122,7 @@ cmds query'' =
     ZrangeByScoreWithScores key start stop -> [unwords ["ZRANGE", key, "BYSCORE", Text.fromFloat start, Text.fromFloat stop, "WITHSCORES"]]
     Zrank key _ -> [unwords ["ZRANK", key, "*****"]]
     Zrem key vals -> [unwords ("ZREM" : key : List.map (\_ -> "*****") (NonEmpty.toList vals))]
-    Zremrangebyscore key lower upper -> [unwords ["ZREMRANGEBYSCORE", key, Text.fromFloat lower, Text.fromFloat upper]]
+    ZremRangeByScore key lower upper -> [unwords ["ZREMRANGEBYSCORE", key, Text.fromFloat lower, Text.fromFloat upper]]
     Zrevrank key _ -> [unwords ["ZREVRANK", key, "*****"]]
     Pure _ -> []
     Apply f x -> cmds f ++ cmds x
@@ -183,7 +183,7 @@ data Query a where
   ZrangeByScoreWithScores :: Text -> Float -> Float -> Query [(ByteString, Float)]
   Zrank :: Text -> ByteString -> Query (Maybe Int)
   Zrem :: Text -> NonEmpty ByteString -> Query Int
-  Zremrangebyscore :: Text -> Float -> Float -> Query Int
+  ZremRangeByScore :: Text -> Float -> Float -> Query Int
   Zrevrank :: Text -> ByteString -> Query (Maybe Int)
   -- The constructors below are not Redis-related, but support using functions
   -- like `map` and `map2` on queries.
@@ -340,7 +340,7 @@ mapKeys fn query' =
     ZrangeByScoreWithScores key start stop -> Task.map (\newKey -> ZrangeByScoreWithScores newKey start stop) (fn key)
     Zrank key member -> Task.map (\newKey -> Zrank newKey member) (fn key)
     Zrem key vals -> Task.map (\newKey -> Zrem newKey vals) (fn key)
-    Zremrangebyscore key lower upper -> Task.map (\newKey -> Zremrangebyscore newKey lower upper) (fn key)
+    ZremRangeByScore key lower upper -> Task.map (\newKey -> ZremRangeByScore newKey lower upper) (fn key)
     Zrevrank key member -> Task.map (\newKey -> Zrevrank newKey member) (fn key)
     Pure x -> Task.succeed (Pure x)
     Apply f x -> Task.map2 Apply (mapKeys fn f) (mapKeys fn x)
@@ -387,7 +387,7 @@ mapReturnedKeys fn query' =
     ZrangeByScoreWithScores key start stop -> ZrangeByScoreWithScores key start stop
     Zrank key member -> Zrank key member
     Zrem key vals -> Zrem key vals
-    Zremrangebyscore key lower upper -> Zremrangebyscore key lower upper
+    ZremRangeByScore key lower upper -> ZremRangeByScore key lower upper
     Zrevrank key member -> Zrevrank key member
     Pure x -> Pure x
     Apply f x -> Apply (mapReturnedKeys fn f) (mapReturnedKeys fn x)
@@ -451,7 +451,7 @@ keysTouchedByQuery query' =
     ZrangeByScoreWithScores key _ _ -> Set.singleton key
     Zrank key _ -> Set.singleton key
     Zrem key _ -> Set.singleton key
-    Zremrangebyscore key _ _ -> Set.singleton key
+    ZremRangeByScore key _ _ -> Set.singleton key
     Zrevrank key _ -> Set.singleton key
     WithResult _ q -> keysTouchedByQuery q
 

--- a/nri-redis/src/Redis/Internal.hs
+++ b/nri-redis/src/Redis/Internal.hs
@@ -117,6 +117,7 @@ cmds query'' =
     Smembers key -> [unwords ["SMEMBERS", key]]
     Ttl key -> [unwords ["TTL", key]]
     Zadd key vals -> [unwords ("ZADD" : key : List.concatMap (\(_, val) -> ["*****", Text.fromFloat val]) (Dict.toList vals))]
+    Zcard key -> [unwords ["ZCARD", key]]
     Zrange key start stop -> [unwords ["ZRANGE", key, Text.fromInt start, Text.fromInt stop]]
     ZrangeByScoreWithScores key start stop -> [unwords ["ZRANGE", key, "BYSCORE", Text.fromFloat start, Text.fromFloat stop, "WITHSCORES"]]
     Zrank key _ -> [unwords ["ZRANK", key, "*****"]]
@@ -175,6 +176,7 @@ data Query a where
   Smembers :: Text -> Query (List ByteString)
   Ttl :: Text -> Query Int
   Zadd :: Text -> Dict.Dict ByteString Float -> Query Int
+  Zcard :: Text -> Query Int
   Zrange :: Text -> Int -> Int -> Query [ByteString]
   ZrangeByScoreWithScores :: Text -> Float -> Float -> Query [(ByteString, Float)]
   Zrank :: Text -> ByteString -> Query (Maybe Int)
@@ -329,6 +331,7 @@ mapKeys fn query' =
     Smembers key -> Task.map Smembers (fn key)
     Ttl key -> Task.map Ttl (fn key)
     Zadd key vals -> Task.map (\newKey -> Zadd newKey vals) (fn key)
+    Zcard key -> Task.map Zcard (fn key)
     Zrange key start stop -> Task.map (\newKey -> Zrange newKey start stop) (fn key)
     ZrangeByScoreWithScores key start stop -> Task.map (\newKey -> ZrangeByScoreWithScores newKey start stop) (fn key)
     Zrank key member -> Task.map (\newKey -> Zrank newKey member) (fn key)
@@ -373,6 +376,7 @@ mapReturnedKeys fn query' =
     Smembers key -> Smembers key
     Ttl key -> Ttl key
     Zadd key vals -> Zadd key vals
+    Zcard key -> Zcard key
     Zrange key start stop -> Zrange key start stop
     ZrangeByScoreWithScores key start stop -> ZrangeByScoreWithScores key start stop
     Zrank key member -> Zrank key member
@@ -434,6 +438,7 @@ keysTouchedByQuery query' =
     -- so it doesn't auto-extending the TTL.
     Ttl _ -> Set.empty
     Zadd key _ -> Set.singleton key
+    Zcard key -> Set.singleton key
     Zrange key _ _ -> Set.singleton key
     ZrangeByScoreWithScores key _ _ -> Set.singleton key
     Zrank key _ -> Set.singleton key

--- a/nri-redis/src/Redis/SortedSet.hs
+++ b/nri-redis/src/Redis/SortedSet.hs
@@ -181,6 +181,6 @@ makeApi Codec.Codec {Codec.codecEncoder, Codec.codecDecoder} toKey =
             ),
       zrank = \key member -> Internal.Zrank (toKey key) (codecEncoder member),
       zrem = \key vals -> Internal.Zrem (toKey key) (NonEmpty.map codecEncoder vals),
-      zremrangebyscore = \key lower upper -> Internal.Zremrangebyscore (toKey key) lower upper,
+      zremrangebyscore = \key lower upper -> Internal.ZremRangeByScore (toKey key) lower upper,
       zrevrank = \key member -> Internal.Zrevrank (toKey key) (codecEncoder member)
     }

--- a/nri-redis/src/Redis/SortedSet.hs
+++ b/nri-redis/src/Redis/SortedSet.hs
@@ -29,6 +29,7 @@ module Redis.SortedSet
     zrange,
     zrangeByScoreWithScores,
     zrank,
+    zrem,
     zremrangebyscore,
     zrevrank,
 
@@ -113,6 +114,11 @@ data Api key a = Api
     --
     -- https://redis.io/commands/zrank
     zrank :: key -> a -> Internal.Query (Maybe Int),
+    -- | Removes the specified members from the sorted set. Members that are
+    -- not part of the set are ignored. Returns the number of members removed.
+    --
+    -- https://redis.io/commands/zrem
+    zrem :: key -> NonEmpty a -> Internal.Query Int,
     -- | Removes all members in the sorted set with a score between the two
     -- bounds (inclusive). Returns the number of members removed.
     --
@@ -174,6 +180,7 @@ makeApi Codec.Codec {Codec.codecEncoder, Codec.codecDecoder} toKey =
                 )
             ),
       zrank = \key member -> Internal.Zrank (toKey key) (codecEncoder member),
+      zrem = \key vals -> Internal.Zrem (toKey key) (NonEmpty.map codecEncoder vals),
       zremrangebyscore = \key lower upper -> Internal.Zremrangebyscore (toKey key) lower upper,
       zrevrank = \key member -> Internal.Zrevrank (toKey key) (codecEncoder member)
     }

--- a/nri-redis/src/Redis/SortedSet.hs
+++ b/nri-redis/src/Redis/SortedSet.hs
@@ -29,6 +29,7 @@ module Redis.SortedSet
     zrange,
     zrangeByScoreWithScores,
     zrank,
+    zremrangebyscore,
     zrevrank,
 
     -- * Running Redis queries
@@ -112,6 +113,11 @@ data Api key a = Api
     --
     -- https://redis.io/commands/zrank
     zrank :: key -> a -> Internal.Query (Maybe Int),
+    -- | Removes all members in the sorted set with a score between the two
+    -- bounds (inclusive). Returns the number of members removed.
+    --
+    -- https://redis.io/commands/zremrangebyscore
+    zremrangebyscore :: key -> Float -> Float -> Internal.Query Int,
     -- | Returns the rank of member in the sorted set stored at key, with the
     -- scores ordered from high to low. The rank (or index) is 0-based, which
     -- means that the member with the highest score has rank 0.
@@ -168,5 +174,6 @@ makeApi Codec.Codec {Codec.codecEncoder, Codec.codecDecoder} toKey =
                 )
             ),
       zrank = \key member -> Internal.Zrank (toKey key) (codecEncoder member),
+      zremrangebyscore = \key lower upper -> Internal.Zremrangebyscore (toKey key) lower upper,
       zrevrank = \key member -> Internal.Zrevrank (toKey key) (codecEncoder member)
     }

--- a/nri-redis/src/Redis/SortedSet.hs
+++ b/nri-redis/src/Redis/SortedSet.hs
@@ -25,6 +25,7 @@ module Redis.SortedSet
     expire,
     ping,
     zadd,
+    zcard,
     zrange,
     zrangeByScoreWithScores,
     zrank,
@@ -82,6 +83,10 @@ data Api key a = Api
     --
     -- https://redis.io/commands/zadd
     zadd :: key -> NonEmptyDict.NonEmptyDict a Float -> Internal.Query Int,
+    -- | Returns the number of members of the sorted set.
+    --
+    -- https://redis.io/commands/zcard
+    zcard :: key -> Internal.Query Int,
     -- | Returns the specified range of elements in the sorted set. The order of
     -- elements is from the lowest to the highest score. Elements with the same
     -- score are ordered lexicographically. The <start> and <stop> arguments
@@ -150,6 +155,7 @@ makeApi Codec.Codec {Codec.codecEncoder, Codec.codecDecoder} toKey =
       ping = Internal.Ping |> map (\_ -> ()),
       zadd = \key vals ->
         Internal.Zadd (toKey key) (Data.Map.Strict.mapKeys codecEncoder (NonEmptyDict.toDict vals)),
+      zcard = \key -> Internal.Zcard (toKey key),
       zrange = \key start stop ->
         Internal.Zrange (toKey key) start stop
           |> Internal.WithResult (Prelude.traverse codecDecoder),

--- a/nri-redis/src/Redis/SortedSet.hs
+++ b/nri-redis/src/Redis/SortedSet.hs
@@ -30,7 +30,7 @@ module Redis.SortedSet
     zrangeByScoreWithScores,
     zrank,
     zrem,
-    zremrangebyscore,
+    zremRangeByScore,
     zrevrank,
 
     -- * Running Redis queries
@@ -123,7 +123,7 @@ data Api key a = Api
     -- bounds (inclusive). Returns the number of members removed.
     --
     -- https://redis.io/commands/zremrangebyscore
-    zremrangebyscore :: key -> Float -> Float -> Internal.Query Int,
+    zremRangeByScore :: key -> Float -> Float -> Internal.Query Int,
     -- | Returns the rank of member in the sorted set stored at key, with the
     -- scores ordered from high to low. The rank (or index) is 0-based, which
     -- means that the member with the highest score has rank 0.
@@ -181,6 +181,6 @@ makeApi Codec.Codec {Codec.codecEncoder, Codec.codecDecoder} toKey =
             ),
       zrank = \key member -> Internal.Zrank (toKey key) (codecEncoder member),
       zrem = \key vals -> Internal.Zrem (toKey key) (NonEmpty.map codecEncoder vals),
-      zremrangebyscore = \key lower upper -> Internal.ZremRangeByScore (toKey key) lower upper,
+      zremRangeByScore = \key lower upper -> Internal.ZremRangeByScore (toKey key) lower upper,
       zrevrank = \key member -> Internal.Zrevrank (toKey key) (codecEncoder member)
     }

--- a/nri-redis/test/Spec/Redis.hs
+++ b/nri-redis/test/Spec/Redis.hs
@@ -358,6 +358,23 @@ queryTests redisHandler =
       Redis.SortedSet.zcard sortedSetApi "zcard-missing-key"
         |> Redis.query redisHandler
         |> Expect.andCheck (Expect.equal 0),
+    Test.test "zremrangebyscore removes members in the inclusive score range" <| \() -> do
+      _ <-
+        Redis.SortedSet.del sortedSetApi ("zremrangebyscore-trims" :| [])
+          |> Redis.query redisHandler
+          |> Expect.succeeds
+      _ <-
+        NonEmptyDict.init "one" 1 (Dict.fromList [("two", 2), ("three", 3)])
+          |> Redis.SortedSet.zadd sortedSetApi "zremrangebyscore-trims"
+          |> Redis.query redisHandler
+          |> Expect.succeeds
+      _ <-
+        Redis.SortedSet.zremrangebyscore sortedSetApi "zremrangebyscore-trims" 0 2
+          |> Redis.query redisHandler
+          |> Expect.andCheck (Expect.equal 2)
+      Redis.SortedSet.zrange sortedSetApi "zremrangebyscore-trims" 0 (-1)
+        |> Redis.query redisHandler
+        |> Expect.andCheck (Expect.equal ["three"]),
     Test.test "zrank works as expected" <| \() -> do
       _ <-
         Redis.SortedSet.del sortedSetApi ("zrank-works" :| [])

--- a/nri-redis/test/Spec/Redis.hs
+++ b/nri-redis/test/Spec/Redis.hs
@@ -358,21 +358,21 @@ queryTests redisHandler =
       Redis.SortedSet.zcard sortedSetApi "zcard-missing-key"
         |> Redis.query redisHandler
         |> Expect.andCheck (Expect.equal 0),
-    Test.test "zremrangebyscore removes members in the inclusive score range" <| \() -> do
+    Test.test "zremRangeByScore removes members in the inclusive score range" <| \() -> do
       _ <-
-        Redis.SortedSet.del sortedSetApi ("zremrangebyscore-trims" :| [])
+        Redis.SortedSet.del sortedSetApi ("zremRangeByScore-trims" :| [])
           |> Redis.query redisHandler
           |> Expect.succeeds
       _ <-
         NonEmptyDict.init "one" 1 (Dict.fromList [("two", 2), ("three", 3)])
-          |> Redis.SortedSet.zadd sortedSetApi "zremrangebyscore-trims"
+          |> Redis.SortedSet.zadd sortedSetApi "zremRangeByScore-trims"
           |> Redis.query redisHandler
           |> Expect.succeeds
       _ <-
-        Redis.SortedSet.zremrangebyscore sortedSetApi "zremrangebyscore-trims" 0 2
+        Redis.SortedSet.zremRangeByScore sortedSetApi "zremRangeByScore-trims" 0 2
           |> Redis.query redisHandler
           |> Expect.andCheck (Expect.equal 2)
-      Redis.SortedSet.zrange sortedSetApi "zremrangebyscore-trims" 0 (-1)
+      Redis.SortedSet.zrange sortedSetApi "zremRangeByScore-trims" 0 (-1)
         |> Redis.query redisHandler
         |> Expect.andCheck (Expect.equal ["three"]),
     Test.test "zrank works as expected" <| \() -> do

--- a/nri-redis/test/Spec/Redis.hs
+++ b/nri-redis/test/Spec/Redis.hs
@@ -403,6 +403,23 @@ queryTests redisHandler =
       Redis.SortedSet.zrank sortedSetApi "zrank-works-nothing-stored" "foobar"
         |> Redis.query redisHandler
         |> Expect.andCheck (Expect.equal Nothing),
+    Test.test "zrem removes only the named members" <| \() -> do
+      _ <-
+        Redis.SortedSet.del sortedSetApi ("zrem-removes-named" :| [])
+          |> Redis.query redisHandler
+          |> Expect.succeeds
+      _ <-
+        NonEmptyDict.init "one" 1 (Dict.fromList [("two", 2), ("three", 3)])
+          |> Redis.SortedSet.zadd sortedSetApi "zrem-removes-named"
+          |> Redis.query redisHandler
+          |> Expect.succeeds
+      _ <-
+        Redis.SortedSet.zrem sortedSetApi "zrem-removes-named" ("one" :| ["not-a-member"])
+          |> Redis.query redisHandler
+          |> Expect.andCheck (Expect.equal 1)
+      Redis.SortedSet.zrange sortedSetApi "zrem-removes-named" 0 (-1)
+        |> Redis.query redisHandler
+        |> Expect.andCheck (Expect.equal ["two", "three"]),
     Test.test "scan iterates over all matching keys in batches" <| \() -> do
       let firstKey = "scanTest::key1"
       let firstValue = "value 1"

--- a/nri-redis/test/Spec/Redis.hs
+++ b/nri-redis/test/Spec/Redis.hs
@@ -337,6 +337,27 @@ queryTests redisHandler =
       Redis.SortedSet.zrange sortedSetApi "zrange-works" (-2) (-1)
         |> Redis.query redisHandler
         |> Expect.andCheck (Expect.equal ["two", "three"]),
+    Test.test "zcard returns the number of members" <| \() -> do
+      _ <-
+        Redis.SortedSet.del sortedSetApi ("zcard-returns-count" :| [])
+          |> Redis.query redisHandler
+          |> Expect.succeeds
+      _ <-
+        NonEmptyDict.init "one" 1 (Dict.fromList [("two", 2), ("three", 3)])
+          |> Redis.SortedSet.zadd sortedSetApi "zcard-returns-count"
+          |> Redis.query redisHandler
+          |> Expect.succeeds
+      Redis.SortedSet.zcard sortedSetApi "zcard-returns-count"
+        |> Redis.query redisHandler
+        |> Expect.andCheck (Expect.equal 3),
+    Test.test "zcard on a missing key returns 0" <| \() -> do
+      _ <-
+        Redis.SortedSet.del sortedSetApi ("zcard-missing-key" :| [])
+          |> Redis.query redisHandler
+          |> Expect.succeeds
+      Redis.SortedSet.zcard sortedSetApi "zcard-missing-key"
+        |> Redis.query redisHandler
+        |> Expect.andCheck (Expect.equal 0),
     Test.test "zrank works as expected" <| \() -> do
       _ <-
         Redis.SortedSet.del sortedSetApi ("zrank-works" :| [])

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-query
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "query"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 126

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-counter-transaction
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "transaction"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 133

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-query
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "query"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 98

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-hash-transaction
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "transaction"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 105

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-query
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "query"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 112

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-list-transaction
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "transaction"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 119

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "query"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 84

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query-timeout
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-query-timeout
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 48
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "query"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 143

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-transaction
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-redis-transaction
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "transaction"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
                     , srcLocModule = "Spec.Redis"
                     , srcLocFile = "test/Spec/Redis.hs"
                     , srcLocStartLine = 91

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-with-query-timout
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-with-query-timout
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "withContext"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
                     , srcLocModule = "Redis.Handler"
                     , srcLocFile = "src/Redis/Handler.hs"
                     , srcLocStartLine = 79

--- a/nri-redis/test/golden-results-9.8/observability-spec-reporting-without-query-timout
+++ b/nri-redis/test/golden-results-9.8/observability-spec-reporting-without-query-timout
@@ -6,7 +6,7 @@ TracingSpan
       Just
         ( "rootTracingSpanIO"
         , SrcLoc
-            { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+            { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
             , srcLocModule = "Spec.Redis"
             , srcLocFile = "test/Spec/Redis.hs"
             , srcLocStartLine = 31
@@ -29,7 +29,7 @@ TracingSpan
               Just
                 ( "withContext"
                 , SrcLoc
-                    { srcLocPackage = "nri-redis-0.4.1.1-inplace-tests"
+                    { srcLocPackage = "nri-redis-0.4.2.0-inplace-tests"
                     , srcLocModule = "Redis.Handler"
                     , srcLocFile = "src/Redis/Handler.hs"
                     , srcLocStartLine = 86


### PR DESCRIPTION
Adds `zcard`, `zrem`, and `zremrangebyscore` to `Redis.SortedSet`, and bumps nri-redis to 0.4.2.0.

Adding these to support multi-window sliding-window rate limiting (e.g. 60 rpm | 300 req/day | 1k req/mo) built on `Redis.transaction` (MULTI/EXEC) instead of Lua scripting.

The bump also touches 11 test goldens: they embed the test-suite package version in `srcLocPackage`, so the suffix has to follow the bump (same situation and same targeted-substitution approach as b62e011).

🤖 Generated with [Claude Code](https://claude.com/claude-code)